### PR TITLE
NIF Codegen rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,28 +35,12 @@ NOTE: If you have previously used Rustler, you need to run `mix archive.uninstal
 This is the code for a minimal NIF that adds two numbers and returns the result.
 
 ```rust
-use rustler::{Encoder, Env, Error, Term};
-
-mod atoms {
-    rustler::atoms! {
-        ok,
-    }
+#[rustler::nif]
+fn add(a: i64, b: i64) -> i64 {
+    a + b
 }
 
-rustler::init!(
-    "Elixir.Math",
-    [
-        ("add", 2, add)
-    ],
-    None
-);
-
-fn add<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let a: i64 = args[0].decode()?;
-    let b: i64 = args[1].decode()?;
-
-    Ok((atoms::ok(), a + b).encode(env))
-}
+rustler::init!("Elixir.Math", [add]);
 ```
 
 #### Supported nif_version

--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -13,9 +13,9 @@ derive = ["rustler_codegen"]
 alternative_nif_init_name = []
 
 [dependencies]
+lazy_static = "1.4"
 rustler_codegen = { path = "../rustler_codegen", version = "0.21.0", optional = true }
 rustler_sys = { path = "../rustler_sys", version = "~2.0" }
-lazy_static = "1.4"
 
 [build-dependencies]
 lazy_static = "1.4"

--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -23,7 +23,7 @@ pub struct Env<'a> {
 
 /// Two environments are equal if they're the same `NIF_ENV` value.
 ///
-/// A `Env<'a>` is equal to a `Env<'b>` iff `'a` and `'b` are the same lifetime.
+/// A `Env<'a>` is equal to a `Env<'b>` if and only if `'a` and `'b` are the same lifetime.
 impl<'a, 'b> PartialEq<Env<'b>> for Env<'a> {
     fn eq(&self, other: &Env<'b>) -> bool {
         self.env == other.env

--- a/rustler/src/export.rs
+++ b/rustler/src/export.rs
@@ -15,23 +15,16 @@
 /// The third argument is an `Option<fn(env: &Env, load_info: Term) -> bool>`. If this is
 /// `Some`, the function will execute when the NIF is first loaded by the BEAM.
 #[macro_export]
-#[deprecated(since = "0.22.0", note = "Please use `init!` instead.")]
+#[deprecated(since = "0.22.0", note = "Please use `rustler::init!` instead.")]
 macro_rules! rustler_export_nifs {
-    ($name:expr, [$( $exported_nif:tt ),+,], $on_load:expr) => {
-        $crate::init!($name, [$( $exported_nif ),*], $on_load);
-    };
-}
-
-#[macro_export]
-macro_rules! init {
     // Strip trailing comma.
     ($name:expr, [$( $exported_nif:tt ),+,], $on_load:expr) => {
-        $crate::init!($name, [$( $exported_nif ),*], $on_load);
+        $crate::rustler_export_nifs!($name, [$( $exported_nif ),*], $on_load);
     };
     ($name:expr, [$( $exported_nif:tt ),*], $on_load:expr) => {
         static mut NIF_ENTRY: Option<$crate::codegen_runtime::DEF_NIF_ENTRY> = None;
 
-        $crate::init!(internal_platform_init, ({
+        $crate::rustler_export_nifs!(internal_platform_init, ({
             // TODO: If an unwrap ever happens, we will unwind right into C! Fix this!
 
             extern "C" fn nif_load(
@@ -45,7 +38,7 @@ macro_rules! init {
             }
 
             const FUN_ENTRIES: &'static [$crate::codegen_runtime::DEF_NIF_FUNC] = &[
-                $($crate::init!(internal_item_init, $exported_nif)),*
+                $($crate::rustler_export_nifs!(internal_item_init, $exported_nif)),*
             ];
 
             let entry = $crate::codegen_runtime::DEF_NIF_ENTRY {
@@ -69,7 +62,7 @@ macro_rules! init {
     };
 
     (internal_item_init, ($nif_name:expr, $nif_arity:expr, $nif_fun:path)) => {
-        $crate::init!(internal_item_init, ($nif_name, $nif_arity, $nif_fun, $crate::schedule::SchedulerFlags::Normal))
+        $crate::rustler_export_nifs!(internal_item_init, ($nif_name, $nif_arity, $nif_fun, $crate::schedule::SchedulerFlags::Normal))
     };
     (internal_item_init, ($nif_name:expr, $nif_arity:expr, $nif_fun:path, $nif_flag:expr)) => {
         $crate::codegen_runtime::DEF_NIF_FUNC {
@@ -82,12 +75,9 @@ macro_rules! init {
                     argv: *const $crate::codegen_runtime::NIF_TERM)
                     -> $crate::codegen_runtime::NIF_TERM {
                         unsafe {
-                            $crate::init!(
+                            $crate::rustler_export_nifs!(
                                 internal_handle_nif_call, ($nif_fun, $nif_arity, env, argc, argv))
                         }
-                    //unsafe {
-                    //    $crate::codegen_runtime::handle_nif_call($nif_fun, $nif_arity, env, argc, argv)
-                    //}
                 }
                 nif_func
             },

--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -25,7 +25,8 @@
 #[macro_use(enif_snprintf)]
 extern crate rustler_sys;
 
-mod wrapper;
+#[doc(hidden)]
+pub mod wrapper;
 
 #[doc(hidden)]
 pub mod codegen_runtime;
@@ -62,7 +63,13 @@ pub use crate::error::Error;
 pub mod r#return;
 pub use crate::r#return::Return;
 
+#[doc(hidden)]
+mod nif;
+pub use nif::Nif;
+
 pub type NifResult<T> = Result<T, Error>;
 
 #[cfg(feature = "derive")]
-pub use rustler_codegen::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};
+pub use rustler_codegen::{
+    init, nif, NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum,
+};

--- a/rustler/src/nif.rs
+++ b/rustler/src/nif.rs
@@ -1,0 +1,13 @@
+use crate::codegen_runtime::{c_int, DEF_NIF_FUNC, NIF_ENV, NIF_TERM};
+
+pub trait Nif {
+    const NAME: *const u8;
+    const ARITY: u32;
+    const FLAGS: u32;
+    const FUNC: DEF_NIF_FUNC;
+    const RAW_FUNC: unsafe extern "C" fn(
+        nif_env: NIF_ENV,
+        argc: c_int,
+        argv: *const NIF_TERM,
+    ) -> NIF_TERM;
+}

--- a/rustler/src/return.rs
+++ b/rustler/src/return.rs
@@ -6,6 +6,7 @@ pub enum Return<'a> {
     Term(Term<'a>),
     Error(Error),
 }
+
 unsafe impl<'b> NifReturnable for Return<'b> {
     unsafe fn as_returned(self, env: Env) -> NifReturned {
         match self {

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -269,6 +269,9 @@ macro_rules! rustler_atoms {
 }
 
 atoms! {
+    /// The `nif_panicked` atom.
+    nif_panicked,
+
     /// The `nil` atom.
     nil,
 

--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -12,7 +12,7 @@ name = "rustler_codegen"
 proc_macro = true
 
 [dependencies]
-syn = { version = "1.0.5", features = ["derive"] }
+syn = { version = "1.0.5", features = ["full", "extra-traits"] }
 quote = "1.0"
 heck = "0.3"
 proc-macro2 = "1.0"

--- a/rustler_codegen/src/init.rs
+++ b/rustler_codegen/src/init.rs
@@ -1,0 +1,112 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{Expr, Ident, Result, Token};
+
+#[derive(Debug)]
+pub struct InitMacroInput {
+    module: syn::Lit,
+    funcs: syn::ExprArray,
+    on_load: Option<TokenStream>,
+}
+
+impl Parse for InitMacroInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let module = syn::Lit::parse(input)?;
+        let _comma = <syn::Token![,]>::parse(input)?;
+        let funcs = syn::ExprArray::parse(input)?;
+        let on_load = if input.peek(Token![,]) {
+            let _comma = <Token![,]>::parse(input)?;
+            Some(TokenStream::parse(input)?)
+        } else {
+            let none = Ident::new("None", Span::call_site());
+            Some(quote!(#none))
+        };
+
+        Ok(InitMacroInput {
+            module,
+            funcs,
+            on_load,
+        })
+    }
+}
+
+impl Into<proc_macro2::TokenStream> for InitMacroInput {
+    fn into(self) -> proc_macro2::TokenStream {
+        let name = self.module;
+        let num_of_funcs = self.funcs.elems.len();
+        let funcs = nif_funcs(self.funcs.elems);
+        let on_load = self.on_load;
+
+        let inner = quote! {
+            static mut NIF_ENTRY: Option<rustler::codegen_runtime::DEF_NIF_ENTRY> = None;
+            use rustler::Nif;
+
+            let entry = rustler::codegen_runtime::DEF_NIF_ENTRY {
+                major: rustler::codegen_runtime::NIF_MAJOR_VERSION,
+                minor: rustler::codegen_runtime::NIF_MINOR_VERSION,
+                name: concat!(#name, "\0").as_ptr() as *const u8,
+                num_of_funcs: #num_of_funcs as rustler::codegen_runtime::c_int,
+                funcs: [#funcs].as_ptr(),
+                load: {
+                    extern "C" fn nif_load(
+                        env: rustler::codegen_runtime::NIF_ENV,
+                        _priv_data: *mut *mut rustler::codegen_runtime::c_void,
+                        load_info: rustler::codegen_runtime::NIF_TERM
+                    ) -> rustler::codegen_runtime::c_int {
+                        unsafe {
+                            // TODO: If an unwrap ever happens, we will unwind right into C! Fix this!
+                            rustler::codegen_runtime::handle_nif_init_call(#on_load, env, load_info)
+                        }
+                    }
+                    Some(nif_load)
+                },
+                reload: None,
+                upgrade: None,
+                unload: None,
+                vm_variant: b"beam.vanilla\0".as_ptr(),
+                options: 0,
+                sizeof_ErlNifResourceTypeInit: rustler::codegen_runtime::get_nif_resource_type_init_size(),
+            };
+
+            unsafe {
+                NIF_ENTRY = Some(entry);
+                NIF_ENTRY.as_ref().unwrap()
+            }
+        };
+
+        quote! {
+            #[cfg(unix)]
+            #[no_mangle]
+            pub extern "C" fn nif_init() -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
+                #inner
+            }
+
+            #[cfg(windows)]
+            #[no_mangle]
+            pub extern "C" fn nif_init(callbacks: *mut rustler::codegen_runtime::TWinDynNifCallbacks) -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
+                unsafe {
+                    rustler::codegen_runtime::WIN_DYN_NIF_CALLBACKS = Some(*callbacks);
+                }
+
+                #inner
+            }
+        }
+    }
+}
+
+fn nif_funcs(funcs: Punctuated<Expr, Comma>) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    for func in funcs.iter() {
+        if let Expr::Path(_) = *func {
+            tokens.extend(quote!(#func::FUNC,));
+        } else {
+            panic!("Expected an expression, found: {}", stringify!(func));
+        }
+    }
+
+    tokens
+}

--- a/rustler_codegen/src/nif.rs
+++ b/rustler_codegen/src/nif.rs
@@ -1,0 +1,205 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+
+pub fn transcoder_decorator(args: syn::AttributeArgs, fun: syn::ItemFn) -> TokenStream {
+    let sig = &fun.sig;
+    let name = &sig.ident;
+    let inputs = &sig.inputs;
+    let flags = schedule_flag(args.to_owned());
+    let function = fun.to_owned().into_token_stream();
+    let arity = arity(inputs.clone());
+    let decoded_terms = extract_inputs(inputs.clone());
+    let argument_names = create_function_params(inputs.clone());
+    let erl_func_name = extract_attr_value(args.clone(), "name")
+        .map(|ref n| syn::Ident::new(n, Span::call_site()))
+        .unwrap_or_else(|| name.clone());
+
+    quote! {
+        #[allow(non_camel_case_types)]
+        pub struct #name;
+
+        impl rustler::Nif for #name {
+            const NAME: *const u8 = concat!(stringify!(#erl_func_name), "\0").as_ptr() as *const u8;
+            const ARITY: u32 = #arity;
+            const FLAGS: u32 = #flags as u32;
+            const RAW_FUNC: unsafe extern "C" fn(
+                nif_env: rustler::codegen_runtime::NIF_ENV,
+                argc: rustler::codegen_runtime::c_int,
+                argv: *const rustler::codegen_runtime::NIF_TERM
+            ) -> rustler::codegen_runtime::NIF_TERM = {
+                unsafe extern "C" fn nif_func(
+                    nif_env: rustler::codegen_runtime::NIF_ENV,
+                    argc: rustler::codegen_runtime::c_int,
+                    argv: *const rustler::codegen_runtime::NIF_TERM
+                ) -> rustler::codegen_runtime::NIF_TERM {
+                    let lifetime = ();
+                    let env = rustler::Env::new(&lifetime, nif_env);
+
+                    let terms = std::slice::from_raw_parts(argv, argc as usize)
+                        .iter()
+                        .map(|term| rustler::Term::new(env, *term))
+                        .collect::<Vec<rustler::Term>>();
+
+                    fn wrapper<'a>(
+                        env: rustler::Env<'a>,
+                        args: &[rustler::Term<'a>]
+                    ) -> rustler::codegen_runtime::NifReturned {
+                        let result: std::thread::Result<_> = std::panic::catch_unwind(move || {
+                            #decoded_terms
+                            #function
+                            Ok(#name(#argument_names))
+                        });
+
+                        rustler::codegen_runtime::handle_nif_result(result, env)
+                    }
+                    wrapper(env, &terms).apply(env)
+                }
+                nif_func
+            };
+            const FUNC: rustler::codegen_runtime::DEF_NIF_FUNC = rustler::codegen_runtime::DEF_NIF_FUNC {
+                arity: Self::ARITY,
+                flags: Self::FLAGS,
+                function: Self::RAW_FUNC,
+                name: Self::NAME
+            };
+        }
+    }
+}
+
+fn schedule_flag(args: syn::AttributeArgs) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    let valid = ["DirtyCpu", "DirtyIo", "Normal"];
+
+    let flag = match extract_attr_value(args, "schedule") {
+        Some(value) => {
+            if valid.contains(&value.as_str()) {
+                syn::Ident::new(value.as_str(), Span::call_site())
+            } else {
+                panic!("Invalid schedule option `{}`", value);
+            }
+        }
+        None => syn::Ident::new("Normal", Span::call_site()),
+    };
+
+    tokens.extend(quote! { rustler::SchedulerFlags::#flag });
+    tokens
+}
+
+fn extract_attr_value(args: syn::AttributeArgs, name: &str) -> Option<String> {
+    use syn::{Lit, Meta, MetaNameValue, NestedMeta};
+
+    for arg in args.iter() {
+        if let NestedMeta::Meta(Meta::NameValue(MetaNameValue { path, lit, .. })) = arg {
+            if path.is_ident(name) {
+                if let Lit::Str(lit) = lit {
+                    return Some(lit.value());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn extract_inputs(inputs: Punctuated<syn::FnArg, Comma>) -> TokenStream {
+    let mut tokens = TokenStream::new();
+    let mut idx = 0 as usize;
+
+    for item in inputs.iter() {
+        if let syn::FnArg::Typed(ref typed) = item {
+            let name = &typed.pat;
+
+            match &*typed.ty {
+                syn::Type::Reference(typ) => {
+                    let decoder = quote! {
+                        let #name: #typ = match args[#idx].decode() {
+                            Ok(value) => value,
+                            Err(err) => return Err(err)
+                        };
+                    };
+
+                    tokens.extend(decoder);
+                }
+                syn::Type::Path(syn::TypePath { path, .. }) => {
+                    let typ = &typed.ty;
+                    let ident = path.segments.last().unwrap().ident.to_string();
+
+                    match ident.as_ref() {
+                        "Env" => {
+                            continue;
+                        }
+                        "Term" => {
+                            let arg = quote! {
+                                let #name: #typ = args[#idx];
+                            };
+
+                            tokens.extend(arg);
+                        }
+                        _ => {
+                            let decoder = quote! {
+                                let #name: #typ = match args[#idx].decode() {
+                                    Ok(value) => value,
+                                    Err(err) => return Err(err)
+                                };
+                            };
+
+                            tokens.extend(decoder);
+                        }
+                    }
+                }
+                other => {
+                    panic!("unsupported input given: {:?}", other);
+                }
+            }
+        } else {
+            panic!("unsupported input given: {:?}", stringify!(&item));
+        };
+        idx += 1;
+    }
+
+    tokens
+}
+
+fn create_function_params(inputs: Punctuated<syn::FnArg, Comma>) -> TokenStream {
+    let mut tokens = TokenStream::new();
+
+    for item in inputs.iter() {
+        let name = if let syn::FnArg::Typed(ref typed) = item {
+            &typed.pat
+        } else {
+            panic!("unsupported input given: {:?}", stringify!(&item));
+        };
+
+        tokens.extend(quote!(#name,));
+    }
+
+    tokens
+}
+
+fn arity(inputs: Punctuated<syn::FnArg, Comma>) -> u32 {
+    let mut arity: u32 = 0;
+
+    for (i, item) in inputs.iter().enumerate() {
+        if let syn::FnArg::Typed(ref typed) = item {
+            if let syn::Type::Path(syn::TypePath { path, .. }) = &*typed.ty {
+                let ident = path.segments.last().unwrap().ident.to_string();
+
+                if i == 0 && ident == "Env" {
+                    continue;
+                }
+
+                if ident == "Env" {
+                    panic!("Env must be the first argument in NIF functions");
+                }
+            };
+        } else {
+            panic!("unsupported input given: {:?}", stringify!(&item));
+        };
+        arity += 1;
+    }
+
+    arity
+}

--- a/rustler_mix/priv/templates/basic/src/lib.rs
+++ b/rustler_mix/priv/templates/basic/src/lib.rs
@@ -1,25 +1,6 @@
-use rustler::{Encoder, Env, Error, Term};
-
-mod atoms {
-    rustler::atoms! {
-        ok,
-        // error,
-        // __true__ = "true",
-        // __false__ = "false"
-    }
+#[rustler::nif]
+fn add(a: i64, b: i64) -> i64 {
+    a + b
 }
 
-rustler::init! {
-    "<%= native_module %>",
-    [
-        ("add", 2, add)
-    ],
-    None
-}
-
-fn add<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let num1: i64 = args[0].decode()?;
-    let num2: i64 = args[1].decode()?;
-
-    Ok((atoms::ok(), num1 + num2).encode(env))
-}
+rustler::init!("<%= native_module %>", [add]);

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -30,7 +30,7 @@ cd $tmp
 mix new test_rustler_mix
 cd test_rustler_mix
 
-cat >mix.exs <<_
+cat >mix.exs <<EOF
 defmodule TestRustlerMix.MixProject do
   use Mix.Project
 
@@ -48,7 +48,7 @@ defmodule TestRustlerMix.MixProject do
 
   defp deps, do: [ {:rustler, path: "$rustler_mix"} ]
 end
-_
+EOF
 
 mix deps.get
 mix deps.compile
@@ -57,7 +57,7 @@ mix rustler.new --module RustlerMixTest --name rustler_mix_test
 
 sed -i "s|^rustler.*$|rustler = { path = \"$rustler\" }|" native/rustler_mix_test/Cargo.toml
 
-cat >mix.exs <<_
+cat >mix.exs <<EOF
 defmodule TestRustlerMix.MixProject do
   use Mix.Project
 
@@ -79,7 +79,7 @@ defmodule TestRustlerMix.MixProject do
 
   defp rustler_crates, do: [rustler_mix_test: []]
 end
-_
+EOF
 
 mix compile
 
@@ -88,28 +88,28 @@ mix compile
 delete=1
 cat native/rustler_mix_test/README.md | while read line; do
     case "$line" in
-	'```elixir')
-	    delete=0
-	    ;;
-	'```'*)
-	    delete=1
-	    ;;
-	*)
-	    if [ "$delete" -eq 0 ]; then
-		echo "$line"
-	    fi
+      '```elixir')
+        delete=0
+        ;;
+      '```'*)
+        delete=1
+        ;;
+      *)
+        if [ "$delete" -eq 0 ]; then
+          echo "$line"
+        fi
     esac
 done > lib/rustler_mix_test.ex
 
