### PR TITLE
Instruct on `:rustler` instead `:rustler_mix`

### DIFF
--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -9,12 +9,12 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
   1. Add rustler_mix to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:rustler_mix, "~> 0.0.1"}]
+          [{:rustler, "~> 0.0.1"}]
         end
 
   2. Ensure rustler_mix is started before your application:
 
         def application do
-          [applications: [:rustler_mix]]
+          [applications: [:rustler]]
         end
 


### PR DESCRIPTION
The instructions in the `rustler_mix` readme talk about `:rustler_mix`, but there’s only `:rustler_mix` on hex: https://hexdocs.pm/rustler