### PR TITLE
Added Error::Term for returning `{:error, <term>}`

### DIFF
--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -70,4 +70,11 @@ defmodule RustlerTest do
   def dirty_cpu(), do: err()
 
   def sum_range(_), do: err()
+
+  def bad_arg_error(), do: err()
+  def atom_str_error(), do: err()
+  def raise_atom_error(), do: err()
+  def raise_term_with_string_error(), do: err()
+  def raise_term_with_atom_error(), do: err()
+  def term_with_tuple_error(), do: err()
 end

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -3,6 +3,7 @@ mod test_binary;
 mod test_codegen;
 mod test_dirty;
 mod test_env;
+mod test_error;
 mod test_list;
 mod test_map;
 mod test_primitives;
@@ -62,6 +63,12 @@ rustler::init!(
         test_dirty::dirty_cpu,
         test_dirty::dirty_io,
         test_range::sum_range,
+        test_error::bad_arg_error,
+        test_error::atom_str_error,
+        test_error::raise_atom_error,
+        test_error::raise_term_with_string_error,
+        test_error::raise_term_with_atom_error,
+        test_error::term_with_tuple_error,
     ],
     load = load
 );

--- a/rustler_tests/native/rustler_test/src/test_error.rs
+++ b/rustler_tests/native/rustler_test/src/test_error.rs
@@ -1,0 +1,45 @@
+use rustler::{Error, NifResult};
+
+mod atoms {
+    rustler::atoms! {
+        error,
+        should_be_a_raised_term_as_atom,
+        return_term_with_atom,
+        should_be_an_atom_wrapped_in_an_error_tuple,
+    }
+}
+
+#[rustler::nif]
+pub fn bad_arg_error() -> NifResult<()> {
+    Err(Error::BadArg)
+}
+
+#[rustler::nif]
+pub fn atom_str_error() -> NifResult<()> {
+    Err(Error::Atom("should_be_a_returned_atom"))
+}
+
+#[rustler::nif]
+pub fn raise_atom_error() -> NifResult<()> {
+    Err(Error::RaiseAtom("should_be_a_raised_atom"))
+}
+
+#[rustler::nif]
+pub fn raise_term_with_string_error() -> NifResult<()> {
+    Err(Error::RaiseTerm(Box::new(
+        "should_be_a_raised_string".to_string(),
+    )))
+}
+
+#[rustler::nif]
+pub fn raise_term_with_atom_error() -> NifResult<()> {
+    Err(Error::RaiseTerm(Box::new(
+        atoms::should_be_a_raised_term_as_atom(),
+    )))
+}
+
+#[rustler::nif]
+pub fn term_with_tuple_error() -> NifResult<()> {
+    let reason = atoms::should_be_an_atom_wrapped_in_an_error_tuple();
+    Err(Error::Term(Box::new(reason)))
+}

--- a/rustler_tests/test/error_test.exs
+++ b/rustler_tests/test/error_test.exs
@@ -1,0 +1,30 @@
+defmodule RustlerTest.ErrorTest do
+  use ExUnit.Case, async: true
+
+  test "in elixir Error::BadArg results in an ArgumentError" do
+    assert_raise(ArgumentError, fn -> RustlerTest.bad_arg_error() end)
+  end
+
+  test "in elixir Error::Atom results in a returned atom" do
+    assert RustlerTest.atom_str_error() == :should_be_a_returned_atom
+  end
+
+  test "raise_atom_error raises an ErlangError with a raise" do
+    exception = assert_raise(ErlangError, fn -> RustlerTest.raise_atom_error() end)
+    assert exception == %ErlangError{original: :should_be_a_raised_atom}
+  end
+
+  test "raise_term_with_string_error returns the expected atom" do
+    exception = assert_raise(ErlangError, fn -> RustlerTest.raise_term_with_string_error() end)
+    assert exception == %ErlangError{original: "should_be_a_raised_string"}
+  end
+
+  test "raise_term_with_atom_error panics with a raise" do
+    assert_raise(ErlangError, fn -> RustlerTest.raise_term_with_atom_error() end)
+  end
+
+  test "return_term_with_tuple_error returns an arbitrary Encoder" do
+    assert RustlerTest.term_with_tuple_error() ==
+             {:error, :should_be_an_atom_wrapped_in_an_error_tuple}
+  end
+end


### PR DESCRIPTION
Hi! I added a variant to return any encoder as an error. I think could help ergonomics and help return more meaningful errors from our native Rustler interfaces to Elixir.

Feedback is appreciated. :)