### PR TITLE
add decoder for RangeInclusive

### DIFF
--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -2,6 +2,7 @@
 
 use wrapper::map;
 use {Decoder, Env, Error, NifResult, Term};
+use std::ops::RangeInclusive;
 
 pub fn map_new<'a>(env: Env<'a>) -> Term<'a> {
     unsafe { Term::new(env, map::map_new(env.as_c_arg())) }
@@ -179,6 +180,23 @@ impl<'a> Decoder<'a> for MapIterator<'a> {
         match MapIterator::new(term) {
             Some(iter) => Ok(iter),
             None => Err(Error::BadArg),
+        }
+    }
+}
+
+impl<'a, T> Decoder<'a> for RangeInclusive<T>
+where
+    T: Decoder<'a>,
+{
+    fn decode(term: Term<'a>) -> NifResult<Self> {
+        let vec:Vec<(Term, Term)> = term.decode::<MapIterator>()?.collect();
+        match (&*vec[0].0.atom_to_string()?, &*vec[0].1.atom_to_string()?) {
+            ("__struct__", "Elixir.Range") => {
+                let first = vec[1].1.decode::<T>()?;
+                let last = vec[2].1.decode::<T>()?;
+                Ok(first ..= last)
+            },
+            _ => Err(Error::BadArg),
         }
     }
 }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -57,4 +57,6 @@ defmodule RustlerTest do
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()
+
+  def sum_range(_), do: err()
 end

--- a/rustler_tests/src/lib.rs
+++ b/rustler_tests/src/lib.rs
@@ -20,6 +20,7 @@ mod test_env;
 mod test_codegen;
 mod test_term;
 mod test_dirty;
+mod test_range;
 
 rustler_export_nifs!(
     "Elixir.RustlerTest",
@@ -72,6 +73,8 @@ rustler_export_nifs!(
 
         ("dirty_cpu", 0, test_dirty::dirty_cpu, SchedulerFlags::DirtyCpu),
         ("dirty_io", 0, test_dirty::dirty_io, SchedulerFlags::DirtyIo),
+
+        ("sum_range", 1, test_range::sum_range),
     ],
     Some(on_load)
 );

--- a/rustler_tests/src/test_range.rs
+++ b/rustler_tests/src/test_range.rs
@@ -1,0 +1,10 @@
+use rustler::{Env, Term, Encoder, NifResult};
+use std::ops::RangeInclusive;
+
+pub fn sum_range<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+		let range: RangeInclusive<i64> = args[0].decode()?;
+
+		let total: i64 = range.into_iter().sum();
+    Ok(total.encode(env))
+}
+

--- a/rustler_tests/test/range_test.exs
+++ b/rustler_tests/test/range_test.exs
@@ -1,0 +1,7 @@
+defmodule RustlerTest.RangeTest do
+  use ExUnit.Case, async: true
+
+  test "range iteration" do
+    assert 55 == RustlerTest.sum_range(1..10)
+  end
+end


### PR DESCRIPTION
sample code: 

```elixir
defmodule RustlerTest.RangeTest do
  use ExUnit.Case, async: true

  test "range iteration" do
    assert 55 == RustlerTest.sum_range(1..10)
  end
end
```

```rust
use rustler::{Env, Term, Encoder, NifResult};
use std::ops::RangeInclusive;

pub fn sum_range<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
        let range: RangeInclusive<i64> = args[0].decode()?;

        let total: i64 = range.into_iter().sum();
    Ok(total.encode(env))
}
```