### PR TITLE
Refactor codegen

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -1,0 +1,138 @@
+use syn::{Lit, Meta, NestedMeta};
+
+use super::RustlerAttr;
+
+///
+/// A parsing context struct.
+///
+/// `Context` holds information usable for different codegen modules.
+///
+#[derive(Debug)]
+pub(crate) struct Context<'a> {
+    pub(crate) attrs: Vec<RustlerAttr>,
+    pub(crate) ident: &'a proc_macro2::Ident,
+    pub(crate) ident_with_lifetime: proc_macro2::TokenStream,
+}
+
+impl<'a> Context<'a> {
+    pub(crate) fn from_ast(ast: &'a syn::DeriveInput) -> Self {
+        let mut attrs: Vec<_> = ast
+            .attrs
+            .iter()
+            .map(Context::get_rustler_attrs)
+            .flatten()
+            .collect();
+
+        //
+        // Default: generate encoder and decoder
+        //
+        if !Context::encode_decode_attr_set(&attrs) {
+            attrs.push(RustlerAttr::Encode);
+            attrs.push(RustlerAttr::Decode);
+        }
+
+        let has_lifetime = match ast.generics.lifetimes().count() {
+            0 => false,
+            1 => true,
+            _ => panic!("Struct can only have one lifetime argument"),
+        };
+
+        let ident = &ast.ident;
+        let ident_with_lifetime = if has_lifetime {
+            quote! { #ident <'a> }
+        } else {
+            quote! { #ident }
+        };
+
+        Self {
+            attrs,
+            ident,
+            ident_with_lifetime,
+        }
+    }
+
+    pub(crate) fn encode(&self) -> bool {
+        self.attrs.iter().any(|attr| match attr {
+            RustlerAttr::Encode => true,
+            _ => false,
+        })
+    }
+
+    pub(crate) fn decode(&self) -> bool {
+        self.attrs.iter().any(|attr| match attr {
+            RustlerAttr::Decode => true,
+            _ => false,
+        })
+    }
+
+    fn encode_decode_attr_set(attrs: &[RustlerAttr]) -> bool {
+        attrs.iter().any(|attr| match attr {
+            RustlerAttr::Encode => true,
+            RustlerAttr::Decode => true,
+            _ => false,
+        })
+    }
+
+    fn get_rustler_attrs(attr: &syn::Attribute) -> Vec<RustlerAttr> {
+        attr.path
+            .segments
+            .iter()
+            .filter_map(|segment| {
+                let meta = attr.parse_meta().expect("can parse meta");
+                match segment.ident.to_string().as_ref() {
+                    "rustler" => Context::parse_rustler(&meta),
+                    "tag" => Context::try_parse_tag(&meta),
+                    "module" => Context::try_parse_module(&meta),
+                    _ => None,
+                }
+            })
+            .flatten()
+            .collect()
+    }
+
+    fn parse_rustler(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::List(ref list) = meta {
+            return Some(
+                list.nested
+                    .iter()
+                    .map(Context::parse_nested_rustler)
+                    .collect(),
+            );
+        }
+
+        panic!("Expected encode and/or decode in rustler attribute");
+    }
+
+    fn parse_nested_rustler(nested: &NestedMeta) -> RustlerAttr {
+        if let NestedMeta::Meta(ref meta) = nested {
+            if let Meta::Path(ref path) = meta {
+                match path.segments[0].ident.to_string().as_ref() {
+                    "encode" => return RustlerAttr::Encode,
+                    "decode" => return RustlerAttr::Decode,
+                    other => panic!("Unexpected literal {}", other),
+                }
+            }
+        }
+
+        panic!("Expected encode and/or decode in rustler attribute");
+    }
+
+    fn try_parse_tag(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(ref name_value) = meta {
+            if let Lit::Str(ref tag) = name_value.lit {
+                return Some(vec![RustlerAttr::Tag(tag.value())]);
+            }
+        }
+        panic!("Cannot parse module")
+    }
+
+    fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(name_value) = meta {
+            if let Lit::Str(ref module) = name_value.lit {
+                let ident = format!("Elixir.{}", module.value());
+                return Some(vec![RustlerAttr::Module(ident)]);
+            }
+        }
+        panic!("Cannot parse tag")
+    }
+}

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -9,15 +9,15 @@ use super::RustlerAttr;
 /// `Context` holds information usable for different codegen modules.
 ///
 pub(crate) struct Context<'a> {
-    pub(crate) attrs: Vec<RustlerAttr>,
-    pub(crate) ident: &'a proc_macro2::Ident,
-    pub(crate) ident_with_lifetime: proc_macro2::TokenStream,
-    pub(crate) variants: Option<Vec<&'a Variant>>,
-    pub(crate) struct_fields: Option<Vec<&'a Field>>,
+    pub attrs: Vec<RustlerAttr>,
+    pub ident: &'a proc_macro2::Ident,
+    pub ident_with_lifetime: proc_macro2::TokenStream,
+    pub variants: Option<Vec<&'a Variant>>,
+    pub struct_fields: Option<Vec<&'a Field>>,
 }
 
 impl<'a> Context<'a> {
-    pub(crate) fn from_ast(ast: &'a syn::DeriveInput) -> Self {
+    pub fn from_ast(ast: &'a syn::DeriveInput) -> Self {
         let mut attrs: Vec<_> = ast
             .attrs
             .iter()
@@ -65,21 +65,21 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn encode(&self) -> bool {
+    pub fn encode(&self) -> bool {
         self.attrs.iter().any(|attr| match attr {
             RustlerAttr::Encode => true,
             _ => false,
         })
     }
 
-    pub(crate) fn decode(&self) -> bool {
+    pub fn decode(&self) -> bool {
         self.attrs.iter().any(|attr| match attr {
             RustlerAttr::Decode => true,
             _ => false,
         })
     }
 
-    pub(crate) fn field_atoms(&self) -> Option<Vec<TokenStream>> {
+    pub fn field_atoms(&self) -> Option<Vec<TokenStream>> {
         self.struct_fields.as_ref().map(|struct_fields| {
             struct_fields
                 .iter()

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -2,7 +2,8 @@ use proc_macro2::{Span, TokenStream};
 
 use syn::{self, Data, Field, Ident};
 
-use super::{Context, RustlerAttr};
+use super::context::Context;
+use super::RustlerAttr;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Data, Field, Ident};
+use syn::{self, Field, Ident};
 
 use super::context::Context;
 use super::RustlerAttr;
@@ -10,25 +10,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 
     let elixir_module = get_module(&ctx);
 
-    let struct_fields = match ast.data {
-        Data::Struct(ref data_struct) => &data_struct.fields,
-        Data::Enum(_) => panic!("NifStruct can only be used with structs"),
-        Data::Union(_) => panic!("NifStruct can only be used with structs"),
-    };
+    let struct_fields = ctx
+        .struct_fields
+        .as_ref()
+        .expect("NifStruct can only be used with structs");
 
-    let field_atoms: Vec<TokenStream> = struct_fields
-        .iter()
-        .map(|field| {
-            let ident = field.ident.as_ref().unwrap();
-            let ident_str = ident.to_string();
-
-            let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
-
-            quote! {
-                #atom_fun = #ident_str,
-            }
-        })
-        .collect();
+    // Unwrap is ok here, as we already determined that struct_fields is not None
+    let field_atoms = ctx.field_atoms().unwrap();
 
     let atom_defs = quote! {
         rustler::atoms! {
@@ -37,8 +25,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
             #(#field_atoms)*
         }
     };
-
-    let struct_fields: Vec<_> = struct_fields.iter().collect();
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &atom_defs, &struct_fields)

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -10,7 +10,7 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
-use syn::{Lit, Meta, NestedMeta};
+mod context;
 
 mod ex_struct;
 mod map;
@@ -25,136 +25,6 @@ enum RustlerAttr {
     Decode,
     Module(String),
     Tag(String),
-}
-
-#[derive(Debug)]
-struct Context<'a> {
-    attrs: Vec<RustlerAttr>,
-    ident: &'a proc_macro2::Ident,
-    ident_with_lifetime: proc_macro2::TokenStream,
-}
-
-impl<'a> Context<'a> {
-    fn from_ast(ast: &'a syn::DeriveInput) -> Self {
-        let mut attrs: Vec<_> = ast
-            .attrs
-            .iter()
-            .map(Context::get_rustler_attrs)
-            .flatten()
-            .collect();
-
-        //
-        // Default: generate encoder and decoder
-        //
-        if !Context::encode_decode_attr_set(&attrs) {
-            attrs.push(RustlerAttr::Encode);
-            attrs.push(RustlerAttr::Decode);
-        }
-
-        let has_lifetime = match ast.generics.lifetimes().count() {
-            0 => false,
-            1 => true,
-            _ => panic!("Struct can only have one lifetime argument"),
-        };
-
-        let ident = &ast.ident;
-        let ident_with_lifetime = if has_lifetime {
-            quote! { #ident <'a> }
-        } else {
-            quote! { #ident }
-        };
-
-        Self {
-            attrs,
-            ident,
-            ident_with_lifetime,
-        }
-    }
-
-    fn encode(&self) -> bool {
-        self.attrs.iter().any(|attr| match attr {
-            RustlerAttr::Encode => true,
-            _ => false,
-        })
-    }
-
-    fn decode(&self) -> bool {
-        self.attrs.iter().any(|attr| match attr {
-            RustlerAttr::Decode => true,
-            _ => false,
-        })
-    }
-
-    fn encode_decode_attr_set(attrs: &[RustlerAttr]) -> bool {
-        attrs.iter().any(|attr| match attr {
-            RustlerAttr::Encode => true,
-            RustlerAttr::Decode => true,
-            _ => false,
-        })
-    }
-
-    fn get_rustler_attrs(attr: &syn::Attribute) -> Vec<RustlerAttr> {
-        attr.path
-            .segments
-            .iter()
-            .filter_map(|segment| {
-                let meta = attr.parse_meta().expect("can parse meta");
-                match segment.ident.to_string().as_ref() {
-                    "rustler" => Context::parse_rustler(&meta),
-                    "tag" => Context::try_parse_tag(&meta),
-                    "module" => Context::try_parse_module(&meta),
-                    _ => None,
-                }
-            })
-            .flatten()
-            .collect()
-    }
-
-    fn parse_rustler(meta: &Meta) -> Option<Vec<RustlerAttr>> {
-        if let Meta::List(ref list) = meta {
-            return Some(
-                list.nested
-                    .iter()
-                    .map(Context::parse_nested_rustler)
-                    .collect(),
-            );
-        }
-
-        panic!("Expected encode and/or decode in rustler attribute");
-    }
-
-    fn parse_nested_rustler(nested: &NestedMeta) -> RustlerAttr {
-        if let NestedMeta::Meta(ref meta) = nested {
-            if let Meta::Path(ref path) = meta {
-                match path.segments[0].ident.to_string().as_ref() {
-                    "encode" => return RustlerAttr::Encode,
-                    "decode" => return RustlerAttr::Decode,
-                    other => panic!("Unexpected literal {}", other),
-                }
-            }
-        }
-
-        panic!("Expected encode and/or decode in rustler attribute");
-    }
-
-    fn try_parse_tag(meta: &Meta) -> Option<Vec<RustlerAttr>> {
-        if let Meta::NameValue(ref name_value) = meta {
-            if let Lit::Str(ref tag) = name_value.lit {
-                return Some(vec![RustlerAttr::Tag(tag.value())]);
-            }
-        }
-        panic!("Cannot parse module")
-    }
-
-    fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
-        if let Meta::NameValue(name_value) = meta {
-            if let Lit::Str(ref module) = name_value.lit {
-                let ident = format!("Elixir.{}", module.value());
-                return Some(vec![RustlerAttr::Module(ident)]);
-            }
-        }
-        panic!("Cannot parse tag")
-    }
 }
 
 /// Implementation of the `NifStruct` macro that lets the user annotate a struct that will

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Span, TokenStream};
 
 use syn::{self, Data, Field, Ident};
 
-use super::Context;
+use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -1,38 +1,25 @@
 use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Data, Field, Ident};
+use syn::{self, Field, Ident};
 
 use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);
 
-    let struct_fields = match ast.data {
-        Data::Struct(ref data_struct) => &data_struct.fields,
-        _ => panic!("Must decorate a struct"),
-    };
+    let struct_fields = ctx
+        .struct_fields
+        .as_ref()
+        .expect("NifMap can only be used with structs");
 
-    let field_atoms: Vec<TokenStream> = struct_fields
-        .iter()
-        .map(|field| {
-            let ident = field.ident.as_ref().unwrap();
-            let ident_str = ident.to_string();
-
-            let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
-
-            quote! {
-                #atom_fun = #ident_str,
-            }
-        })
-        .collect();
+    // Unwrap is ok here, as we already determined that struct_fields is not None
+    let field_atoms = ctx.field_atoms().unwrap();
 
     let atom_defs = quote! {
         rustler::atoms! {
             #(#field_atoms)*
         }
     };
-
-    let struct_fields: Vec<_> = struct_fields.iter().collect();
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &struct_fields, &atom_defs)

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Data, Field, Ident};
+use syn::{self, Data, Field};
 
 use super::{Context, RustlerAttr};
 
@@ -15,12 +15,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         Data::Union(_) => panic!("NifRecord can only be used with enums"),
     };
 
-    let num_lifetimes = ast.generics.lifetimes().count();
-    if num_lifetimes > 1 {
-        panic!("Struct can only have one lifetime argument");
-    }
-    let has_lifetime = num_lifetimes == 1;
-
     let atom_defs = quote! {
         rustler::atoms! {
             atom_tag = #record_tag,
@@ -30,13 +24,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let struct_fields: Vec<_> = struct_fields.iter().collect();
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime)
+        gen_decoder(&ctx, &atom_defs, &struct_fields)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ast.ident, &struct_fields, &atom_defs, has_lifetime)
+        gen_encoder(&ctx, &atom_defs, &struct_fields)
     } else {
         quote! {}
     };
