### PR TITLE
Fix module namespace

### DIFF
--- a/rustler_mix/priv/templates/basic/src/lib.rs
+++ b/rustler_mix/priv/templates/basic/src/lib.rs
@@ -1,7 +1,7 @@
 use rustler::{Encoder, Env, Error, Term};
 
 mod atoms {
-    rustler_atoms! {
+    rustler::rustler_atoms! {
         atom ok;
         //atom error;
         //atom __true__ = "true";


### PR DESCRIPTION
In the generated template, the module namespace is missing