### PR TITLE
Specifies so path to @external_resource

### DIFF
--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -81,12 +81,12 @@ defmodule Rustler do
 
     lib_path = Application.app_dir(otp_app, "priv/native/#{crate}") |> to_charlist()
     load_data = opts[:load_data] || config[:load_data] || 0
-    resource_path = Path.join(lib_path, ressource_extension())
+    resource_path = Path.join(lib_path, resource_extension())
 
     {resource_path, lib_path, load_data}
   end
 
-  defp ressource_extension do
+  defp resource_extension do
     case :os.type() do
       {:win32, _} -> ".dll"
       {:unix, _} -> ".so"


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Development experience improvement**.

## What is the current behaviour?
When using IEX when we use `recompile/0', the nif is not reloaded.

## What is the new behaviour?
We explicitly specify that the module depends on an external SO file.

## Does this PR introduce a breaking change?

**No**.
