### PR TITLE
Bump dependencies and refactor attribute retrieval

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -15,10 +15,10 @@ alternative_nif_init_name = []
 [dependencies]
 rustler_codegen = { path = "../rustler_codegen", version = "0.21.0", optional = true }
 rustler_sys = { path = "../rustler_sys", version = "~2.0" }
-lazy_static = "1.2"
+lazy_static = "1.4"
 
 [build-dependencies]
-lazy_static = "1.2"
+lazy_static = "1.4"
 which = "2"
 
 [package.metadata.release]

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -13,6 +13,6 @@ proc_macro = true
 
 [dependencies]
 syn = { version = "0.15.44", features = ["derive"] }
-quote = "0.6.13"
+quote = "1.0"
 heck = "0.3"
 proc-macro2 = "1.0"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -15,4 +15,4 @@ proc_macro = true
 syn = { version = "0.15.44", features = ["derive"] }
 quote = "0.6.13"
 heck = "0.3"
-proc-macro2 = "0.4"
+proc-macro2 = "1.0"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "rustler_codegen"
 proc_macro = true
 
 [dependencies]
-syn = { version = "0.15.44", features = ["derive"] }
+syn = { version = "1.0.5", features = ["derive"] }
 quote = "1.0"
 heck = "0.3"
 proc-macro2 = "1.0"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "rustler_codegen"
 proc_macro = true
 
 [dependencies]
-syn = { version = "0.15.24", features = ["derive"] }
+syn = { version = "0.15.44", features = ["derive"] }
 quote = "0.6.13"
 heck = "0.3"
 proc-macro2 = "0.4"

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -13,6 +13,6 @@ proc_macro = true
 
 [dependencies]
 syn = { version = "0.15.24", features = ["derive"] }
-quote = "0.6.10"
+quote = "0.6.13"
 heck = "0.3"
 proc-macro2 = "0.4"

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -10,7 +10,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
-use syn::{Lit, Meta, MetaList, NestedMeta};
+use syn::{Lit, Meta, NestedMeta};
 
 mod ex_struct;
 mod map;
@@ -37,7 +37,7 @@ impl Context {
         let mut attrs: Vec<_> = ast
             .attrs
             .iter()
-            .filter_map(Context::get_rustler_attrs)
+            .map(Context::get_rustler_attrs)
             .flatten()
             .collect();
 
@@ -74,54 +74,67 @@ impl Context {
         })
     }
 
