### PR TITLE
codegen: Support newtype and tuple structs

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use syn::{Data, Field, Ident, Lit, Meta, NestedMeta, Variant};
+use syn::{Data, Field, Fields, Ident, Lit, Meta, NestedMeta, Variant};
 
 use super::RustlerAttr;
 
@@ -14,6 +14,7 @@ pub(crate) struct Context<'a> {
     pub ident_with_lifetime: proc_macro2::TokenStream,
     pub variants: Option<Vec<&'a Variant>>,
     pub struct_fields: Option<Vec<&'a Field>>,
+    pub is_tuple_struct: bool,
 }
 
 impl<'a> Context<'a> {
@@ -56,12 +57,21 @@ impl<'a> Context<'a> {
             _ => None,
         };
 
+        let is_tuple_struct = match ast.data {
+            Data::Struct(ref data_struct) => match data_struct.fields {
+                Fields::Unnamed(_) => true,
+                _ => false,
+            },
+            _ => false,
+        };
+
         Self {
             attrs,
             ident,
             ident_with_lifetime,
             variants,
             struct_fields,
+            is_tuple_struct,
         }
     }
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -61,6 +61,10 @@ defmodule RustlerTest do
   def unit_enum_echo(_), do: err()
   def untagged_enum_echo(_), do: err()
   def untagged_enum_with_truthy(_), do: err()
+  def newtype_echo(_), do: err()
+  def tuplestruct_echo(_), do: err()
+  def newtype_record_echo(_), do: err()
+  def tuplestruct_record_echo(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -86,6 +86,14 @@ rustler::init!(
             1,
             test_codegen::untagged_enum_with_truthy
         ),
+        ("newtype_echo", 1, test_codegen::newtype_echo),
+        ("tuplestruct_echo", 1, test_codegen::tuplestruct_echo),
+        ("newtype_record_echo", 1, test_codegen::newtype_record_echo),
+        (
+            "tuplestruct_record_echo",
+            1,
+            test_codegen::tuplestruct_record_echo
+        ),
         ("dirty_cpu", 0, test_dirty::dirty_cpu, DirtyCpu),
         ("dirty_io", 0, test_dirty::dirty_io, DirtyIo),
         ("sum_range", 1, test_range::sum_range),

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -88,3 +88,40 @@ pub fn untagged_enum_with_truthy<'a>(
     let untagged_enum: UntaggedEnumWithTruthy = args[0].decode()?;
     Ok(untagged_enum)
 }
+
+#[derive(NifTuple)]
+pub struct Newtype(i64);
+
+pub fn newtype_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<Newtype> {
+    let newtype: Newtype = args[0].decode()?;
+    Ok(newtype)
+}
+
+#[derive(NifTuple)]
+pub struct TupleStruct(i64, i64, i64);
+
+pub fn tuplestruct_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<TupleStruct> {
+    let tuplestruct: TupleStruct = args[0].decode()?;
+    Ok(tuplestruct)
+}
+
+#[derive(NifRecord)]
+#[tag = "newtype"]
+pub struct NewtypeRecord(i64);
+
+pub fn newtype_record_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<NewtypeRecord> {
+    let newtype: NewtypeRecord = args[0].decode()?;
+    Ok(newtype)
+}
+
+#[derive(NifRecord)]
+#[tag = "tuplestruct"]
+pub struct TupleStructRecord(i64, i64, i64);
+
+pub fn tuplestruct_record_echo<'a>(
+    _env: Env<'a>,
+    args: &[Term<'a>],
+) -> NifResult<TupleStructRecord> {
+    let tuplestruct: TupleStructRecord = args[0].decode()?;
+    Ok(tuplestruct)
+}


### PR DESCRIPTION
This implements support for NifTuple and NifRecord on newtypes or tuple
structs.

Fix #258 