### PR TITLE
Add clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ before_install:
 install:
   - mix local.rebar --force
   - mix local.hex --force
+  - source $HOME/.cargo/env
+  - rustup component add clippy
 
 script:
   - source $HOME/.cargo/env
   - cargo test
   - cd rustler_mix && mix do deps.get, test && cd -
   - cd rustler_tests && mix do deps.get, test && cd -
+  - cargo clippy --all-targets --all-features -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for OTP22
+- Rust linting with [clippy](https://github.com/rust-lang/rust-clippy).
 
 ### Changes
 - `rustler_codegen` is now reexported by the `rustler` crate. Depending on the `rustler_codegen` crate is deprecated.

--- a/erl_nif_sys/src/erl_nif_sys_api.rs
+++ b/erl_nif_sys/src/erl_nif_sys_api.rs
@@ -146,6 +146,7 @@ pub struct ErlNifResourceTypeInit {
 
 /// See [ErlNifSelectFlags](http://erlang.org/doc/man/erl_nif.html#ErlNifSelectFlags) in the Erlang docs.
 pub type ErlNifSelectFlags = c_int;
+#[allow(clippy::identity_op)]
 pub const ERL_NIF_SELECT_READ: ErlNifSelectFlags = (1 << 0);
 pub const ERL_NIF_SELECT_WRITE: ErlNifSelectFlags = (1 << 1);
 pub const ERL_NIF_SELECT_STOP: ErlNifSelectFlags = (1 << 2);
@@ -186,7 +187,7 @@ pub struct ErlNifPid {
 }
 
 /// See [enif_make_pid](http://erlang.org/doc/man/erl_nif.html#enif_make_pid) in the Erlang docs
-pub unsafe fn enif_make_pid(_env: *mut ErlNifEnv, pid: &ErlNifPid) -> ERL_NIF_TERM {
+pub unsafe fn enif_make_pid(_env: *mut ErlNifEnv, pid: ErlNifPid) -> ERL_NIF_TERM {
     pid.pid
 }
 
@@ -243,7 +244,7 @@ pub enum ErlNifMapIteratorEntry {
 pub type ErlNifTime = i64;
 
 /// Error return value for `enif_monotonic_time()`, `enif_time_offset()`, and `enif_convert_time_unit()`.
-pub const ERL_NIF_TIME_ERROR: i64 = -9223372036854775808;
+pub const ERL_NIF_TIME_ERROR: i64 = -9_223_372_036_854_775_808;
 //const ERL_NIF_TIME_ERROR:i64 = i64::min_value();  "error: const fn's not yet stable"
 
 /// See [ErlNifTimeUnit](http://www.erlang.org/doc/man/erl_nif.html#ErlNifTimeUnit) in the Erlang docs.
@@ -259,7 +260,9 @@ pub enum ErlNifTimeUnit {
 
 /// See [ErlNifUniqueInteger](http://erlang.org/doc/man/erl_nif.html#ErlNifUniqueInteger) in the Erlang docs.
 pub type ErlNifUniqueInteger = c_int;
+#[allow(clippy::identity_op)]
 pub const ERL_NIF_UNIQUE_POSITIVE: ErlNifUniqueInteger = (1 << 0);
+#[allow(clippy::identity_op)]
 pub const ERL_NIF_UNIQUE_MONOTONIC: ErlNifUniqueInteger = (1 << 1);
 // ref https://github.com/erlang/otp/blob/maint/erts/emulator/beam/erl_nif.h#L203
 // FIXME: Should actually be C enum, but repr(C) enums in Rust can't be used as bitfields.
@@ -275,7 +278,7 @@ pub struct ErlNifPort {
 
 /// See [ErlNifBinaryToTerm](http://erlang.org/doc/man/erl_nif.html#ErlNifBinaryToTerm) in the Erlang docs.
 pub type ErlNifBinaryToTerm = c_int;
-pub const ERL_NIF_BIN2TERM_SAFE: ErlNifBinaryToTerm = 0x20000000;
+pub const ERL_NIF_BIN2TERM_SAFE: ErlNifBinaryToTerm = 0x20_000_000;
 
 pub const ERL_NIF_THR_UNDEFINED: c_int = 0;
 pub const ERL_NIF_THR_NORMAL_SCHEDULER: c_int = 1;
@@ -312,9 +315,8 @@ pub enum ErlNifTermType {
      * unhandled values in a switch even if all the above values have been
      * handled. We can add new entries at any time so the user must always
      * have a default case. */
-    ERL_NIF_TERM_TYPE__MISSING_DEFAULT_CASE__READ_THE_MANUAL = -1
+    ERL_NIF_TERM_TYPE__MISSING_DEFAULT_CASE__READ_THE_MANUAL = -1,
 }
-
 
 include!(concat!(env!("OUT_DIR"), "/nif_api.snippet"));
 // example of included content:

--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -42,12 +42,12 @@ impl<'a> Env<'a> {
     /// Don't create multiple `Env`s with the same lifetime.
     pub unsafe fn new<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> Env<'a> {
         Env {
-            env: env,
+            env,
             id: PhantomData,
         }
     }
 
-    pub fn as_c_arg(&self) -> NIF_ENV {
+    pub fn as_c_arg(self) -> NIF_ENV {
         self.env
     }
 
@@ -153,8 +153,7 @@ impl OwnedEnv {
     where
         F: for<'a> FnOnce(Env<'a>) -> R,
     {
-        let env_lifetime = ();
-        let env = unsafe { Env::new(&env_lifetime, *self.env) };
+        let env = unsafe { Env::new(&(), *self.env) };
         closure(env)
     }
 
@@ -275,5 +274,11 @@ impl SavedTerm {
             },
             _ => panic!("can't load SavedTerm into a different environment"),
         }
+    }
+}
+
+impl Default for OwnedEnv {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/rustler/src/error.rs
+++ b/rustler/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
 }
 
 unsafe impl NifReturnable for crate::error::Error {
-    unsafe fn as_returned<'a>(self, env: Env<'a>) -> NifReturned {
+    unsafe fn as_returned(self, env: Env) -> NifReturned {
         match self {
             Error::BadArg => NifReturned::BadArg,
             Error::Atom(atom_str) => {

--- a/rustler/src/resource.rs
+++ b/rustler/src/resource.rs
@@ -104,7 +104,7 @@ fn get_alloc_size_struct<T>() -> usize {
 /// Unsafe: `ptr` must point to a large enough allocation and not be null.
 unsafe fn align_alloced_mem_for_struct<T>(ptr: *const c_void) -> *const c_void {
     let offset = mem::align_of::<T>() - ((ptr as usize) % mem::align_of::<T>());
-    ptr.offset(offset as isize)
+    ptr.add(offset)
 }
 
 /// A reference to a resource of type `T`.

--- a/rustler/src/return.rs
+++ b/rustler/src/return.rs
@@ -7,7 +7,7 @@ pub enum Return<'a> {
     Error(Error),
 }
 unsafe impl<'b> NifReturnable for Return<'b> {
-    unsafe fn as_returned<'a>(self, env: Env<'a>) -> NifReturned {
+    unsafe fn as_returned(self, env: Env) -> NifReturned {
         match self {
             Return::Term(inner) => NifReturned::Term(inner.as_c_arg()),
             Return::Error(inner) => inner.as_returned(env),

--- a/rustler/src/schedule.rs
+++ b/rustler/src/schedule.rs
@@ -7,7 +7,7 @@ pub enum SchedulerFlags {
     DirtyIo = ErlNifTaskFlags::ERL_NIF_DIRTY_JOB_IO_BOUND as isize,
 }
 
-pub fn consume_timeslice<'a>(env: Env<'a>, percent: i32) -> bool {
+pub fn consume_timeslice(env: Env, percent: i32) -> bool {
     let success = unsafe { erl_nif_sys::enif_consume_timeslice(env.as_c_arg(), percent) };
     success == 1
 }

--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -28,10 +28,7 @@ impl<'a> Term<'a> {
     /// The caller must ensure that `env` is the environment that `inner` belongs to,
     /// unless `inner` is an atom term.
     pub unsafe fn new(env: Env<'a>, inner: NIF_TERM) -> Self {
-        Term {
-            term: inner,
-            env: env,
-        }
+        Term { term: inner, env }
     }
     /// This extracts the raw term pointer. It is usually used in order to obtain a type that can
     /// be passed to calls into the erlang vm.

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -10,23 +10,24 @@ pub struct Atom {
 }
 
 impl Atom {
-    pub fn as_c_arg(&self) -> NIF_TERM {
+    pub fn as_c_arg(self) -> NIF_TERM {
         self.term
     }
 
-    pub fn to_term<'a>(self, env: Env<'a>) -> Term<'a> {
+    pub fn to_term(self, env: Env) -> Term {
         // Safe because atoms are not associated with any environment.
         unsafe { Term::new(env, self.term) }
     }
 
     unsafe fn from_nif_term(term: NIF_TERM) -> Self {
-        Atom { term: term }
+        Atom { term }
     }
 
     pub fn from_term(term: Term) -> NifResult<Self> {
-        match term.is_atom() {
-            true => Ok(unsafe { Atom::from_nif_term(term.as_c_arg()) }),
-            false => Err(Error::BadArg),
+        if term.is_atom() {
+            Ok(unsafe { Atom::from_nif_term(term.as_c_arg()) })
+        } else {
+            Err(Error::BadArg)
         }
     }
 
@@ -52,7 +53,7 @@ impl Atom {
         unsafe {
             match atom::make_existing_atom(env.as_c_arg(), bytes) {
                 Some(term) => Ok(Some(Atom::from_nif_term(term))),
-                None => return Ok(None),
+                None => Ok(None),
             }
         }
     }

--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -15,7 +15,7 @@ pub struct OwnedBinary {
 impl<'a> OwnedBinary {
     pub unsafe fn from_raw(inner: ErlNifBinary) -> OwnedBinary {
         OwnedBinary {
-            inner: inner,
+            inner,
             release: true,
         }
     }
@@ -84,7 +84,7 @@ impl<'a> OwnedBinary {
 
     /// Releases control of the binary to the VM. After this point
     /// the binary will be immutable.
-    pub fn release<'b>(self, env: Env<'b>) -> Binary<'b> {
+    pub fn release(self, env: Env) -> Binary {
         Binary::from_owned(self, env)
     }
 }
@@ -141,8 +141,8 @@ impl<'a> Binary<'a> {
             )
         };
         Binary {
-            inner: bin.inner.clone(),
-            term: term,
+            inner: bin.inner,
+            term,
         }
     }
 
@@ -164,7 +164,7 @@ impl<'a> Binary<'a> {
         }
         Ok(Binary {
             inner: binary,
-            term: term,
+            term,
         })
     }
 

--- a/rustler/src/types/elixir_struct.rs
+++ b/rustler/src/types/elixir_struct.rs
@@ -14,7 +14,7 @@ pub fn get_ex_struct_name(map: Term) -> NifResult<Atom> {
     let env = map.get_env();
     // In an Elixir struct the value in the __struct__ field is always an atom.
     map.map_get(atom::__struct__().to_term(env))
-        .and_then(|e| Atom::from_term(e))
+        .and_then(Atom::from_term)
 }
 
 pub fn make_ex_struct<'a>(env: Env<'a>, struct_module: &str) -> NifResult<Term<'a>> {

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -45,7 +45,7 @@ pub struct ListIterator<'a> {
 impl<'a> ListIterator<'a> {
     fn new(term: Term<'a>) -> Option<Self> {
         if term.is_list() || term.is_empty_list() {
-            let iter = ListIterator { term: term };
+            let iter = ListIterator { term };
             Some(iter)
         } else {
             None

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -5,7 +5,7 @@ use crate::wrapper::map;
 use crate::{Decoder, Env, Error, NifResult, Term};
 use std::ops::RangeInclusive;
 
-pub fn map_new<'a>(env: Env<'a>) -> Term<'a> {
+pub fn map_new(env: Env) -> Term {
     unsafe { Term::new(env, map::map_new(env.as_c_arg())) }
 }
 
@@ -180,12 +180,8 @@ pub struct MapIterator<'a> {
 impl<'a> MapIterator<'a> {
     pub fn new(map: Term<'a>) -> Option<MapIterator<'a>> {
         let env = map.get_env();
-        unsafe { map::map_iterator_create(env.as_c_arg(), map.as_c_arg()) }.map(|iter| {
-            MapIterator {
-                env: env,
-                iter: iter,
-            }
-        })
+        unsafe { map::map_iterator_create(env.as_c_arg(), map.as_c_arg()) }
+            .map(|iter| MapIterator { env, iter })
     }
 }
 

--- a/rustler/src/types/pid.rs
+++ b/rustler/src/types/pid.rs
@@ -23,7 +23,7 @@ impl<'a> Decoder<'a> for Pid {
 
 impl Encoder for Pid {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
-        unsafe { Term::new(env, pid::make_pid(env.as_c_arg(), &self.c)) }
+        unsafe { Term::new(env, pid::make_pid(env.as_c_arg(), self.c)) }
     }
 }
 

--- a/rustler/src/types/primitive.rs
+++ b/rustler/src/types/primitive.rs
@@ -5,6 +5,7 @@ macro_rules! impl_number_transcoder {
     ($dec_type:ty, $nif_type:ty, $encode_fun:ident, $decode_fun:ident) => {
         impl Encoder for $dec_type {
             fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+                #[allow(clippy::cast_lossless)]
                 unsafe {
                     Term::new(
                         env,

--- a/rustler/src/types/string.rs
+++ b/rustler/src/types/string.rs
@@ -33,7 +33,7 @@ impl Encoder for str {
             None => panic!("binary term allocation fail"),
         };
         bin.as_mut_slice()
-            .write(self.as_bytes())
+            .write_all(self.as_bytes())
             .expect("memory copy of string failed");
         bin.release(env).to_term(env)
     }

--- a/rustler/src/wrapper/pid.rs
+++ b/rustler/src/wrapper/pid.rs
@@ -14,5 +14,5 @@ pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
 // }
 
 pub unsafe fn make_pid(env: NIF_ENV, pid: ErlNifPid) -> NIF_TERM {
-    erl_nif_sys::enif_make_pid(env, &pid)
+    erl_nif_sys::enif_make_pid(env, pid)
 }

--- a/rustler/src/wrapper/pid.rs
+++ b/rustler/src/wrapper/pid.rs
@@ -13,6 +13,6 @@ pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
 //     erl_nif_sys::enif_is_process_alive(env, pid) != 0
 // }
 
-pub unsafe fn make_pid(env: NIF_ENV, pid: &ErlNifPid) -> NIF_TERM {
-    erl_nif_sys::enif_make_pid(env, pid)
+pub unsafe fn make_pid(env: NIF_ENV, pid: ErlNifPid) -> NIF_TERM {
+    erl_nif_sys::enif_make_pid(env, &pid)
 }

--- a/rustler/src/wrapper/resource.rs
+++ b/rustler/src/wrapper/resource.rs
@@ -7,7 +7,6 @@ pub use erl_nif_sys::{
     enif_make_resource as make_resource,
 };
 
-#[allow(dead_code)]
 pub use erl_nif_sys::enif_release_resource as release_resource;
 
 use std::mem;

--- a/rustler/src/wrapper/term.rs
+++ b/rustler/src/wrapper/term.rs
@@ -2,7 +2,7 @@ use crate::wrapper::NIF_TERM;
 use std::fmt;
 use std::os::raw::c_char;
 
-pub fn fmt<'a>(term: NIF_TERM, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+pub fn fmt(term: NIF_TERM, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     const SIZE: usize = 1024;
     let mut bytes: Vec<u8> = Vec::with_capacity(SIZE);
 

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -61,7 +61,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(
@@ -106,7 +106,7 @@ pub fn gen_decoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(
@@ -143,7 +143,7 @@ pub fn gen_encoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 fn get_module(ast: &syn::DeriveInput, ctx: &Context) -> String {
@@ -154,8 +154,8 @@ fn get_module(ast: &syn::DeriveInput, ctx: &Context) -> String {
             _ => None,
         })
         .or_else(|| {
-            let ref attr_value =
-                ast.attrs
+            let attr_value =
+                &ast.attrs
                     .iter()
                     .map(|attr| attr.parse_meta())
                     .find(|meta| match meta {

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -53,34 +53,25 @@ impl Context {
     }
 
     fn encode(&self) -> bool {
-        self.attrs
-            .iter()
-            .find(|attr| match attr {
-                RustlerAttr::Encode => true,
-                _ => false,
-            })
-            .is_some()
+        self.attrs.iter().any(|attr| match attr {
+            RustlerAttr::Encode => true,
+            _ => false,
+        })
     }
 
     fn decode(&self) -> bool {
-        self.attrs
-            .iter()
-            .find(|attr| match attr {
-                RustlerAttr::Decode => true,
-                _ => false,
-            })
-            .is_some()
+        self.attrs.iter().any(|attr| match attr {
+            RustlerAttr::Decode => true,
+            _ => false,
+        })
     }
 
     fn encode_decode_attr_set(attrs: &[RustlerAttr]) -> bool {
-        attrs
-            .iter()
-            .find(|attr| match attr {
-                RustlerAttr::Encode => true,
-                RustlerAttr::Decode => true,
-                _ => false,
-            })
-            .is_some()
+        attrs.iter().any(|attr| match attr {
+            RustlerAttr::Encode => true,
+            RustlerAttr::Decode => true,
+            _ => false,
+        })
     }
 
     fn get_rustler_attrs(attr: &syn::Attribute) -> Option<Vec<RustlerAttr>> {

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -56,7 +56,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(
@@ -96,7 +96,7 @@ pub fn gen_decoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(
@@ -134,5 +134,5 @@ pub fn gen_encoder(
         }
     };
 
-    gen.into()
+    gen
 }

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -46,7 +46,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(
@@ -101,7 +101,7 @@ pub fn gen_decoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(
@@ -148,7 +148,7 @@ pub fn gen_encoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 fn get_tag(ast: &syn::DeriveInput, ctx: &Context) -> String {
@@ -159,8 +159,8 @@ fn get_tag(ast: &syn::DeriveInput, ctx: &Context) -> String {
             _ => None,
         })
         .or_else(|| {
-            let ref attr_value =
-                ast.attrs
+            let attr_value =
+                &ast.attrs
                     .iter()
                     .map(|attr| attr.parse_meta())
                     .find(|meta| match meta {

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -37,7 +37,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(
@@ -88,7 +88,7 @@ pub fn gen_decoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(
@@ -134,5 +134,5 @@ pub fn gen_encoder(
         }
     };
 
-    gen.into()
+    gen
 }

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -63,7 +63,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(
@@ -107,7 +107,7 @@ pub fn gen_decoder(
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(
@@ -147,5 +147,5 @@ pub fn gen_encoder(
         }
     };
 
-    gen.into()
+    gen
 }

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -49,7 +49,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         #encoder
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_decoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool) -> TokenStream {
@@ -83,7 +83,7 @@ pub fn gen_decoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool)
         }
     };
 
-    gen.into()
+    gen
 }
 
 pub fn gen_encoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool) -> TokenStream {
@@ -114,5 +114,5 @@ pub fn gen_encoder(enum_name: &Ident, variants: &[&Variant], has_lifetime: bool)
         }
     };
 
-    gen.into()
+    gen
 }

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -20,7 +20,7 @@ pub fn parse_integer<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<i64> {
 
 pub fn binary_new<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<'a>> {
     let mut binary = OwnedBinary::new(4).unwrap();
-    binary.as_mut_slice().write(&[1, 2, 3, 4]).unwrap();
+    binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
     Ok(binary.release(env))
 }
 
@@ -35,7 +35,7 @@ pub fn realloc_shrink<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<
     let mut binary = OwnedBinary::new(8).unwrap();
     binary
         .as_mut_slice()
-        .write(&[1, 2, 3, 4, 5, 6, 7, 8])
+        .write_all(&[1, 2, 3, 4, 5, 6, 7, 8])
         .unwrap();
     if !binary.realloc(4) {
         panic!("Realloc failed");
@@ -45,7 +45,7 @@ pub fn realloc_shrink<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<
 
 pub fn realloc_grow<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<'a>> {
     let mut binary = OwnedBinary::new(4).unwrap();
-    binary.as_mut_slice().write(&[1, 2, 3, 4]).unwrap();
+    binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
     binary.realloc_or_copy(5);
     binary.as_mut_slice()[4] = 5;
     Ok(binary.release(env))

--- a/rustler_tests/native/rustler_test/src/test_list.rs
+++ b/rustler_tests/native/rustler_test/src/test_list.rs
@@ -7,7 +7,7 @@ pub fn sum_list<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     let res: Result<Vec<i64>, Error> = iter.map(|x| x.decode::<i64>()).collect();
 
     match res {
-        Ok(result) => Ok(result.iter().fold(0, |acc, &x| acc + x).encode(env)),
+        Ok(result) => Ok(result.iter().sum::<i64>().encode(env)),
         Err(err) => Err(err),
     }
 }

--- a/rustler_tests/native/rustler_test/src/test_range.rs
+++ b/rustler_tests/native/rustler_test/src/test_range.rs
@@ -4,6 +4,6 @@ use std::ops::RangeInclusive;
 pub fn sum_range<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
     let range: RangeInclusive<i64> = args[0].decode()?;
 
-    let total: i64 = range.into_iter().sum();
+    let total: i64 = range.sum();
     Ok(total.encode(env))
 }

--- a/rustler_tests/native/rustler_test/src/test_resource.rs
+++ b/rustler_tests/native/rustler_test/src/test_resource.rs
@@ -14,7 +14,7 @@ struct ImmutableResource {
     b: u32,
 }
 
-pub fn on_load<'a>(env: Env<'a>) -> bool {
+pub fn on_load(env: Env) -> bool {
     rustler::resource_struct_init!(TestResource, env);
     rustler::resource_struct_init!(ImmutableResource, env);
     true

--- a/rustler_tests/native/rustler_test/src/test_thread.rs
+++ b/rustler_tests/native/rustler_test/src/test_thread.rs
@@ -13,7 +13,7 @@ pub fn threaded_fac<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> 
 
     let n: u64 = args[0].decode()?;
     thread::spawn::<thread::ThreadSpawner, _>(env, move |thread_env| {
-        let result = (1..n + 1).fold(1, mul);
+        let result = (1..=n).fold(1, mul);
         result.encode(thread_env)
     });
 


### PR DESCRIPTION
This pull requests adds [clippy](https://github.com/rust-lang/rust-clippy) to travis. I fixed the current clippy suggestions within Rustler. I left out some suggestions to show what they look like.

To run clippy against Rustler:

```
$ rustup component add clippy
$ cargo clippy --all-targets --all-features -- -D warnings
```

Fix #222.