### PR TITLE
Better struct decoding error messages

### DIFF
--- a/rustler/src/types/elixir_struct.rs
+++ b/rustler/src/types/elixir_struct.rs
@@ -4,7 +4,8 @@
 //! # Elixir struct transcoders
 //! The compiler plugin has functionality for automatically generating a transcoder that can decode
 //! and encode a Rust struct to an Elixir struct. To do so, simply annotate a struct with
-//! `#[ExStruct(module = "Elixir.TheStructModule")]`.
+//! `#[derive(NifStruct)]
+//! `#[module = "Elixir.TheStructModule"]`.
 
 use super::atom::{self, Atom};
 use super::map::map_new;

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -87,7 +87,7 @@ pub fn gen_decoder(
             quote! {
                 #ident: match ::rustler::Decoder::decode(term.map_get(#atom_fun().encode(env))?) {
                     Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
-                    Ok(stuff) => stuff
+                    Ok(value) => value
                 }
             }
         })

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -72,9 +72,13 @@ pub fn gen_decoder(
             let ident_str = ident.to_string();
 
             let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
-
+            let error_message = format!("Could not decode field :{} on %{{}}", ident.to_string());
             quote! {
-                #ident: ::rustler::Decoder::decode(term.map_get(#atom_fun().encode(env))?)?
+                #ident: match ::rustler::Decoder::decode(term.map_get(#atom_fun().encode(env))?) {
+                    Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
+                    Ok(value) => value
+                }
+
             }
         })
         .collect();

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -50,8 +50,14 @@ pub fn gen_decoder(
     let field_defs: Vec<TokenStream> = fields
         .iter()
         .enumerate()
-        .map(|(idx, field)| {
-            let decoder = quote! { ::rustler::Decoder::decode(terms[#idx])? };
+        .map(|(index, field)| {
+            let error_message = format!("Could not decode index {} on tuple", index);
+            let decoder = quote! {
+                match ::rustler::Decoder::decode(terms[#index]) {
+                    Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
+                    Ok(value) => value
+                }
+            };
 
             if is_tuple {
                 unimplemented!();

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -20,10 +20,21 @@ defmodule RustlerTest.CodegenTest do
     assert value == RustlerTest.map_echo(value)
   end
 
-  test "struct transcoder" do
-    value = %AddStruct{lhs: 45, rhs: 123}
-    assert value == RustlerTest.struct_echo(value)
-    assert :invalid_struct == RustlerTest.struct_echo(DateTime.utc_now())
+
+  describe "struct" do
+    test "transcoder" do
+      value = %AddStruct{lhs: 45, rhs: 123}
+      assert value == RustlerTest.struct_echo(value)
+      assert :invalid_struct == RustlerTest.struct_echo(DateTime.utc_now())
+    end
+
+    test "struct with invalid types" do
+       value = %AddStruct{lhs: "lhs", rhs: 123}
+
+      assert_raise ErlangError, "Erlang error: \"Could not decode field :lhs on %AddStruct{}\"", fn ->
+         RustlerTest.struct_echo(value)
+      end
+    end
   end
 
   test "record transcoder" do


### PR DESCRIPTION
Currently if you try to decode a struct that has a field with a type mismatch, all you get back is `Argument error`.

We use Rustler to build large application level NIFs, with structs that have many, often nested, fields. This PR attempts to improve the error message to at least pinpoint which field cannot be decoded. I would love feedback on how I could further improve. 

1. Is there a way to raise an Error that is not `ErlangError`?
2. The error message currently now shows the offending field and the struct `Could not decode field :lhs on %AddStruct{}`, should it also show the value? 