### PR TITLE
Fix a Clippy warning (Clippy 0.0.212 / Rust 1.38.0)

### DIFF
--- a/rustler/src/resource.rs
+++ b/rustler/src/resource.rs
@@ -85,9 +85,9 @@ pub fn open_struct_resource_type<'a, T: ResourceTypeProvider>(
             flags,
         )
     };
-    if res.is_some() {
+    if let Some(res) = res {
         Some(ResourceType {
-            res: res.unwrap(),
+            res,
             struct_type: PhantomData,
         })
     } else {


### PR DESCRIPTION
Clippy in the latest Rust stable emits the following warning:

```console
error: You checked before that `unwrap()` cannot fail. Instead of checking and unwrapping, it's better to use `if let` or `match`.
  --> rustler/src/resource.rs:90:18
   |
88 |     if res.is_some() {
   |        ------------- the check is happening here
89 |         Some(ResourceType {
90 |             res: res.unwrap(),
   |                  ^^^^^^^^^^^^
   |
   = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap
```
This pull request addresses the warning by changing the codes as [suggested by Clippy](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap).

**Version Info**

Rust 1.38.0 stable

```console
$ rustc -V
rustc 1.38.0 (625451e37 2019-09-23)

$ cargo clippy -V
clippy 0.0.212 (3aea860 2019-09-03)
```
