### PR TITLE
WIP: Integrate cargo test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ Cargo.lock
 /rustler_codegen/test/target/
 /rustler_codegen/Cargo.lock
 
+/rustler_mix/native/*/target
+
 /_build
 /cover
 /deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 members = [
   "rustler",
   "rustler_codegen",
-  "rustler_tests"
+  "rustler_tests",
+  "rustler_mix/native/rustler_cargo_test_runner"
 ]

--- a/rustler_mix/lib/mix/tasks/rustler.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.Rustler do
+  use Mix.Task
+
+  @shortdoc "Prints Rustler help information"
+
+  @moduledoc """
+  Prints Rustler tasks and their information
+
+      mix rustler
+  """
+
+  @doc false
+  def run(args) do
+    {_opts, args, _} = OptionParser.parse(args)
+
+    case args do
+      [] -> general()
+      _ ->
+        Mix.raise "Invalid arguments, expected: mix rustler"
+    end
+  end
+
+  defp general() do
+    Application.ensure_all_started(:rustler)
+    Mix.shell.info(
+      """
+      Rustler v#{Application.spec(:rustler, :vsn)}
+      Safe Rust bridge for creating Erlang NIF functions.\n
+      Available tasks:
+      """
+    )
+    Mix.Tasks.Help.run(["--search", "rustler."])
+  end
+end

--- a/rustler_mix/lib/mix/tasks/rustler.test.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.test.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Rustler.Test do
+  use Mix.Task
+
+  @shortdoc "Run cargo tests from Elixir"
+
+  @moduledoc """
+  This task runs `cargo test` for NIF crates configured to be used with Elixir.
+
+  By running Rust tests directly from within BEAM, users can also write tests in Rust
+  using types defined by Rustler. Usually, this is not possibly, as those types often
+  only work properly when the executable is dynamically linked in by BEAM.
+
+  Usage:
+  mix rustler.test
+
+  ## Arguments
+
+  * `--crate`: Run tests for specific crates. This option can be used multiple times.
+
+  """
+
+  def run(argv) do
+    {opts, _} = OptionParser.parse!(argv, strict: [crate: :keep, all: :boolean])
+
+    crates = get_crates(opts)
+    cwd = System.cwd()
+    homedir = System.user_home()
+
+    for {crate, kw} <- crates do
+      Mix.shell().info("Running tests for #{crate}")
+      manifest_path = cwd |> Path.join(kw[:path]) |> Path.join("Cargo.toml")
+      Rustler.CargoTestRunner.run_tests(cwd, homedir, manifest_path)
+    end
+  end
+
+  defp get_crates(opts) do
+    config = Mix.Project.config()
+    all_crates = config[:rustler_crates]
+
+    selected_crates =
+      with selected when is_list(selected) <- Enum.filter(opts, &(elem(&1, 0) == :crate)) do
+        selected |> Enum.unzip() |> elem(1)
+      end
+
+    if selected_crates != [] do
+      all_crates_set = all_crates |> Enum.unzip() |> elem(0) |> MapSet.new()
+      selected_crates_set = selected_crates |> Enum.map(&String.to_atom/1) |> MapSet.new()
+
+      if MapSet.subset?(selected_crates_set, all_crates_set) do
+        Enum.filter(all_crates, fn {crate, _} -> crate in selected_crates_set end)
+      else
+        diff =
+          selected_crates_set
+          |> MapSet.difference(all_crates_set)
+          |> MapSet.to_list()
+
+        Mix.shell().error("Tried to select crates missing in mix.exs: #{inspect(diff)}")
+        throw(:wrong_crates)
+      end
+    else
+      all_crates
+    end
+  end
+end

--- a/rustler_mix/lib/rustler/cargo_test_runner.ex
+++ b/rustler_mix/lib/rustler/cargo_test_runner.ex
@@ -1,0 +1,10 @@
+defmodule Rustler.CargoTestRunner do
+  @moduledoc """
+  Run `cargo test`.
+  """
+
+  use Rustler, otp_app: :rustler, crate: "rustler_cargo_test_runner"
+
+  @doc false
+  def run_tests(_cwd, _homedir, _manifest_path), do: :erlang.nif_error(:not_loaded)
+end

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -16,7 +16,10 @@ defmodule Rustler.Mixfile do
        source_url_pattern: "https://github.com/hansihe/Rustler/blob/master/rustler_mix/%{path}#L%{line}"
      ],
      package: package(),
-     description: description()]
+     description: description(),
+     compilers: [:rustler] ++ Mix.compilers(),
+     rustler_crates: rustler_crates()
+    ]
   end
 
   def application do
@@ -38,5 +41,13 @@ defmodule Rustler.Mixfile do
      maintainers: ["hansihe"],
      licenses: ["MIT", "Apache-2.0"],
      links: %{"GitHub" => "https://github.com/hansihe/Rustler"}]
+  end
+
+  defp rustler_crates do
+    [
+      rustler_cargo_test_runner: [
+        path: "native/rustler_cargo_test_runner"
+      ]
+    ]
   end
 end

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -17,7 +17,7 @@ defmodule Rustler.Mixfile do
      ],
      package: package(),
      description: description(),
-     compilers: [:rustler] ++ Mix.compilers(),
+     compilers: Mix.compilers() ++ [:rustler],
      rustler_crates: rustler_crates()
     ]
   end

--- a/rustler_mix/native/rustler_cargo_test_runner/Cargo.toml
+++ b/rustler_mix/native/rustler_cargo_test_runner/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rustler_cargo_test_runner"
+version = "0.1.0"
+authors = ["Magnus Ottenklinger <evnu@posteo.de>"]
+
+[lib]
+name = "rustler_cargo_test_runner"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+rustler = "0.17.0"
+rustler_codegen = "0.17.0"
+lazy_static = "1.0"
+cargo = "0.27"

--- a/rustler_mix/native/rustler_cargo_test_runner/README.md
+++ b/rustler_mix/native/rustler_cargo_test_runner/README.md
@@ -1,0 +1,1 @@
+# Nif for Elixir.Rustler.CargoTestRunner

--- a/rustler_mix/native/rustler_cargo_test_runner/src/lib.rs
+++ b/rustler_mix/native/rustler_cargo_test_runner/src/lib.rs
@@ -1,0 +1,77 @@
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate rustler;
+
+extern crate cargo;
+
+use rustler::schedule::SchedulerFlags;
+use rustler::{Encoder, Env, NifResult, Term};
+
+use cargo::core::shell;
+use cargo::core::Workspace;
+use cargo::ops;
+use cargo::util::config;
+
+use std::path::PathBuf;
+
+mod atoms {
+    rustler_atoms! {
+        atom ok;
+        atom failed;
+    }
+}
+
+rustler_export_nifs! {
+    "Elixir.Rustler.CargoTestRunner",
+    [("run_tests", 3, run_tests, SchedulerFlags::DirtyCpu)],
+    None
+}
+
+// NOTE: this might take a long time if Rust needs to compile first
+fn run_tests<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+    let cwd: String = args[0].decode()?;
+    let homedir: String = args[1].decode()?;
+    let manifest_path: String = args[2].decode()?;
+    let manifest_path: PathBuf = manifest_path.into();
+
+    let shell = shell::Shell::new();
+    let config = config::Config::new(shell, cwd.into(), homedir.into());
+    let ws = match Workspace::new(manifest_path.as_path(), &config) {
+        Ok(ws) => ws,
+        Err(err) => {
+            eprintln!("Failed to create Workspace: {:?}", err);
+            return Ok(atoms::failed().encode(env));
+        }
+    };
+
+    let compile_opts = ops::CompileOptions::default(&config, ops::CompileMode::Test);
+    let options = ops::TestOptions {
+        compile_opts: compile_opts,
+        no_run: false,
+        no_fail_fast: false,
+        only_doc: false,
+    };
+
+    // TODO test_args ignored for now
+    let test_args: Vec<String> = vec![];
+
+    match ops::run_tests(&ws, &options, &test_args) {
+        Ok(None) => Ok(atoms::ok().encode(env)),
+        Ok(Some(_err)) => {
+            return Ok(atoms::failed().encode(env));
+        }
+        Err(err) => {
+            eprintln!("An unexpected error:\n{:?}", err);
+            return Ok(atoms::failed().encode(env));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn success() {
+        assert!(true);
+    }
+}


### PR DESCRIPTION
This implements `mix rustler.test` to fix #147. It does so by calling into the cargo API from within a NIF. The implementation is a little rough around the edges: 

* The crate is compiled within the NIF (by cargo itself) and ends up in `native/<crate>/target`. This should be fixable by setting the build path differently (I am using defaults right now) and maybe use `Mix.run("compile.rustler")` before executing the tests. Ideas and hints are welcome.
* Cargo is currently pulled in for all modes. It should only be needed when testing.

To test the implementation, run `mix rustler.test` within `rustler_mix/`. After some lengthy compilation, it should print this:

```
$ cd rustler_mix; mix rustler.test
Compiling NIF crate :rustler_cargo_test_runner (native/rustler_cargo_test_runner)...
    Finished release [optimized] target(s) in 0.0 secs
Compiling 1 file (.ex)
Running tests for rustler_cargo_test_runner

...snip compilation output...

running 1 test
test tests::success ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```