### PR TITLE
use $crate::Term in `init!` macro

### DIFF
--- a/rustler/src/export.rs
+++ b/rustler/src/export.rs
@@ -96,6 +96,7 @@ macro_rules! init {
     };
 
     (internal_handle_nif_call, ($fun:path, $arity:expr, $env:expr, $argc:expr, $argv:expr)) => ({
+        use $crate::Term;
         let env_lifetime = ();
         let env = $crate::Env::new(&env_lifetime, $env);
 


### PR DESCRIPTION
I've been noticing that when I don't have `Term` in scope in `lib.rs` I get the following error:

```
error[E0277]: the size for values of type `[rustler::term::Term<'_>]` cannot be known at compilation time
  --> src/lib.rs:6:1
   |
6  | / rustler::init! {
7  | |     "Elixir.Hyperbeam.Native",
8  | |     [
9  | |         ("start", 1, server::start),
...  |
14 | |     Some(server::load)
15 | | }
   | |_^ doesn't have a size known at compile-time
   |
   = help: the trait `std::marker::Sized` is not implemented for `[rustler::term::Term<'_>]`
   = note: to learn more, visit <https://doc.rust-lang.org/book/ch19-04-advanced-types.html#dynamically-sized-types-and-the-sized-trait>
   = note: all local variables must have a statically known size
   = help: unsized locals are gated as an unstable feature
   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

The one-line change in this PR brings that type into scope to fix this. I'm not sure if this is the right thing to do...