### PR TITLE
Introduce a Truthy newtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `erlang_nif-sys` has been renamed to `erl_nif_sys` and vendored into the rustler repo.
 - Replaced the hand-rolled TOML parser in `rustler_mix` with the `toml-elixir` package.
 - Improve error messages for derived encoders/decoders.
+- Rust `bool` now corresponds only to booleans (`false`, `true`) in Elixir. Previously, `nil` and `false` were both decodable to
+  `bool`. To use the previous behaviour, a `Truthy` newtype was introduced.

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -123,6 +123,20 @@ pub fn is_truthy(term: Term) -> bool {
     !((term.as_c_arg() == false_().as_c_arg()) || (term.as_c_arg() == nil().as_c_arg()))
 }
 
+pub(in crate::types) fn decode_bool(term: Term) -> NifResult<bool> {
+    let as_c_arg = term.as_c_arg();
+
+    if as_c_arg == true_().as_c_arg() {
+        return Ok(true);
+    }
+
+    if as_c_arg == false_().as_c_arg() {
+        return Ok(false);
+    }
+
+    Err(Error::BadArg)
+}
+
 // This is safe because atoms are never removed/changed once they are created.
 unsafe impl Sync for Atom {}
 unsafe impl Send for Atom {}

--- a/rustler/src/types/mod.rs
+++ b/rustler/src/types/mod.rs
@@ -26,6 +26,8 @@ pub mod tuple;
 pub mod pid;
 pub use crate::types::pid::Pid;
 
+pub mod truthy;
+
 pub mod elixir_struct;
 
 pub trait Encoder {

--- a/rustler/src/types/primitive.rs
+++ b/rustler/src/types/primitive.rs
@@ -57,6 +57,6 @@ impl Encoder for bool {
 }
 impl<'a> Decoder<'a> for bool {
     fn decode(term: Term<'a>) -> NifResult<bool> {
-        Ok(atom::is_truthy(term))
+        atom::decode_bool(term)
     }
 }

--- a/rustler/src/types/truthy.rs
+++ b/rustler/src/types/truthy.rs
@@ -1,0 +1,24 @@
+//!
+//! A type to represent a truthy value.
+//!
+//! In Elixir, a term which does not equal `:false` or `:nil` is considered to be
+//! truthy. This does not cleanly map to Rust's `bool` type. To distinguish between
+//! `bool` and a truthy value, the newtype `Truthy` can be used.
+//!
+
+use crate::types::atom;
+use crate::{Decoder, Encoder, Env, NifResult, Term};
+
+pub struct Truthy(bool);
+
+impl Encoder for Truthy {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        self.0.encode(env)
+    }
+}
+
+impl<'a> Decoder<'a> for Truthy {
+    fn decode(term: Term<'a>) -> NifResult<Truthy> {
+        Ok(Truthy(atom::is_truthy(term)))
+    }
+}

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -58,6 +58,7 @@ defmodule RustlerTest do
   def struct_echo(_), do: err()
   def unit_enum_echo(_), do: err()
   def untagged_enum_echo(_), do: err()
+  def untagged_enum_with_truthy(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -82,6 +82,11 @@ rustler::rustler_export_nifs!(
         ("unit_enum_echo", 1, test_codegen::unit_enum_echo),
         ("untagged_enum_echo", 1, test_codegen::untagged_enum_echo),
         (
+            "untagged_enum_with_truthy",
+            1,
+            test_codegen::untagged_enum_with_truthy
+        ),
+        (
             "dirty_cpu",
             0,
             test_dirty::dirty_cpu,

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -1,3 +1,4 @@
+use rustler::types::truthy::Truthy;
 use rustler::{Encoder, Env, NifResult, Term};
 use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};
 
@@ -66,9 +67,24 @@ pub enum UntaggedEnum {
     Foo(u32),
     Bar(String),
     Baz(AddStruct),
+    Bool(bool),
 }
 
 pub fn untagged_enum_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<UntaggedEnum> {
     let untagged_enum: UntaggedEnum = args[0].decode()?;
+    Ok(untagged_enum)
+}
+
+#[derive(NifUntaggedEnum)]
+pub enum UntaggedEnumWithTruthy {
+    Baz(AddStruct),
+    Truthy(Truthy),
+}
+
+pub fn untagged_enum_with_truthy<'a>(
+    _env: Env<'a>,
+    args: &[Term<'a>],
+) -> NifResult<UntaggedEnumWithTruthy> {
+    let untagged_enum: UntaggedEnumWithTruthy = args[0].decode()?;
     Ok(untagged_enum)
 }

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -90,7 +90,17 @@ defmodule RustlerTest.CodegenTest do
   test "untagged enum transcoder" do
     assert 123 == RustlerTest.untagged_enum_echo(123)
     assert "Hello" == RustlerTest.untagged_enum_echo("Hello")
+    assert RustlerTest.untagged_enum_echo(true)
     assert %AddStruct{lhs: 45, rhs: 123} = RustlerTest.untagged_enum_echo(%AddStruct{lhs: 45, rhs: 123})
+    assert true == RustlerTest.untagged_enum_echo(true)
     assert :invalid_variant == RustlerTest.untagged_enum_echo([1,2,3,4])
+  end
+
+  test "untagged enum with truthy" do
+    assert %AddStruct{lhs: 45, rhs: 123} =
+      RustlerTest.untagged_enum_with_truthy(%AddStruct{lhs: 45, rhs: 123})
+    assert true == RustlerTest.untagged_enum_with_truthy([1,2,3,4])
+    assert false == RustlerTest.untagged_enum_with_truthy(false)
+    assert false == RustlerTest.untagged_enum_with_truthy(nil)
   end
 end


### PR DESCRIPTION
This pull request implements the `Truthy` newtype suggested in https://github.com/rusterlium/rustler/issues/215#issuecomment-496675299. This type allows to distinguish between "real" booleans and truthy values (terms not equal `false` or `nil`). Where a "real" boolean is expected, Rust's `bool` can be used directly. Where a truthy value is expected, the newtype `Truthy` can be used.

See #214 for the original failing test case which is fixed by this pull request.