-cat >test/rustler_mix_test_test.exs <<_
+cat >test/rustler_mix_test_test.exs <<EOF
 defmodule RustlerMixTestTest do
   use ExUnit.Case
 
   test "can use generated nif" do
-      assert RustlerMixTest.add(1, 2) == {:ok, 3}
+      assert RustlerMixTest.add(1, 2) == 3
   end
 end
-_
+EOF
 
 mix test
 

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -1,6 +1,3 @@
-use rustler::schedule::SchedulerFlags::*;
-use rustler::{Env, Term};
-
 mod test_atom;
 mod test_binary;
 mod test_codegen;
@@ -17,92 +14,59 @@ mod test_thread;
 rustler::init!(
     "Elixir.RustlerTest",
     [
-        ("add_u32", 2, test_primitives::add_u32),
-        ("add_i32", 2, test_primitives::add_i32),
-        ("echo_u8", 1, test_primitives::echo_u8),
-        ("option_inc", 1, test_primitives::option_inc),
-        ("result_to_int", 1, test_primitives::result_to_int),
-        ("sum_list", 1, test_list::sum_list),
-        ("make_list", 0, test_list::make_list),
-        ("term_debug", 1, test_term::term_debug),
-        ("term_eq", 2, test_term::term_eq),
-        ("term_cmp", 2, test_term::term_cmp),
-        ("sum_map_values", 1, test_map::sum_map_values),
-        ("map_entries_sorted", 1, test_map::map_entries_sorted),
-        ("map_from_arrays", 2, test_map::map_from_arrays),
-        ("resource_make", 0, test_resource::resource_make),
-        (
-            "resource_set_integer_field",
-            2,
-            test_resource::resource_set_integer_field
-        ),
-        (
-            "resource_get_integer_field",
-            1,
-            test_resource::resource_get_integer_field
-        ),
-        (
-            "resource_make_immutable",
-            1,
-            test_resource::resource_make_immutable
-        ),
-        (
-            "resource_immutable_count",
-            0,
-            test_resource::resource_immutable_count
-        ),
-        ("atom_to_string", 1, test_atom::atom_to_string),
-        ("atom_equals_ok", 1, test_atom::atom_equals_ok),
-        ("binary_to_atom", 1, test_atom::binary_to_atom),
-        (
-            "binary_to_existing_atom",
-            1,
-            test_atom::binary_to_existing_atom
-        ),
-        (
-            "make_shorter_subbinary",
-            1,
-            test_binary::make_shorter_subbinary
-        ),
-        ("parse_integer", 1, test_binary::parse_integer),
-        ("binary_new", 0, test_binary::binary_new),
-        ("unowned_to_owned", 1, test_binary::unowned_to_owned),
-        ("realloc_shrink", 0, test_binary::realloc_shrink),
-        ("realloc_grow", 0, test_binary::realloc_grow),
-        ("encode_string", 0, test_binary::encode_string),
-        ("decode_iolist", 1, test_binary::decode_iolist),
-        ("threaded_fac", 1, test_thread::threaded_fac),
-        ("threaded_sleep", 1, test_thread::threaded_sleep),
-        ("send_all", 2, test_env::send_all),
-        ("sublists", 1, test_env::sublists),
-        ("tuple_echo", 1, test_codegen::tuple_echo),
-        ("record_echo", 1, test_codegen::record_echo),
-        ("map_echo", 1, test_codegen::map_echo),
-        ("struct_echo", 1, test_codegen::struct_echo),
-        ("unit_enum_echo", 1, test_codegen::unit_enum_echo),
-        ("untagged_enum_echo", 1, test_codegen::untagged_enum_echo),
-        (
-            "untagged_enum_with_truthy",
-            1,
-            test_codegen::untagged_enum_with_truthy
-        ),
-        ("newtype_echo", 1, test_codegen::newtype_echo),
-        ("tuplestruct_echo", 1, test_codegen::tuplestruct_echo),
-        ("newtype_record_echo", 1, test_codegen::newtype_record_echo),
-        (
-            "tuplestruct_record_echo",
-            1,
-            test_codegen::tuplestruct_record_echo
-        ),
-        ("dirty_cpu", 0, test_dirty::dirty_cpu, DirtyCpu),
-        ("dirty_io", 0, test_dirty::dirty_io, DirtyIo),
-        ("sum_range", 1, test_range::sum_range),
+        test_primitives::add_u32,
+        test_primitives::add_i32,
+        test_primitives::echo_u8,
+        test_primitives::option_inc,
+        test_primitives::result_to_int,
+        test_list::sum_list,
+        test_list::make_list,
+        test_term::term_debug,
+        test_term::term_eq,
+        test_term::term_cmp,
+        test_map::sum_map_values,
+        test_map::map_entries_sorted,
+        test_map::map_from_arrays,
+        test_resource::resource_make,
+        test_resource::resource_set_integer_field,
+        test_resource::resource_get_integer_field,
+        test_resource::resource_make_immutable,
+        test_resource::resource_immutable_count,
+        test_atom::atom_to_string,
+        test_atom::atom_equals_ok,
+        test_atom::binary_to_atom,
+        test_atom::binary_to_existing_atom,
+        test_binary::make_shorter_subbinary,
+        test_binary::parse_integer,
+        test_binary::binary_new,
+        test_binary::unowned_to_owned,
+        test_binary::realloc_shrink,
+        test_binary::realloc_grow,
+        test_binary::encode_string,
+        test_binary::decode_iolist,
+        test_thread::threaded_fac,
+        test_thread::threaded_sleep,
+        test_env::send_all,
+        test_env::sublists,
+        test_codegen::tuple_echo,
+        test_codegen::record_echo,
+        test_codegen::map_echo,
+        test_codegen::struct_echo,
+        test_codegen::unit_enum_echo,
+        test_codegen::untagged_enum_echo,
+        test_codegen::untagged_enum_with_truthy,
+        test_codegen::newtype_echo,
+        test_codegen::tuplestruct_echo,
+        test_codegen::newtype_record_echo,
+        test_codegen::tuplestruct_record_echo,
+        test_dirty::dirty_cpu,
+        test_dirty::dirty_io,
+        test_range::sum_range,
     ],
-    Some(on_load)
+    Some(load)
 );
 
