### PR TITLE
UntaggedEnum with bool variant breaks unexpectedly

### DIFF
--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -65,6 +65,7 @@ pub enum UntaggedEnum {
     Foo(u32),
     Bar(String),
     Baz(AddStruct),
+    Bool(bool),
 }
 
 pub fn untagged_enum_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<UntaggedEnum> {


### PR DESCRIPTION
This PR does not have a fix yet, but opening for a discussion

```bash
  1) test untagged enum transcoder (RustlerTest.CodegenTest)
     test/codegen_test.exs:44
     Assertion with == failed
     code:  assert :invalid_variant == RustlerTest.untagged_enum_echo([1, 2, 3, 4])
     left:  :invalid_variant
     right: true
     stacktrace:
       test/codegen_test.exs:48: (test)
```