@@ -49,12 +43,10 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-pub fn gen_decoder(
-    struct_name: &Ident,
-    fields: &[&Field],
-    atom_defs: &TokenStream,
-    has_lifetime: bool,
-) -> TokenStream {
+fn gen_decoder(ctx: &Context, atom_defs: &TokenStream, fields: &[&Field]) -> TokenStream {
+    let struct_type = &ctx.ident_with_lifetime;
+    let struct_name = ctx.ident;
+
     // Make a decoder for each of the fields in the struct.
     let field_defs: Vec<TokenStream> = fields
         .iter()
@@ -77,20 +69,15 @@ pub fn gen_decoder(
         })
         .collect();
 
-    // If the struct has a lifetime argument, put that in the struct type.
-    let struct_typ = if has_lifetime {
-        quote! { #struct_name <'a> }
-    } else {
-        quote! { #struct_name }
-    };
-
     let field_num = field_defs.len();
     let struct_name_str = struct_name.to_string();
 
     // The implementation itself
     let gen = quote! {
-        impl<'a> ::rustler::Decoder<'a> for #struct_typ {
+        impl<'a> ::rustler::Decoder<'a> for #struct_type {
             fn decode(term: ::rustler::Term<'a>) -> Result<Self, ::rustler::Error> {
+                #atom_defs
+
                 let terms = match ::rustler::types::tuple::get_tuple(term) {
                     Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(format!("Invalid Record structure for {}", #struct_name_str)))),
                     Ok(value) => value,
@@ -99,8 +86,6 @@ pub fn gen_decoder(
                 if terms.len() != #field_num + 1 {
                     return Err(::rustler::Error::Atom("invalid_record"));
                 }
-
-                #atom_defs
 
                 let tag : ::rustler::types::atom::Atom = terms[0].decode()?;
 
@@ -120,12 +105,9 @@ pub fn gen_decoder(
     gen
 }
 
-pub fn gen_encoder(
-    struct_name: &Ident,
-    fields: &[&Field],
-    atom_defs: &TokenStream,
-    has_lifetime: bool,
-) -> TokenStream {
+fn gen_encoder(ctx: &Context, atom_defs: &TokenStream, fields: &[&Field]) -> TokenStream {
+    let struct_type = &ctx.ident_with_lifetime;
+
     // Make a field encoder expression for each of the items in the struct.
     let field_encoders: Vec<TokenStream> = fields
         .iter()
@@ -144,19 +126,11 @@ pub fn gen_encoder(
         [#tag_encoder, #(#field_encoders),*]
     };
 
-    // If the struct has a lifetime argument, put that in the struct type.
-    let struct_typ = if has_lifetime {
-        quote! { #struct_name <'b> }
-    } else {
-        quote! { #struct_name }
-    };
-
     // The implementation itself
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_typ {
+        impl<'b> ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 #atom_defs
-
                 let arr = #field_list_ast;
                 ::rustler::types::tuple::make_tuple(env, &arr)
             }

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Data, Field};
+use syn::{self, Field};
 
 use super::context::Context;
 use super::RustlerAttr;
@@ -10,19 +10,16 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 
     let record_tag = get_tag(&ctx);
 
-    let struct_fields = match ast.data {
-        Data::Struct(ref data_struct) => &data_struct.fields,
-        Data::Enum(_) => panic!("NifRecord can only be used with structs"),
-        Data::Union(_) => panic!("NifRecord can only be used with enums"),
-    };
+    let struct_fields = ctx
+        .struct_fields
+        .as_ref()
+        .expect("NifRecord can only be used with structs");
 
     let atom_defs = quote! {
         rustler::atoms! {
             atom_tag = #record_tag,
         }
     };
-
-    let struct_fields: Vec<_> = struct_fields.iter().collect();
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &atom_defs, &struct_fields)

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -2,7 +2,8 @@ use proc_macro2::TokenStream;
 
 use syn::{self, Data, Field};
 
-use super::{Context, RustlerAttr};
+use super::context::Context;
+use super::RustlerAttr;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,18 +1,16 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Data, Field};
+use syn::{self, Field};
 
 use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);
 
-    let struct_fields = match ast.data {
-        Data::Struct(ref struct_data) => &struct_data.fields,
-        _ => panic!("Must decorate a struct"),
-    };
-
-    let struct_fields: Vec<_> = struct_fields.iter().collect();
+    let struct_fields = ctx
+        .struct_fields
+        .as_ref()
+        .expect("NifStruct can only be used with structs");
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &struct_fields, false)

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 
 use syn::{self, Data, Field};
 
-use super::Context;
+use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -10,7 +10,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let struct_fields = ctx
         .struct_fields
         .as_ref()
-        .expect("NifStruct can only be used with structs");
+        .expect("NifTuple can only be used with structs");
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &struct_fields, false)

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use heck::SnakeCase;
 use syn::{self, Data, Fields, Ident, Variant};
 
-use super::Context;
+use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -1,18 +1,17 @@
 use proc_macro2::{Span, TokenStream};
 
 use heck::SnakeCase;
-use syn::{self, Data, Fields, Ident, Variant};
+use syn::{self, Fields, Ident, Variant};
 
 use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);
 
-    let variants = match ast.data {
-        Data::Enum(ref data_enum) => &data_enum.variants,
-        Data::Struct(_) => panic!("NifUnitEnum can only be used with enums"),
-        Data::Union(_) => panic!("NifUnitEnum can only be used with enums"),
-    };
+    let variants = ctx
+        .variants
+        .as_ref()
+        .expect("NifUnitEnum can only be used with enums");
 
     for variant in variants {
         if let Fields::Unit = variant.fields {
@@ -37,8 +36,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
             #(#atoms)*
         }
     };
-
-    let variants: Vec<&Variant> = variants.iter().collect();
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &variants, &atom_defs)

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -14,12 +14,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         Data::Union(_) => panic!("NifUnitEnum can only be used with enums"),
     };
 
-    let num_lifetimes = ast.generics.lifetimes().count();
-    if num_lifetimes > 1 {
-        panic!("Enum can only have one lifetime argument");
-    }
-    let has_lifetime = num_lifetimes == 1;
-
     for variant in variants {
         if let Fields::Unit = variant.fields {
         } else {
@@ -47,13 +41,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let variants: Vec<&Variant> = variants.iter().collect();
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ast.ident, &variants, &atom_defs, has_lifetime)
+        gen_decoder(&ctx, &variants, &atom_defs)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ast.ident, &variants, &atom_defs, has_lifetime)
+        gen_encoder(&ctx, &variants, &atom_defs)
     } else {
         quote! {}
     };
@@ -66,17 +60,9 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-pub fn gen_decoder(
-    enum_name: &Ident,
-    variants: &[&Variant],
-    atom_defs: &TokenStream,
-    has_lifetime: bool,
-) -> TokenStream {
-    let enum_type = if has_lifetime {
-        quote! { #enum_name <'b> }
-    } else {
-        quote! { #enum_name }
-    };
+fn gen_decoder(ctx: &Context, variants: &[&Variant], atom_defs: &TokenStream) -> TokenStream {
+    let enum_type = &ctx.ident_with_lifetime;
+    let enum_name = ctx.ident;
 
     let variant_defs: Vec<TokenStream> = variants
         .iter()
@@ -110,17 +96,9 @@ pub fn gen_decoder(
     gen
 }
 
-pub fn gen_encoder(
-    enum_name: &Ident,
-    variants: &[&Variant],
-    atom_defs: &TokenStream,
-    has_lifetime: bool,
-) -> TokenStream {
-    let enum_type = if has_lifetime {
-        quote! { #enum_name <'b> }
-    } else {
-        quote! { #enum_name }
-    };
+fn gen_encoder(ctx: &Context, variants: &[&Variant], atom_defs: &TokenStream) -> TokenStream {
+    let enum_type = &ctx.ident_with_lifetime;
+    let enum_name = ctx.ident;
 
     let variant_defs: Vec<TokenStream> = variants
         .iter()

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -1,16 +1,16 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Data, Fields, Variant};
+use syn::{self, Fields, Variant};
 
 use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);
-    let variants = match ast.data {
-        Data::Enum(ref data_enum) => &data_enum.variants,
-        Data::Struct(_) => panic!("NifUntaggedEnum can only be used with enums"),
-        Data::Union(_) => panic!("NifUntaggedEnum can only be used with enums"),
-    };
+
+    let variants = ctx
+        .variants
+        .as_ref()
+        .expect("NifUntaggedEnum can only be used with enums");
 
     for variant in variants {
         if let Fields::Unnamed(_) = variant.fields {
@@ -23,8 +23,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
             );
         }
     }
-
-    let variants: Vec<&Variant> = variants.iter().collect();
 
     let decoder = if ctx.decode() {
         gen_decoder(&ctx, &variants)

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 
 use syn::{self, Data, Fields, Variant};
 
-use super::Context;
+use super::context::Context;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);


### PR DESCRIPTION
The proc-macro code generation has a lot of duplicate code over multiple modules. This merge request refactors the modules by pulling common code into the `rustler_codegen::context::Context` struct and its functions. This is in part as a preparation for #241 in order to simplify de-duplicating the `field_atoms`.