### PR TITLE
Support target pointer width.

### DIFF
--- a/rustler_sys/build.rs
+++ b/rustler_sys/build.rs
@@ -4,16 +4,16 @@
 //
 
 use std::env;
-use std::os::raw::c_ulong;
 use std::path::Path;
 use std::process::Command;
 
 fn main() {
-    // use environment escript if available
     let escript = env::var("ESCRIPT").unwrap_or("escript".to_string());
 
-    // get size of C long
-    let ulong_size = std::mem::size_of::<c_ulong>();
+    let target_pointer_width = match env::var("CARGO_CFG_TARGET_POINTER_WIDTH") {
+        Ok(ref val) if val == "32" => "4",
+        _ => "8",
+    };
 
     // setup output directory
     let out_dir = env::var("OUT_DIR")
@@ -23,7 +23,7 @@ fn main() {
     let dst = Path::new(&out_dir);
     match Command::new(escript)
         .arg("gen_api.erl")
-        .arg(ulong_size.to_string())
+        .arg(target_pointer_width.to_string())
         .arg(dst)
         .status()
         .map_err(|_| "Failed to start gen_api.erl.  Is 'escript' available in the path?")

--- a/rustler_sys/build.rs
+++ b/rustler_sys/build.rs
@@ -12,7 +12,12 @@ fn main() {
 
     let target_pointer_width = match env::var("CARGO_CFG_TARGET_POINTER_WIDTH") {
         Ok(ref val) if val == "32" => "4",
-        _ => "8",
+        Ok(ref val) if val == "64" => "8",
+        Ok(ref val) => panic!("Unsupported target pointer width: {}", val),
+        Err(err) => panic!(
+            "An error occurred while determining the pointer width to compile `rustler_sys` for:\n\n{:?}\n\nPlease report a bug.",
+            err
+        ),
     };
 
     // setup output directory


### PR DESCRIPTION
This change makes it possible to compile `rustler_sys` for 32-bit systems.

I was successfully able to run `cargo build` with a target suited for ARM:

```
# Install ARM target
λ rustup target add armv7-unknown-linux-gnueabihf

# Install GCC toolchain
λ sudo apt install gcc-arm-linux-gnueabihf

# Add the following into the .cargo/config file
[target.armv7-unknown-linux-gnueabihf]
linker = "arm-linux-gnueabihf-gcc"

# Finally...build
λ cargo build --target=armv7-unknown-linux-gnueabihf
   Compiling libc v0.2.51
   Compiling cc v1.0.35
   Compiling autocfg v0.1.2
   Compiling rustc-demangle v0.1.13
   Compiling proc-macro2 v0.4.27
   Compiling cfg-if v0.1.7
   Compiling unicode-xid v0.1.0
   Compiling syn v0.15.30
   Compiling void v1.0.2
   Compiling rustler_sys v2.0.0 (/home/scrogson/github/rusterlium/rustler/rustler_sys)
   Compiling unicode-segmentation v1.2.1
   Compiling lazy_static v1.3.0
   Compiling unreachable v0.1.1
   Compiling heck v0.3.1
   Compiling backtrace v0.3.15
   Compiling backtrace-sys v0.1.28
   Compiling quote v0.6.12
   Compiling failure v0.1.5
   Compiling which v2.0.1
   Compiling rustler v0.21.0 (/home/scrogson/github/rusterlium/rustler/rustler)
   Compiling rustler_codegen v0.21.0 (/home/scrogson/github/rusterlium/rustler/rustler_codegen)
   Compiling rustler_test v0.1.0 (/home/scrogson/github/rusterlium/rustler/rustler_tests/native/rustler_test)
    Finished dev [unoptimized + debuginfo] target(s) in 10.72s
```