### PR TITLE
Deduplicate field atoms

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -75,6 +75,10 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub fn atoms_module_name(&self, span: Span) -> Ident {
+        Ident::new(&format!("RUSTLER_ATOMS_{}", self.ident), span)
+    }
+
     pub fn encode(&self) -> bool {
         self.attrs.iter().any(|attr| match attr {
             RustlerAttr::Encode => true,

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -99,14 +99,17 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
     let struct_type = &ctx.ident_with_lifetime;
 
-    let field_defs: Vec<TokenStream> = fields.iter().map(|field| {
-        let field_ident = field.ident.as_ref().unwrap();
-        let field_ident_str = field_ident.to_string();
-        let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
-        quote! {
-            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
-        }
-    }).collect();
+    let field_defs: Vec<TokenStream> = fields
+        .iter()
+        .map(|field| {
+            let field_ident = field.ident.as_ref().unwrap();
+            let field_ident_str = field_ident.to_string();
+            let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
+            quote! {
+                map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
+            }
+        })
+        .collect();
 
     let gen = quote! {
         impl<'b> ::rustler::Encoder for #struct_type {

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -104,7 +104,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         let field_ident_str = field_ident.to_string();
         let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
         quote! {
-            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).ok().unwrap();
+            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
         }
     }).collect();
 
@@ -113,7 +113,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
                 let mut map = ::rustler::types::map::map_new(env);
-                map = map.map_put(atom_struct().encode(env), atom_module().encode(env)).ok().unwrap();
+                map = map.map_put(atom_struct().encode(env), atom_module().encode(env)).unwrap();
                 #(#field_defs)*
                 map
             }

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -21,19 +21,25 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         }
     };
 
+    let atoms_module_name = ctx.atoms_module_name(Span::call_site());
+
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &struct_fields, &atom_defs)
+        gen_decoder(&ctx, &struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &struct_fields, &atom_defs)
+        gen_encoder(&ctx, &struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let gen = quote! {
+        mod #atoms_module_name {
+            #atom_defs
+        }
+
         #decoder
         #encoder
     };
@@ -41,7 +47,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-fn gen_decoder(ctx: &Context, fields: &[&Field], atom_defs: &TokenStream) -> TokenStream {
+fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
     let struct_type = &ctx.ident_with_lifetime;
     let struct_name = ctx.ident;
 
@@ -66,7 +72,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atom_defs: &TokenStream) -> Tok
     let gen = quote! {
         impl<'a> ::rustler::Decoder<'a> for #struct_type {
             fn decode(term: ::rustler::Term<'a>) -> Result<Self, ::rustler::Error> {
-                #atom_defs
+                use #atoms_module_name::*;
 
                 let env = term.get_env();
                 Ok(#struct_name { #(#field_defs),* })
@@ -77,7 +83,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atom_defs: &TokenStream) -> Tok
     gen
 }
 
-fn gen_encoder(ctx: &Context, fields: &[&Field], atom_defs: &TokenStream) -> TokenStream {
+fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
     let struct_type = &ctx.ident_with_lifetime;
 
     let field_defs: Vec<TokenStream> = fields.iter().map(|field| {
@@ -94,7 +100,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atom_defs: &TokenStream) -> Tok
     let gen = quote! {
         impl<'b> ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
-                #atom_defs
+                use #atoms_module_name::*;
 
                 let mut map = ::rustler::types::map::map_new(env);
                 #(#field_defs)*

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -93,7 +93,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
 
         quote! {
-            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).ok().unwrap();
+            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
         }
     }).collect();
 

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -86,16 +86,19 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
     let struct_type = &ctx.ident_with_lifetime;
 
-    let field_defs: Vec<TokenStream> = fields.iter().map(|field| {
-        let field_ident = field.ident.as_ref().unwrap();
-        let field_ident_str = field_ident.to_string();
+    let field_defs: Vec<TokenStream> = fields
+        .iter()
+        .map(|field| {
+            let field_ident = field.ident.as_ref().unwrap();
+            let field_ident_str = field_ident.to_string();
 
-        let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
+            let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
 
-        quote! {
-            map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
-        }
-    }).collect();
+            quote! {
+                map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
+            }
+        })
+        .collect();
 
     let gen = quote! {
         impl<'b> ::rustler::Encoder for #struct_type {


### PR DESCRIPTION
This pull request deduplicates generating atoms in codegen by generating a module which can be used by both the encoder and decoder.

Fix #241. 