### PR TITLE
Fix segfault in map_from_arrays.

### DIFF
--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -33,12 +33,16 @@ impl<'a> Term<'a> {
         keys: &[Term<'a>],
         values: &[Term<'a>],
     ) -> NifResult<Term<'a>> {
-        let keys: Vec<_> = keys.iter().map(|k| k.as_c_arg()).collect();
-        let values: Vec<_> = values.iter().map(|v| v.as_c_arg()).collect();
+        if keys.len() == values.len() {
+            let keys: Vec<_> = keys.iter().map(|k| k.as_c_arg()).collect();
+            let values: Vec<_> = values.iter().map(|v| v.as_c_arg()).collect();
 
-        unsafe {
-            map::make_map_from_arrays(env.as_c_arg(), &keys, &values)
-                .map_or_else(|| Err(Error::BadArg), |map| Ok(Term::new(env, map)))
+            unsafe {
+                map::make_map_from_arrays(env.as_c_arg(), &keys, &values)
+                    .map_or_else(|| Err(Error::BadArg), |map| Ok(Term::new(env, map)))
+            }
+        } else {
+            Err(Error::BadArg)
         }
     }
 

--- a/rustler_tests/test/map_test.exs
+++ b/rustler_tests/test/map_test.exs
@@ -17,4 +17,10 @@ defmodule RustlerTest.MapTest do
     expected_map = Enum.zip(keys, values) |> Enum.into(%{})
     assert expected_map == RustlerTest.map_from_arrays(keys, values)
   end
+
+  test "map from arrays with non-matching length raises ArgumentError" do
+    keys = Enum.into(1..10, [])
+    values = []
+    assert_raise(ArgumentError, fn -> RustlerTest.map_from_arrays(keys, values) end)
+  end
 end


### PR DESCRIPTION
Currently on master if you pass a shorter list of values than keys to `Term.map_from_arrays` you will get a segfault (you can reproduce with the new test case before the patch is applied). This adds a check that the sizes are the same and returns BadArg otherwise.