### PR TITLE
rustler_mix: Fix template test on Elixir < 1.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,27 @@ jobs:
         working-directory: rustler_tests
         run: mix format --check-formatted
 
+  rustler_mix_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install Erlang/Elixir
+        uses: actions/setup-elixir@v1.0.0
+        with:
+          otp-version: 21.x
+          elixir-version: 1.6
+
+      - name: Test rustler_mix
+        working-directory: rustler_mix
+        run: ./test.sh
+
   test:
     name: OTP ${{matrix.pair.erlang}} / Elixir ${{matrix.pair.elixir}} / Rust ${{matrix.rust}}
     runs-on: ubuntu-latest
@@ -108,7 +129,6 @@ jobs:
         run: |
           mix deps.get
           mix test
-          ./test.sh
 
       - name: Test rustler_tests
         working-directory: rustler_tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   clippy:

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -38,7 +38,7 @@ defmodule TestRustlerMix.MixProject do
     [
       app: :test_rustler_mix,
       version: "0.1.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -65,7 +65,7 @@ defmodule TestRustlerMix.MixProject do
     [
       app: :test_rustler_mix,
       version: "0.1.0",
-      elixir: "~> 1.9",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       compilers: [:rustler] ++ Mix.compilers(),


### PR DESCRIPTION
Another fix for #266 (d7552b4). This also adds the event `pull_request` to github actions in order to try to test this PR before it hits master. We can drop this commit when CI succeeded.