### PR TITLE
Fix crash when compiling port

### DIFF
--- a/rustler_mix/lib/mix/tasks/compile.rustler.ex
+++ b/rustler_mix/lib/mix/tasks/compile.rustler.ex
@@ -143,7 +143,11 @@ defmodule Mix.Tasks.Compile.Rustler do
   defp make_build_mode_flag(args, :debug), do: args ++ []
 
   defp get_name(cargo_data, section) do
-    get_in(cargo_data, [section, "name"])
+    case cargo_data[section] do
+      nil -> nil
+      values when is_map(values) -> values["name"]
+      values when is_list(values) -> Enum.find_value(values, & &1["name"])
+    end
   end
 
   def make_file_names(base_name, :lib) do


### PR DESCRIPTION
A data section can contain multiple sets of values, instead of a single one.