### PR TITLE
Remove superfluous use statements from proc-macros

### DIFF
--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -96,8 +96,6 @@ pub fn gen_decoder(
     let gen = quote! {
         impl<'a> ::rustler::Decoder<'a> for #struct_type {
             fn decode(term: ::rustler::Term<'a>) -> Result<Self, ::rustler::Error> {
-                use ::rustler::Encoder;
-
                 #atom_defs
 
                 let env = term.get_env();

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -157,7 +157,6 @@ pub fn gen_encoder(
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 #atom_defs
 
-                use ::rustler::Encoder;
                 let arr = #field_list_ast;
                 ::rustler::types::tuple::make_tuple(env, &arr)
             }

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -133,7 +133,6 @@ pub fn gen_encoder(
     let gen = quote! {
         impl<'b> ::rustler::Encoder for #struct_typ {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
-                use ::rustler::Encoder;
                 let arr = #field_list_ast;
                 ::rustler::types::tuple::make_tuple(env, &arr)
             }


### PR DESCRIPTION
This pull request removes some superfluous `use` statements within `rustler_codegen`.