### PR TITLE
Parse literals in TOML keys

### DIFF
--- a/rustler_mix/lib/rustler/toml_parser.ex
+++ b/rustler_mix/lib/rustler/toml_parser.ex
@@ -4,7 +4,7 @@ defmodule Rustler.TomlParser do
   # just used to extract version numbers from Cargo.toml files.
 
   def parse(text) do
-    {:ok, tokens, _test_chars} = text |> to_charlist |> :toml_lexer.string
+    {:ok, tokens, _test_chars} = text |> to_charlist |> :toml_lexer.string()
     {:ok, parsed} = :toml_parser.parse(tokens)
 
     collect(parsed, [])
@@ -16,14 +16,17 @@ defmodule Rustler.TomlParser do
     {rest, res_items} = collect_keys(items, [])
     collect(rest, [{:table, [], res_items} | acc])
   end
+
   def collect([{:table, path} | items], acc) do
     {rest, res_items, path_proc} = collect_table(path, items)
     collect(rest, [{:table, path_proc, res_items} | acc])
   end
+
   def collect([{:table_array, path} | items], acc) do
     {rest, res_items, path_proc} = collect_table(path, items)
     collect(rest, [{:table_array, path_proc, res_items} | acc])
   end
+
   def collect([], acc) do
     Enum.reverse(acc)
   end
@@ -37,6 +40,7 @@ defmodule Rustler.TomlParser do
   def collect_keys([{:kv, key, val} | rest], acc) do
     collect_keys(rest, [{proc_key(key), proc_val(val)} | acc])
   end
+
   def collect_keys(rest, acc) do
     {rest, acc}
   end
@@ -53,19 +57,23 @@ defmodule Rustler.TomlParser do
     # TODO: Escapes
     :binary.part(raw_str, 1, byte_size(raw_str) - 2)
   end
+
   def proc_val({:val_integer, raw_num}) do
     {num, ""} = Integer.parse(raw_num)
     num
   end
+
   def proc_val({:val_boolean, bool}) do
     bool
   end
+
   def proc_val({:array, arr_ast}) do
     # TODO: Validate types
     Enum.map(arr_ast, fn
       item -> proc_val(item)
     end)
   end
+
   def proc_val(any) do
     any
   end
@@ -81,6 +89,7 @@ defmodule Rustler.TomlParser do
   end
 
   def get_keys_key(nil, _), do: nil
+
   def get_keys_key(vals, key) do
     case List.keyfind(vals, key, 0) do
       {_key, val} -> val
@@ -92,5 +101,4 @@ defmodule Rustler.TomlParser do
     vals = get_table_vals(data, path)
     get_keys_key(vals, key)
   end
-
 end

--- a/rustler_mix/lib/rustler/toml_parser.ex
+++ b/rustler_mix/lib/rustler/toml_parser.ex
@@ -53,6 +53,10 @@ defmodule Rustler.TomlParser do
     name
   end
 
+  def proc_key({:literal, name}) do
+    name
+  end
+
   def proc_val({:val_basic, raw_str}) do
     # TODO: Escapes
     :binary.part(raw_str, 1, byte_size(raw_str) - 2)

--- a/rustler_mix/test/rustler/toml_parser_test.exs
+++ b/rustler_mix/test/rustler/toml_parser_test.exs
@@ -27,7 +27,7 @@ defmodule Rustler.TomlParserTest do
     res = Rustler.TomlParser.parse(@simple_toml)
     assert Rustler.TomlParser.get_table_val(res, ["dependencies"], "libc") == ">=0.1"
     assert Rustler.TomlParser.get_table_val(res, ["dependencies"], "none") == nil
-    assert Rustler.TomlParser.get_table_val(res, ["testing"], "wooo") == nil
+    assert Rustler.TomlParser.get_table_val(res, ["testing"], "wooo") == "hoo"
     assert Rustler.TomlParser.get_table_val(res, [], "root_var") == 5
   end
 end

--- a/rustler_mix/test/rustler/toml_parser_test.exs
+++ b/rustler_mix/test/rustler/toml_parser_test.exs
@@ -19,6 +19,8 @@ defmodule Rustler.TomlParserTest do
 
   [a."b.c"]
 
+  [foo.'cfg(bar)'.baz]
+
   [[testing]]
   wooo = "hoo"
   """


### PR DESCRIPTION
Supports Cargo.toml configurations such as:
```toml
[target.'cfg(windows)'.dependencies]
```
which are matched by the lexer as `{:literal, _}` but fail to parse with a function missing error.

Also updates formatting and fixes a broken unit test. See commits.