-    fn get_rustler_attrs(attr: &syn::Attribute) -> Option<Vec<RustlerAttr>> {
-        if attr.path.segments.len() == 1 && attr.path.segments[0].ident == "rustler" {
-            let meta = attr.parse_meta().expect("can parse meta");
-            match meta {
-                Meta::List(list) => Some(Context::parse_attribute_list(list)),
-                _meta => panic!("Unexpected meta"),
-            }
-        } else {
-            None
-        }
-    }
-
-    fn parse_attribute_list(list: MetaList) -> Vec<RustlerAttr> {
-        list.nested
+    fn get_rustler_attrs(attr: &syn::Attribute) -> Vec<RustlerAttr> {
+        attr.path
+            .segments
             .iter()
-            .map(|nested| match nested {
-                NestedMeta::Lit(_) => panic!("Unexpected lit"),
-                NestedMeta::Meta(ref meta) => Context::parse_attribute(meta),
+            .filter_map(|segment| {
+                let meta = attr.parse_meta().expect("can parse meta");
+                match segment.ident.to_string().as_ref() {
+                    "rustler" => Context::parse_rustler(&meta),
+                    "tag" => Context::try_parse_tag(&meta),
+                    "module" => Context::try_parse_module(&meta),
+                    _ => None,
+                }
             })
+            .flatten()
             .collect()
     }
 
-    fn parse_attribute(meta: &Meta) -> RustlerAttr {
-        match meta {
-            Meta::Path(path) => match path.segments[0].ident.to_string().as_ref() {
-                "encode" => RustlerAttr::Encode,
-                "decode" => RustlerAttr::Decode,
-                unknown => panic!("Unexpected path {}", unknown),
-            },
-            Meta::NameValue(name_value) => {
-                match name_value.path.segments[0].ident.to_string().as_ref() {
-                    "module" => {
-                        if let Lit::Str(ref module) = name_value.lit {
-                            return RustlerAttr::Module(module.value().into());
-                        }
-                        panic!("Cannot parse module")
-                    }
-                    "tag" => {
-                        if let Lit::Str(ref tag) = name_value.lit {
-                            return RustlerAttr::Tag(tag.value().into());
-                        }
-                        panic!("Cannot parse tag")
-                    }
-                    path => panic!("Unexpected path {:?}", path),
+    fn parse_rustler(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::List(ref list) = meta {
+            return Some(
+                list.nested
+                    .iter()
+                    .map(Context::parse_nested_rustler)
+                    .collect(),
+            );
+        }
+
+        panic!("Expected encode and/or decode in rustler attribute");
+    }
+
+    fn parse_nested_rustler(nested: &NestedMeta) -> RustlerAttr {
+        if let NestedMeta::Meta(ref meta) = nested {
+            if let Meta::Path(ref path) = meta {
+                match path.segments[0].ident.to_string().as_ref() {
+                    "encode" => return RustlerAttr::Encode,
+                    "decode" => return RustlerAttr::Decode,
+                    other => panic!("Unexpected literal {}", other),
                 }
             }
-            Meta::List(_) => panic!("Unexpected list"),
         }
+
+        panic!("Expected encode and/or decode in rustler attribute");
+    }
+
+    fn try_parse_tag(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(ref name_value) = meta {
+            if let Lit::Str(ref tag) = name_value.lit {
+                return Some(vec![RustlerAttr::Tag(tag.value())]);
+            }
+        }
+        panic!("Cannot parse module")
+    }
+
+    fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(name_value) = meta {
+            if let Lit::Str(ref module) = name_value.lit {
+                let ident = format!("Elixir.{}", module.value());
+                return Some(vec![RustlerAttr::Module(ident)]);
+            }
+        }
+        panic!("Cannot parse tag")
     }
 }
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -180,12 +180,15 @@ fn get_tag(ast: &syn::DeriveInput, ctx: &Context) -> String {
                     .iter()
                     .map(|attr| attr.parse_meta())
                     .find(|meta| match meta {
-                        Ok(Meta::NameValue(meta_name_value)) => meta_name_value.ident == "tag",
+                        Ok(Meta::NameValue(name_value)) => {
+                            let ident = name_value.path.segments[0].ident.to_string();
+                            ident == "tag"
+                        }
                         _ => false,
                     });
 
             match *attr_value {
-                Some(Ok(Meta::NameValue(ref meta_name_value))) => match meta_name_value.lit {
+                Some(Ok(Meta::NameValue(ref name_value))) => match name_value.lit {
                     Lit::Str(ref tag) => Some(tag.value()),
                     _ => panic!("Cannot parse tag"),
                 },

--- a/rustler_sys/Cargo.toml
+++ b/rustler_sys/Cargo.toml
@@ -35,4 +35,4 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [dependencies]
-unreachable = "0.1"
+unreachable = "1.0"

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-lazy_static = "1.2"
+lazy_static = "1.4"
 rustler = { path = "../../../rustler" }


### PR DESCRIPTION
This pull request started as an attempt to bump dependencies. I bumped syn as well as proc-macro2, which resulted in some code churn. While doing that, I realized that the attribute retrieval for `RustlerAttrs` was very hard to read, and even incorrect for retrieving the `module` and `tag` attribute. I fixed that by refactoring the attribute dispatch to happen as early as possible. With that change, I also removed the code for retrieving the module and tag from `record.rs` and `ex_struct.rs` in favor of the new implementation.

Note that this pull request could also be split into two parts, one for bumping the dependencies and the needed migration, and one for the attribute refactoring.

Let me know if this PR is of help to you and if you need further work to be done.