### PR TITLE
Re-export codegen derives

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -8,10 +8,12 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [features]
+default = ["derive"]
+derive = ["rustler_codegen"]
 alternative_nif_init_name = []
 
 [dependencies]
-rustler_codegen = { path = "../rustler_codegen" }
+rustler_codegen = { path = "../rustler_codegen", optional = true }
 erl_nif_sys = { path = "../erl_nif_sys" }
 lazy_static = "1.2"
 

--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 alternative_nif_init_name = []
 
 [dependencies]
+rustler_codegen = { path = "../rustler_codegen" }
 erl_nif_sys = { path = "../erl_nif_sys" }
 lazy_static = "1.2"
 

--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -64,4 +64,5 @@ pub use crate::r#return::Return;
 
 pub type NifResult<T> = Result<T, Error>;
 
+#[cfg(feature = "derive")]
 pub use rustler_codegen::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};

--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -38,7 +38,9 @@ pub mod types;
 mod term;
 
 pub use crate::term::Term;
-pub use crate::types::{Atom, Binary, Decoder, Encoder, ListIterator, MapIterator, OwnedBinary, Pid};
+pub use crate::types::{
+    Atom, Binary, Decoder, Encoder, ListIterator, MapIterator, OwnedBinary, Pid,
+};
 pub mod resource;
 pub use crate::resource::ResourceArc;
 
@@ -61,3 +63,5 @@ pub mod r#return;
 pub use crate::r#return::Return;
 
 pub type NifResult<T> = Result<T, Error>;
+
+pub use rustler_codegen::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};

--- a/rustler_mix/priv/templates/basic/Cargo.toml.eex
+++ b/rustler_mix/priv/templates/basic/Cargo.toml.eex
@@ -2,6 +2,7 @@
 name = "<%= library_name %>"
 version = "0.1.0"
 authors = []
+edition = "2018"
 
 [lib]
 name = "<%= library_name %>"
@@ -10,5 +11,4 @@ crate-type = ["dylib"]
 
 [dependencies]
 rustler = "<%= rustler_version %>"
-rustler_codegen = "<%= rustler_version %>"
 lazy_static = "1.0"

--- a/rustler_mix/priv/templates/basic/README.md
+++ b/rustler_mix/priv/templates/basic/README.md
@@ -1,4 +1,4 @@
-# Nif for <%= project_name %>
+# NIF for <%= project_name %>
 
 ## To build the NIF module:
 

--- a/rustler_mix/priv/templates/basic/src/lib.rs
+++ b/rustler_mix/priv/templates/basic/src/lib.rs
@@ -1,8 +1,4 @@
-#[macro_use] extern crate rustler;
-#[macro_use] extern crate rustler_codegen;
-#[macro_use] extern crate lazy_static;
-
-use rustler::{Env, Term, NifResult, Encoder};
+use rustler::{Encoder, Env, Error, Term};
 
 mod atoms {
     rustler_atoms! {
@@ -13,13 +9,15 @@ mod atoms {
     }
 }
 
-rustler_export_nifs! {
+rustler::rustler_export_nifs! {
     "<%= native_module %>",
-    [("add", 2, add)],
+    [
+        ("add", 2, add)
+    ],
     None
 }
 
-fn add<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+fn add<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
     let num1: i64 = args[0].decode()?;
     let num2: i64 = args[1].decode()?;
 

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustler_test"
 version = "0.1.0"
 authors = ["HansiHE <hansihe@hansihe.com>"]
+edition = "2018"
 
 [lib]
 name = "rustler_test"
@@ -11,4 +12,3 @@ crate-type = ["cdylib"]
 [dependencies]
 lazy_static = "1.2"
 rustler = { path = "../../../rustler" }
-rustler_codegen = { path = "../../../rustler_codegen" }

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -1,11 +1,3 @@
-//#[macro_use]
-extern crate rustler;
-#[macro_use]
-extern crate rustler_codegen;
-
-//#[macro_use]
-extern crate lazy_static;
-
 use rustler::schedule::SchedulerFlags;
 use rustler::{Env, Term};
 

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -1,4 +1,5 @@
 use rustler::{Encoder, Env, NifResult, Term};
+use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};
 
 #[derive(NifTuple)]
 pub struct AddTuple {


### PR DESCRIPTION
This change removes the need for users to depend directly on
`rustler_codegen`.