### PR TITLE
Test rustler_mix generated files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
         run: |
           mix deps.get
           mix test
+          ./test.sh
 
       - name: Test rustler_tests
         working-directory: rustler_tests

--- a/rustler_mix/lib/mix/tasks/rustler.new.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.new.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Rustler.New do
   Generates boilerplate for a new Rustler project.
 
   Usage:
-  mix rustler.new [--module <Module>] [--name <Name>]
+  mix rustler.new [--module <Module>] [--name <Name>] [--otp-app <OTP App>]
   """
 
   @basic [
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Rustler.New do
     end
   end
 
-  @switches [:module, :name]
+  @switches [:module, :name, :otp_app]
 
   def run(argv) do
     {opts, _argv, _} = OptionParser.parse(argv, switches: @switches)
@@ -52,16 +52,23 @@ defmodule Mix.Tasks.Rustler.New do
         name -> name
       end
 
+    otp_app =
+      case opts[:otp_app] do
+        nil -> Mix.Project.config() |> Keyword.get(:app)
+        otp_app -> otp_app
+      end
+
     check_module_name_validity!(module)
 
     path = Path.join([File.cwd!(), "native/", name])
-    new(path, module, name, opts)
+    new(otp_app, path, module, name, opts)
   end
 
-  def new(path, module, name, _opts) do
+  def new(otp_app, path, module, name, _opts) do
     module_elixir = "Elixir." <> module
 
     binding = [
+      otp_app: otp_app,
       project_name: module_elixir,
       native_module: module_elixir,
       module: module,

--- a/rustler_mix/lib/mix/tasks/rustler.new.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.new.ex
@@ -26,21 +26,31 @@ defmodule Mix.Tasks.Rustler.New do
     end
   end
 
-  @switches []
+  @switches [:module, :name]
 
   def run(argv) do
     {opts, _argv, _} = OptionParser.parse(argv, switches: @switches)
 
     module =
-      prompt(
-        "This is the name of the Elixir module the NIF module will be registered to.\nModule name"
-      )
+      case opts[:module] do
+        nil ->
+          prompt(
+            "This is the name of the Elixir module the NIF module will be registered to.\n" <>
+              "Module name"
+          )
+        module -> module
+      end
 
     name =
-      prompt_default(
-        "This is the name used for the generated Rust crate. The default is most likely fine.\nLibrary name",
-        format_module_name_as_name(module)
-      )
+      case opts[:name] do
+        nil ->
+          prompt_default(
+            "This is the name used for the generated Rust crate. The default is most likely fine.\n" <>
+              "Library name",
+            format_module_name_as_name(module)
+          )
+        name -> name
+      end
 
     check_module_name_validity!(module)
 

--- a/rustler_mix/lib/mix/tasks/rustler.new.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.new.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Rustler.New do
   Generates boilerplate for a new Rustler project.
 
   Usage:
-  mix rustler.new path
+  mix rustler.new [--module <Module>] [--name <Name>]
   """
 
   @basic [

--- a/rustler_mix/priv/templates/basic/Cargo.toml.eex
+++ b/rustler_mix/priv/templates/basic/Cargo.toml.eex
@@ -11,4 +11,3 @@ crate-type = ["dylib"]
 
 [dependencies]
 rustler = "<%= rustler_version %>"
-lazy_static = "1.0"

--- a/rustler_mix/priv/templates/basic/README.md
+++ b/rustler_mix/priv/templates/basic/README.md
@@ -10,7 +10,7 @@
 
 ```elixir
 defmodule <%= module %> do
-    use Rustler, otp_app: <otp-app>, crate: "<%= library_name %>"
+    use Rustler, otp_app: :<%= otp_app %>, crate: "<%= library_name %>"
 
     # When your NIF is loaded, it will override this function.
     def add(_a, _b), do: :erlang.nif_error(:nif_not_loaded)

--- a/rustler_mix/priv/templates/basic/src/lib.rs
+++ b/rustler_mix/priv/templates/basic/src/lib.rs
@@ -2,10 +2,10 @@ use rustler::{Encoder, Env, Error, Term};
 
 mod atoms {
     rustler::atoms! {
-        atom ok;
-        //atom error;
-        //atom __true__ = "true";
-        //atom __false__ = "false";
+        ok,
+        // error,
+        // __true__ = "true",
+        // __false__ = "false"
     }
 }
 

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+#
+# Test if rustler_mix can be used to create a working example from the template.
+#
+# Note: This creates a temporary directory for the mix project. The directory is only cleaned up
+# if the test works. This is done in order to allow investigating the error.
+#
+
+set -e
+
+rustler_mix=$PWD
+rustler=$(realpath $PWD/../rustler)
+tmp=$(mktemp --directory)
+
+#
+# Test Steps
+#
+# * Create a new Elixir project
+# * Add rustler as a dependency
+# * Initialize a first crate from the template
+# * Use rustler from the repository instead of from crates.io
+# * Check that it compiles
+# * Check that the module template in the generated README works
+# * Check that the NIF can be loaded and used
+#
+
+echo "Creating a new mix project and rustler template in $tmp"
+cd $tmp
+
+mix new test_rustler_mix
+cd test_rustler_mix
+
+cat >mix.exs <<_
+defmodule TestRustlerMix.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_rustler_mix,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application, do: [ ]
+
+  defp deps, do: [ {:rustler, path: "$rustler_mix"} ]
+end
+_
+
+mix deps.get
+mix deps.compile
+
+mix rustler.new --module RustlerMixTest --name rustler_mix_test
+
+sed -i "s|^rustler.*$|rustler = { path = \"$rustler\" }|" native/rustler_mix_test/Cargo.toml
+
+cat >mix.exs <<_
+defmodule TestRustlerMix.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :test_rustler_mix,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      compilers: [:rustler] ++ Mix.compilers(),
+      rustler_crates: rustler_crates()
+    ]
+  end
+
+  def application, do: [ ]
+
+  defp deps, do: [ {:rustler, path: "$rustler_mix"} ]
+
+  defp rustler_crates, do: [rustler_mix_test: []]
+end
+_
+
+mix compile
+
+# Delete everything except the templated module from the generated README
+
+delete=1
+cat native/rustler_mix_test/README.md | while read line; do
+    case "$line" in
+	'```elixir')
+	    delete=0
+	    ;;
+	'```'*)
+	    delete=1
+	    ;;
+	*)
+	    if [ "$delete" -eq 0 ]; then
+		echo "$line"
+	    fi
+    esac
+done > lib/rustler_mix_test.ex
+
+cat >test/rustler_mix_test_test.exs <<_
+defmodule RustlerMixTestTest do
+  use ExUnit.Case
+
+  test "can use generated nif" do
+      assert RustlerMixTest.add(1, 2) == {:ok, 3}
+  end
+end
+_
+
+mix test
+
+echo "Done; cleaning up"
+rm -r $tmp


### PR DESCRIPTION
This pull request adds a shell script to test that the files generated by `rustler_mix` work when used to create a new crate. I fixed some small issues while implementing the script, and extended the mix task to allow specifying the module, name and otp app on the command line.