-fn on_load<'a>(env: Env<'a>, _load_info: Term<'a>) -> bool {
+fn load(env: rustler::Env, _: rustler::Term) -> bool {
     test_resource::on_load(env);
-    test_atom::on_load(env);
     true
 }

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -63,7 +63,7 @@ rustler::init!(
         test_dirty::dirty_io,
         test_range::sum_range,
     ],
-    Some(load)
+    load = load
 );
 
 fn load(env: rustler::Env, _: rustler::Term) -> bool {

--- a/rustler_tests/native/rustler_test/src/test_atom.rs
+++ b/rustler_tests/native/rustler_test/src/test_atom.rs
@@ -1,28 +1,27 @@
-use rustler::types::{atom::Atom, binary::Binary};
-use rustler::{Env, NifResult, Term};
+use rustler::{Atom, Binary, Env, NifResult, Term};
 
 mod atoms {
     rustler::atoms! { ok }
 }
 
-pub fn on_load(_env: Env) {}
-
-pub fn atom_to_string<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<String> {
-    args[0].atom_to_string()
+#[rustler::nif]
+pub fn atom_to_string(atom: Term) -> NifResult<String> {
+    atom.atom_to_string()
 }
 
-pub fn atom_equals_ok<'a>(_env: Env<'a>, args: &[Term<'a>]) -> bool {
-    atoms::ok() == args[0]
+#[rustler::nif]
+pub fn atom_equals_ok(atom: Atom) -> bool {
+    atoms::ok() == atom
 }
 
-pub fn binary_to_atom<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Atom> {
-    let binary: Binary = args[0].decode()?;
+#[rustler::nif]
+pub fn binary_to_atom(env: Env, binary: Binary) -> NifResult<Atom> {
     let atom = Atom::from_bytes(env, binary.as_slice())?;
     Ok(atom)
 }
 
-pub fn binary_to_existing_atom<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Option<Atom>> {
-    let binary: Binary = args[0].decode()?;
+#[rustler::nif]
+pub fn binary_to_existing_atom(env: Env, binary: Binary) -> NifResult<Option<Atom>> {
     let atom = Atom::try_from_bytes(env, binary.as_slice())?;
     Ok(atom)
 }

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -3,35 +3,33 @@ use std::io::Write;
 use rustler::types::binary::{Binary, OwnedBinary};
 use rustler::{Env, Error, NifResult, Term};
 
-pub fn make_shorter_subbinary<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<Binary<'a>> {
-    let binary: Binary = args[0].decode()?;
+#[rustler::nif]
+pub fn make_shorter_subbinary(binary: Binary) -> NifResult<Binary> {
     let length: usize = binary.as_slice().len();
-    Ok(binary.make_subbinary(1, length - 2)?)
+    binary.make_subbinary(1, length - 2)
 }
 
-pub fn parse_integer<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<i64> {
-    let str_num: &str = args[0].decode()?;
-    let num: i64 = match ::std::str::FromStr::from_str(str_num) {
-        Ok(num) => num,
-        Err(_) => return Err(Error::BadArg),
-    };
-    Ok(num)
+#[rustler::nif]
+pub fn parse_integer(string: &str) -> NifResult<i64> {
+    std::str::FromStr::from_str(string).map_err(|_| Error::BadArg)
 }
 
-pub fn binary_new<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<'a>> {
+#[rustler::nif]
+pub fn binary_new(env: Env) -> Binary {
     let mut binary = OwnedBinary::new(4).unwrap();
     binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
-    Ok(binary.release(env))
+    binary.release(env)
 }
 
-pub fn unowned_to_owned<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Binary<'a>> {
-    let in_binary: Binary = args[0].decode()?;
-    let mut copied = in_binary.to_owned().unwrap();
+#[rustler::nif]
+pub fn unowned_to_owned<'a>(env: Env<'a>, binary: Binary<'a>) -> NifResult<Binary<'a>> {
+    let mut copied = binary.to_owned().unwrap();
     copied.as_mut_slice()[0] = 1;
     Ok(copied.release(env))
 }
 
-pub fn realloc_shrink<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<'a>> {
+#[rustler::nif]
+pub fn realloc_shrink(env: Env) -> Binary {
     let mut binary = OwnedBinary::new(8).unwrap();
     binary
         .as_mut_slice()
@@ -40,27 +38,24 @@ pub fn realloc_shrink<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<
     if !binary.realloc(4) {
         panic!("Realloc failed");
     }
-    Ok(binary.release(env))
+    binary.release(env)
 }
 
-pub fn realloc_grow<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Binary<'a>> {
+#[rustler::nif]
+pub fn realloc_grow(env: Env) -> Binary {
     let mut binary = OwnedBinary::new(4).unwrap();
     binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
     binary.realloc_or_copy(5);
     binary.as_mut_slice()[4] = 5;
-    Ok(binary.release(env))
+    binary.release(env)
 }
 
-pub fn encode_string<'a>(_env: Env<'a>, _args: &[Term<'a>]) -> NifResult<(String, &'static str)> {
-    Ok(("first".to_string(), "second"))
+#[rustler::nif]
+pub fn encode_string() -> (String, &'static str) {
+    ("first".to_string(), "second")
 }
 
-pub fn decode_iolist<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<Binary<'a>> {
-    let input: Binary = args[0].decode_as_binary()?;
-    Ok(input)
+#[rustler::nif]
+pub fn decode_iolist(binary: Term) -> NifResult<Binary> {
+    binary.decode_as_binary()
 }
-
-// OwnedBinary::new
-// OwnedBinary::from_unowned
-// OwnedBinary::realloc
-// OwnedBinary::realloc_or_copy

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -1,5 +1,5 @@
 use rustler::types::truthy::Truthy;
-use rustler::{Encoder, Env, NifResult, Term};
+use rustler::Encoder;
 use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};
 
 #[derive(NifTuple)]
@@ -8,9 +8,9 @@ pub struct AddTuple {
     rhs: i32,
 }
 
-pub fn tuple_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<AddTuple> {
-    let tuple: AddTuple = args[0].decode()?;
-    Ok(tuple)
+#[rustler::nif]
+pub fn tuple_echo(tuple: AddTuple) -> AddTuple {
+    tuple
 }
 
 #[derive(NifRecord)]
@@ -22,9 +22,9 @@ pub struct AddRecord {
     rhs: i32,
 }
 
-pub fn record_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<AddRecord> {
-    let record: AddRecord = args[0].decode()?;
-    Ok(record)
+#[rustler::nif]
+pub fn record_echo(record: AddRecord) -> AddRecord {
+    record
 }
 
 #[derive(NifMap)]
@@ -33,9 +33,9 @@ pub struct AddMap {
     rhs: i32,
 }
 
-pub fn map_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<AddMap> {
-    let map: AddMap = args[0].decode()?;
-    Ok(map)
+#[rustler::nif]
+pub fn map_echo(map: AddMap) -> AddMap {
+    map
 }
 
 #[derive(Debug, NifStruct)]
@@ -46,9 +46,9 @@ pub struct AddStruct {
     rhs: i32,
 }
 
-pub fn struct_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<AddStruct> {
-    let add_struct: AddStruct = args[0].decode()?;
-    Ok(add_struct)
+#[rustler::nif]
+pub fn struct_echo(add_struct: AddStruct) -> AddStruct {
+    add_struct
 }
 
 #[derive(NifUnitEnum)]
@@ -57,9 +57,9 @@ pub enum UnitEnum {
     Baz,
 }
 
-pub fn unit_enum_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<UnitEnum> {
-    let unit_enum: UnitEnum = args[0].decode()?;
-    Ok(unit_enum)
+#[rustler::nif]
+pub fn unit_enum_echo(unit_enum: UnitEnum) -> UnitEnum {
+    unit_enum
 }
 
 #[derive(NifUntaggedEnum)]
@@ -70,9 +70,9 @@ pub enum UntaggedEnum {
     Bool(bool),
 }
 
-pub fn untagged_enum_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<UntaggedEnum> {
-    let untagged_enum: UntaggedEnum = args[0].decode()?;
-    Ok(untagged_enum)
+#[rustler::nif]
+pub fn untagged_enum_echo(untagged_enum: UntaggedEnum) -> UntaggedEnum {
+    untagged_enum
 }
 
 #[derive(NifUntaggedEnum)]
@@ -81,47 +81,41 @@ pub enum UntaggedEnumWithTruthy {
     Truthy(Truthy),
 }
 
-pub fn untagged_enum_with_truthy<'a>(
-    _env: Env<'a>,
-    args: &[Term<'a>],
-) -> NifResult<UntaggedEnumWithTruthy> {
-    let untagged_enum: UntaggedEnumWithTruthy = args[0].decode()?;
-    Ok(untagged_enum)
+#[rustler::nif]
+pub fn untagged_enum_with_truthy(untagged_enum: UntaggedEnumWithTruthy) -> UntaggedEnumWithTruthy {
+    untagged_enum
 }
 
 #[derive(NifTuple)]
 pub struct Newtype(i64);
 
-pub fn newtype_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<Newtype> {
-    let newtype: Newtype = args[0].decode()?;
-    Ok(newtype)
+#[rustler::nif]
+pub fn newtype_echo(newtype: Newtype) -> Newtype {
+    newtype
 }
 
 #[derive(NifTuple)]
 pub struct TupleStruct(i64, i64, i64);
 
-pub fn tuplestruct_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<TupleStruct> {
-    let tuplestruct: TupleStruct = args[0].decode()?;
-    Ok(tuplestruct)
+#[rustler::nif]
+pub fn tuplestruct_echo(tuplestruct: TupleStruct) -> TupleStruct {
+    tuplestruct
 }
 
 #[derive(NifRecord)]
 #[tag = "newtype"]
 pub struct NewtypeRecord(i64);
 
-pub fn newtype_record_echo<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<NewtypeRecord> {
-    let newtype: NewtypeRecord = args[0].decode()?;
-    Ok(newtype)
+#[rustler::nif]
+pub fn newtype_record_echo(newtype: NewtypeRecord) -> NewtypeRecord {
+    newtype
 }
 
 #[derive(NifRecord)]
 #[tag = "tuplestruct"]
 pub struct TupleStructRecord(i64, i64, i64);
 
-pub fn tuplestruct_record_echo<'a>(
-    _env: Env<'a>,
-    args: &[Term<'a>],
-) -> NifResult<TupleStructRecord> {
-    let tuplestruct: TupleStructRecord = args[0].decode()?;
-    Ok(tuplestruct)
+#[rustler::nif]
+pub fn tuplestruct_record_echo(tuplestruct: TupleStructRecord) -> TupleStructRecord {
+    tuplestruct
 }

--- a/rustler_tests/native/rustler_test/src/test_dirty.rs
+++ b/rustler_tests/native/rustler_test/src/test_dirty.rs
@@ -1,25 +1,24 @@
-use rustler::{Atom, Env, Term};
-
-use std::time;
+use rustler::Atom;
+use std::time::Duration;
 
 mod atoms {
-    rustler::atoms! {
-        ok,
-    }
+    rustler::atoms! { ok }
 }
 
 // TODO: Make these realistic
 
-pub fn dirty_cpu<'a>(_env: Env<'a>, _: &[Term<'a>]) -> Atom {
-    let duration = time::Duration::from_millis(100);
-    ::std::thread::sleep(duration);
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn dirty_cpu() -> Atom {
+    let duration = Duration::from_millis(100);
+    std::thread::sleep(duration);
 
     atoms::ok()
 }
 
-pub fn dirty_io<'a>(_env: Env<'a>, _: &[Term<'a>]) -> Atom {
-    let duration = time::Duration::from_millis(100);
-    ::std::thread::sleep(duration);
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn dirty_io() -> Atom {
+    let duration = Duration::from_millis(100);
+    std::thread::sleep(duration);
 
     atoms::ok()
 }

--- a/rustler_tests/native/rustler_test/src/test_env.rs
+++ b/rustler_tests/native/rustler_test/src/test_env.rs
@@ -2,22 +2,21 @@ use rustler::env::{OwnedEnv, SavedTerm};
 use rustler::types::atom;
 use rustler::types::list::ListIterator;
 use rustler::types::pid::Pid;
-use rustler::{Encoder, Env, NifResult, Term};
+use rustler::{Atom, Encoder, Env, NifResult, Term};
 use std::thread;
 
 // Send a message to several PIDs.
-pub fn send_all<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let pids: Vec<Pid> = args[0].decode()?;
-    let message = args[1];
-
+#[rustler::nif]
+pub fn send_all<'a>(env: Env<'a>, pids: Vec<Pid>, msg: Term<'a>) -> Term<'a> {
     for pid in pids {
-        env.send(&pid, message);
+        env.send(&pid, msg);
     }
 
-    Ok(message)
+    msg
 }
 
-pub fn sublists<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
+#[rustler::nif]
+pub fn sublists<'a>(env: Env<'a>, list: Term<'a>) -> NifResult<Atom> {
     // This is a "threaded NIF": it spawns a thread that sends a message back
     // to the calling thread later.
     let pid = env.pid();
@@ -25,14 +24,14 @@ pub fn sublists<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     // Our worker thread will need an environment.  We can't ship `env` to the
     // other thread, because the Erlang VM is going to tear it down as soon as
     // we return from this NIF. So we use an `OwnedEnv`.
-    let mut my_env = OwnedEnv::new();
+    let mut owned_env = OwnedEnv::new();
 
     // Start by taking the argument (which should be a list), and copying it
-    // into `my_env`, and reversing it. We can use `my_env.save()` to save
+    // into `owned_env`, and reversing it. We can use `owned_env.save()` to save
     // terms in a form that doesn't have a lifetime parameter.
-    let saved_reversed_list = my_env.run(|env| -> NifResult<SavedTerm> {
-        let list_arg = args[0].in_env(env);
-        Ok(my_env.save(list_arg.list_reverse()?))
+    let saved_reversed_list = owned_env.run(|env| -> NifResult<SavedTerm> {
+        let list_arg = list.in_env(env);
+        Ok(owned_env.save(list_arg.list_reverse()?))
     })?;
 
     // Start the worker thread. This `move` closure takes ownership of both
@@ -40,7 +39,7 @@ pub fn sublists<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
     thread::spawn(move || {
         // Use `.send()` to get a `Env` from our `OwnedEnv`,
         // run some rust code, and finally send the result back to `pid`.
-        my_env.send_and_clear(&pid, |env| {
+        owned_env.send_and_clear(&pid, |env| {
             let result: NifResult<Term> = (|| {
                 let reversed_list = saved_reversed_list.load(env);
                 let iter: ListIterator = reversed_list.decode()?;
@@ -65,5 +64,5 @@ pub fn sublists<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
         });
     });
 
-    Ok(atom::ok().to_term(env))
+    Ok(atom::ok())
 }

--- a/rustler_tests/native/rustler_test/src/test_list.rs
+++ b/rustler_tests/native/rustler_test/src/test_list.rs
@@ -1,18 +1,16 @@
-use rustler::types::list::ListIterator;
-use rustler::{Encoder, Env, Error, NifResult, Term};
+use rustler::{Error, ListIterator, NifResult};
 
-pub fn sum_list<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let iter: ListIterator = args[0].decode()?;
-
+#[rustler::nif]
+pub fn sum_list(iter: ListIterator) -> NifResult<i64> {
     let res: Result<Vec<i64>, Error> = iter.map(|x| x.decode::<i64>()).collect();
 
     match res {
-        Ok(result) => Ok(result.iter().sum::<i64>().encode(env)),
+        Ok(result) => Ok(result.iter().sum::<i64>()),
         Err(err) => Err(err),
     }
 }
 
-pub fn make_list<'a>(env: Env<'a>, _args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let list = vec![1, 2, 3];
-    Ok(list.encode(env))
+#[rustler::nif]
+pub fn make_list() -> Vec<usize> {
+    vec![1, 2, 3]
 }

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -2,19 +2,16 @@ use rustler::types::map::MapIterator;
 use rustler::types::tuple::make_tuple;
 use rustler::{Encoder, Env, NifResult, Term};
 
-pub fn sum_map_values<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<i64> {
-    let iter: MapIterator = args[0].decode()?;
-
+#[rustler::nif]
+pub fn sum_map_values(iter: MapIterator) -> NifResult<i64> {
     let res: NifResult<Vec<i64>> = iter.map(|(_key, value)| value.decode::<i64>()).collect();
 
     let nums = res?;
-    let total: i64 = nums.into_iter().sum();
-    Ok(total)
+    Ok(nums.into_iter().sum())
 }
 
-pub fn map_entries_sorted<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let iter: MapIterator = args[0].decode()?;
-
+#[rustler::nif]
+pub fn map_entries_sorted<'a>(env: Env<'a>, iter: MapIterator<'a>) -> NifResult<Vec<Term<'a>>> {
     let mut vec = vec![];
     for (key, value) in iter {
         let key_string = key.decode::<String>()?;
@@ -26,12 +23,14 @@ pub fn map_entries_sorted<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term
         .into_iter()
         .map(|(key, value)| make_tuple(env, &[key.encode(env), value]))
         .collect();
-    Ok(erlang_pairs.encode(env))
+    Ok(erlang_pairs)
 }
 
-pub fn map_from_arrays<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let keys: Vec<Term> = args[0].decode()?;
-    let values: Vec<Term> = args[1].decode()?;
-
+#[rustler::nif]
+pub fn map_from_arrays<'a>(
+    env: Env<'a>,
+    keys: Vec<Term<'a>>,
+    values: Vec<Term<'a>>,
+) -> NifResult<Term<'a>> {
     Term::map_from_arrays(env, &keys, &values)
 }

--- a/rustler_tests/native/rustler_test/src/test_primitives.rs
+++ b/rustler_tests/native/rustler_test/src/test_primitives.rs
@@ -1,35 +1,28 @@
-use rustler::{Encoder, Env, NifResult, Term};
-
-pub fn add_u32<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let lhs: u32 = args[0].decode()?;
-    let rhs: u32 = args[1].decode()?;
-
-    Ok((lhs + rhs).encode(env))
-}
-pub fn add_i32<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let lhs: i32 = args[0].decode()?;
-    let rhs: i32 = args[1].decode()?;
-
-    Ok((lhs + rhs).encode(env))
+#[rustler::nif]
+pub fn add_u32(a: u32, b: u32) -> u32 {
+    a + b
 }
 
-pub fn echo_u8<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let num: u8 = args[0].decode()?;
-    Ok(num.encode(env))
+#[rustler::nif]
+pub fn add_i32(a: i32, b: i32) -> i32 {
+    a + b
 }
 
-pub fn option_inc<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let opt: Option<f64> = args[0].decode()?;
-    let incremented = opt.map(|num| num + 1.0);
-    Ok(incremented.encode(env))
+#[rustler::nif]
+pub fn echo_u8(n: u8) -> u8 {
+    n
 }
 
-pub fn result_to_int<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
-    let result: Result<bool, &'a str> = args[0].decode()?;
-    let int_result = match result {
+#[rustler::nif]
+pub fn option_inc(opt: Option<f64>) -> Option<f64> {
+    opt.map(|num| num + 1.0)
+}
+
+#[rustler::nif]
+pub fn result_to_int(res: Result<bool, &str>) -> Result<usize, String> {
+    match res {
         Ok(true) => Ok(1),
         Ok(false) => Ok(0),
         Err(errstr) => Err(format!("{}{}", errstr, errstr)),
-    };
-    Ok(int_result.encode(env))
+    }
 }

--- a/rustler_tests/native/rustler_test/src/test_range.rs
+++ b/rustler_tests/native/rustler_test/src/test_range.rs
@@ -1,9 +1,6 @@
-use rustler::{Encoder, Env, Error, Term};
 use std::ops::RangeInclusive;
 
-pub fn sum_range<'a>(env: Env<'a>, args: &[Term<'a>]) -> Result<Term<'a>, Error> {
-    let range: RangeInclusive<i64> = args[0].decode()?;
-
-    let total: i64 = range.sum();
-    Ok(total.encode(env))
+#[rustler::nif]
+pub fn sum_range(range: RangeInclusive<i64>) -> i64 {
+    range.sum()
 }

--- a/rustler_tests/native/rustler_test/src/test_term.rs
+++ b/rustler_tests/native/rustler_test/src/test_term.rs
@@ -1,13 +1,6 @@
-use rustler::Atom;
-use rustler::{Env, NifResult, Term};
+use rustler::{Atom, Term};
 use std::cmp::Ordering;
 use std::io::Write;
-
-pub fn term_debug<'a>(_env: Env<'a>, args: &[Term<'a>]) -> NifResult<String> {
-    let mut bytes: Vec<u8> = Vec::new();
-    write!(&mut bytes, "{:?}", args[0]).expect("debug formatting should succeed");
-    Ok(String::from_utf8_lossy(&bytes).to_string())
-}
 
 mod atoms {
     rustler::atoms! {
@@ -17,11 +10,21 @@ mod atoms {
     }
 }
 
-pub fn term_eq<'a>(_env: Env<'a>, args: &[Term<'a>]) -> bool {
-    args[0] == args[1]
+#[rustler::nif]
+pub fn term_debug(term: Term) -> String {
+    let mut bytes: Vec<u8> = Vec::new();
+    write!(&mut bytes, "{:?}", term).expect("debug formatting should succeed");
+    String::from_utf8_lossy(&bytes).to_string()
 }
-pub fn term_cmp<'a>(_env: Env<'a>, args: &[Term<'a>]) -> Atom {
-    match Ord::cmp(&args[0], &args[1]) {
+
+#[rustler::nif]
+pub fn term_eq<'a>(a: Term<'a>, b: Term<'a>) -> bool {
+    a == b
+}
+
+#[rustler::nif]
+pub fn term_cmp<'a>(a: Term<'a>, b: Term<'a>) -> Atom {
+    match Ord::cmp(&a, &b) {
         Ordering::Equal => atoms::equal(),
         Ordering::Less => atoms::less(),
         Ordering::Greater => atoms::greater(),

--- a/rustler_tests/test/atom_test.exs
+++ b/rustler_tests/test/atom_test.exs
@@ -13,7 +13,7 @@ defmodule RustlerTest.AtomTest do
 
   test "binary to existing atom" do
     assert RustlerTest.binary_to_existing_atom("test_atom_nonexisting") == nil
-    RustlerTest.binary_to_atom("test_atom_nonexisting")
+    assert RustlerTest.binary_to_atom("test_atom_nonexisting")
     assert RustlerTest.binary_to_existing_atom("test_atom_nonexisting") != nil
   end
 
@@ -21,9 +21,9 @@ defmodule RustlerTest.AtomTest do
     assert catch_error(RustlerTest.atom_to_string("already a string")) == :badarg
   end
 
-  test "term equals ok" do
+  test "atom equals ok" do
     assert RustlerTest.atom_equals_ok(:ok)
     refute RustlerTest.atom_equals_ok(:fish)
-    refute RustlerTest.atom_equals_ok("ok")
+    assert catch_error(RustlerTest.atom_equals_ok("ok")) == :badarg
   end
 end

--- a/rustler_tests/test/term_test.exs
+++ b/rustler_tests/test/term_test.exs
@@ -12,7 +12,7 @@ defmodule RustlerTest.TermTest do
 
     assert RustlerTest.term_debug(Enum.to_list(0..5)) == "[0,1,2,3,4,5]"
     assert RustlerTest.term_debug(Enum.to_list(0..1000)) == "[#{Enum.join(0..1000, ",")}]"
-    # assert RustlerTest.term_debug([[[[]],[]],[[]],[]]) == "[[[[]],[]],[[]],[]]"
+    assert RustlerTest.term_debug([[[[]], []], [[]], []]) == "[[[[]],[]],[[]],[]]"
 
     sues = Enum.map(1..500, fn i -> %{name: "Aunt Sue", id: i} end)
     sue_strs = Enum.map(1..500, fn i -> "\#{id=>#{i},name=><<\"Aunt Sue\">>}" end)


### PR DESCRIPTION
I've got the new macros all working! :tada:

I'm pretty excited about this, but I'm pretty sure there are some opportunities for some clean up.

~One thing I've noticed is that if you specify any term which is has `decode` called on it, that function needs to return a `Result<T, E>`. It would be nice to avoid this if possible.~

Let me know what you think.