### PR TITLE
Refactor compilation

### DIFF
--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -14,7 +14,7 @@ This package is available on [`hex.pm`](https://hex.pm/packages/rustler). To ins
 
 ```elixir
 def deps do
-  [{:rustler, "~> 0.21.0"}]
+  [{:rustler, "~> 0.21.0", runtime: false}]
 end
 ```
 
@@ -54,7 +54,9 @@ loaded.
 
 ```elixir
 defmodule MyProject.MyModule do
-  use Rustler, otp_app: :my_app, crate: :my_crate
+  use Rustler,
+    otp_app: :my_app,
+    crate: :my_crate
 
   # When loading a NIF module, dummy clauses for all NIF function are required.
   # NIF dummies usually just error out when called when the NIF is not loaded, as that should never normally happen.

--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -3,8 +3,7 @@
 This is the Mix package for [rustler](https://github.com/rusterlium/rustler), a library to write Erlang NIFs in
 safe Rust code. Here, we provide the basic functionality to use Rustler from Elixir:
 
-* A task to generate a new crate to write NIFs (`mix help rustler.new`)
-* A task to compile NIFs written in Rust (`mix help compile.rustler`)
+- A task to generate a new crate to write NIFs (`mix help rustler.new`)
 
 See below for information on how to install this, which options are exposed through the configuration, and how to
 load a NIF.
@@ -22,10 +21,8 @@ end
 Then,
 
 1. Run `mix deps.get` to fetch the dependency.
-2. Run `mix rustler.new` and follow the instructions to generate the boilerplate for your NIF.
-3. Enable the `:rustler` mix compiler by adding `compilers: [:rustler] ++ Mix.compilers(),` to the `project` section of your `mix.exs`.
-4. Add a configuration entry to the `rustler_crates` section of your `mix.exs`. [See below](#crate-configuration).
-5. Load the NIF in your program. [See below](#loading-the-nif).
+1. Run `mix rustler.new` and follow the instructions to generate the boilerplate for your NIF.
+1. Load the NIF in your program. [See below](#loading-the-nif).
 
 ## Crate configuration
 
@@ -40,40 +37,12 @@ The NIF configuration may contain the following entries:
   - `{:bin, "path"}` - Use `path` as the cargo command. This is not portable, and you should not normally use this.
 - `default_features` (true default) - Boolean indicating if you want the NIF built with or without default cargo features.
 - `features` ([] default) - List of binaries indicating what cargo features you want enabled when building.
-- `mode` (:release default) - Indicates what cargo build flavor you want.
+- `target` (nil default) - Specify which build target to compile for. See .
+- `mode` - Indicates what cargo build flavor to compile with. The default
+  depends on the `Mix.env()`. When `:prod` the crate will be compiled in
+  `release` mode. Otherwise it will be compiled in `debug` mode.
   - `:release` - Optimized build, normally a LOT faster than debug.
   - `:debug` - Unoptimized debug build with debug assertions and more.
-
-When you are done, the project section might look something like this:
-
-```elixir
-def project do
-  [app: :my_app,
-   version: "0.1.0",
-   compilers: [:rustler] ++ Mix.compilers(),
-   rustler_crates: [my_crate: []],
-   deps: deps()]
-end
-```
-
-### Conditionally setting the mode
-
-The `rustc` mode defaults to `release`, but if you wish to compile your crate
-in `debug` mode for `dev`/`test` but want `release` mode for `prod`:
-
-```elixir
-def project do
-  [app: :my_app,
-   version: "0.1.0",
-   compilers: [:rustler] ++ Mix.compilers(),
-   rustler_crates: [
-     my_crate: [
-       mode: (if Mix.env() == :prod, do: :release, else: :debug)
-     ]
-   ],
-   deps: deps()]
-end
-```
 
 ## Loading the NIF
 

--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -26,23 +26,10 @@ Then,
 
 ## Crate configuration
 
-The `rustler_crates` configuration is a keyword list mapping the crate name (an atom) to the NIF configuration (another keyword list).
-The NIF configuration may contain the following entries:
+The Rust crate compilation can be controlled via Mix compile-time configuration in `config/config.exs`.
+See [configuration options](https://hexdocs.pm/rustler/Rustler.html#module-configuration-options) for more
+details.
 
-- `path` - The path to the crate directory relative to the project root
-  (default: `native/<crate-name>`)
-- `cargo` (:system default) - The rust/cargo version to build the NIF with. May be one of the following:
-  - `:system` - Use the version installed on the system.
-  - `{:rustup, "rust-version"}` - Use `rustup` to compile the NIF with a specific version.
-  - `{:bin, "path"}` - Use `path` as the cargo command. This is not portable, and you should not normally use this.
-- `default_features` (true default) - Boolean indicating if you want the NIF built with or without default cargo features.
-- `features` ([] default) - List of binaries indicating what cargo features you want enabled when building.
-- `target` (nil default) - Specify which build target to compile for. See .
-- `mode` - Indicates what cargo build flavor to compile with. The default
-  depends on the `Mix.env()`. When `:prod` the crate will be compiled in
-  `release` mode. Otherwise it will be compiled in `debug` mode.
-  - `:release` - Optimized build, normally a LOT faster than debug.
-  - `:debug` - Unoptimized debug build with debug assertions and more.
 
 ## Loading the NIF
 

--- a/rustler_mix/lib/mix/tasks/compile.rustler.ex
+++ b/rustler_mix/lib/mix/tasks/compile.rustler.ex
@@ -1,0 +1,19 @@
+defmodule Mix.Tasks.Compile.Rustler do
+  @moduledoc false
+
+  use Mix.Task
+
+  def run(_args) do
+    IO.puts([
+      IO.ANSI.yellow(),
+      """
+
+      The `:rustler` compiler has been deprecated since v0.22.0 and will be
+      removed in v1.0.
+
+      To remove this warning, please consult the CHANGELOG for v0.22.0.
+      """,
+      IO.ANSI.default_color()
+    ])
+  end
+end

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -18,14 +18,51 @@ defmodule Rustler do
 
   Configuration options:
 
+    * `:cargo` - Specify how to envoke the rust compiler. Options are:
+        - `:system` (default) - use `cargo` from the system (must by in `$PATH`)
+        - `{:rustup, <version>}` - use `rustup` to specify which channel to use.
+          Available options include: `:stable`, `:beta`, `:nightly`, or a string
+          which specifies a specific version (i.e. `"1.39.0"`).
+        - `{:bin, "/path/to/binary"}` - provide a specific path to `cargo`.
+
     * `:crate` - the name of the Rust crate (as an atom), if different from your
       `otp_app` value. If you have more than one crate in your project, you will
       need to be explicit about which crate you intend to use.
 
+    * `:default_features` - a boolean to specify whether the crate's default features
+      should be used.
+
+    * `:env` - Specify a list of environment variables when envoking the compiler.
+
+    * `:feature` - a list of features to enable when compiling the crate.
+
     * `:load_data` - Any valid term. This value is passed into the NIF when it is
       loaded (default: `0`)
 
-  Either of the above options can be passed directly into the `use` macro like so:
+    * `:load_from` - This option allows control over where the final artifact should be
+      loaded from at runtime. By default the compiled artifact is loaded from the
+      owning `:otp_app`'s `priv/native` directory. This option comes in handy in
+      combination with the `:skip_compilation?` option in order to load pre-compiled
+      artifacts. To override the default behaviour specify a tuple:
+      `{:my_app, "priv/native/<artifact>"}`. Due to the way `:erlang.load_nif/2`
+      works, the artifact should not include the file extension (i.e. `.so`, `.dll`).
+
+    * `:mode` - Specify which mode to compile the crate with. If you do not specify
+      this option, a default will be provide based on the `Mix.env()`:
+      - When `Mix.env()` is `:dev` or `:test`, the crate will be compiled in `:debug` mode.
+      - When `Mix.env()` is `:prod` or `:bench`, the crate will be compiled in `:release` mode.
+
+    * `:path` - By default, rustler expects the crate to be found in `native/<crate>` in the
+      root of the project. Use this option to override this.
+
+    * `:skip_compilation?` - This option skips envoking the rust compiler. Specify this option
+      in combination with `:load_from` to load a pre-compiled artifact.
+
+    * `:target` - Specify a compile [target] triple.
+
+    * `:target_dir`: Override the compiler output directory.
+
+  Any of the above options can be passed directly into the `use` macro like so:
 
       defmodule MyNIF do
         use Rustler,
@@ -34,6 +71,7 @@ defmodule Rustler do
           load_data: :something
       end
 
+  [target]: https://forge.rust-lang.org/release/platform-support.html
   """
 
   defmacro __using__(opts) do

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -38,16 +38,19 @@ defmodule Rustler do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
+      lib? = Keyword.get(opts, :lib, true)
       config = Rustler.Compiler.compile_crate(__MODULE__, opts)
 
       for resource <- config.external_resources do
         @external_resource resource
       end
 
-      @load_from config.load_from
-      @load_data config.load_data
+      if lib? do
+        @load_from config.load_from
+        @load_data config.load_data
 
-      @before_compile Rustler
+        @before_compile Rustler
+      end
     end
   end
 

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -16,7 +16,7 @@ defmodule Rustler do
         crate: :my_nif,
         load_data: [1, 2, 3]
 
-  Configuration options:
+  ## Configuration options
 
     * `:cargo` - Specify how to envoke the rust compiler. Options are:
         - `:system` (default) - use `cargo` from the system (must by in `$PATH`)
@@ -34,7 +34,7 @@ defmodule Rustler do
 
     * `:env` - Specify a list of environment variables when envoking the compiler.
 
-    * `:feature` - a list of features to enable when compiling the crate.
+    * `:features` - a list of features to enable when compiling the crate.
 
     * `:load_data` - Any valid term. This value is passed into the NIF when it is
       loaded (default: `0`)

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -25,9 +25,9 @@ defmodule Rustler do
           which specifies a specific version (i.e. `"1.39.0"`).
         - `{:bin, "/path/to/binary"}` - provide a specific path to `cargo`.
 
-    * `:crate` - the name of the Rust crate (as an atom), if different from your
-      `otp_app` value. If you have more than one crate in your project, you will
-      need to be explicit about which crate you intend to use.
+    * `:crate` - the name of the Rust crate, if different from your `otp_app`
+      value. If you have more than one crate in your project, you will need to
+      be explicit about which crate you intend to use.
 
     * `:default_features` - a boolean to specify whether the crate's default features
       should be used.
@@ -76,14 +76,13 @@ defmodule Rustler do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      lib? = Keyword.get(opts, :lib, true)
       config = Rustler.Compiler.compile_crate(__MODULE__, opts)
 
       for resource <- config.external_resources do
         @external_resource resource
       end
 
-      if lib? do
+      if config.lib do
         @load_from config.load_from
         @load_data config.load_data
 

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -113,6 +113,7 @@ defmodule Rustler.Compiler do
   defp handle_artifacts(path, config) do
     toml = toml_data(path)
     names = get_name(toml, :lib) ++ get_name(toml, :bin)
+
     Enum.each(names, fn {name, type} ->
       {src_file, dst_file} = make_file_names(name, type)
       compiled_lib = Path.join([config.target_dir, Atom.to_string(config.mode), src_file])
@@ -131,7 +132,7 @@ defmodule Rustler.Compiler do
     case toml[to_string(section)] do
       nil -> []
       values when is_map(values) -> [{values["name"], section}]
-      values when is_list(values) -> Enum.map(values, & {&1["name"], section})
+      values when is_list(values) -> Enum.map(values, &{&1["name"], section})
     end
   end
 

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -37,7 +37,7 @@ defmodule Rustler.Compiler.Config do
     features = Keyword.get(config, :features, [])
     mode = config[:mode] || opts[:mode] || build_mode(Mix.env())
     load_data = config[:load_data] || opts[:load_data] || 0
-    load_from = {(config[:load_from] || otp_app), "priv/native/lib#{crate}"}
+    load_from = {config[:load_from] || otp_app, "priv/native/lib#{crate}"}
     path = config[:path] || "native/#{crate}"
     target = config[:target]
     external_resources = external_resources(path)
@@ -58,7 +58,7 @@ defmodule Rustler.Compiler.Config do
       path: path,
       skip_compilation?: skip_compilation?,
       target: target,
-      target_dir: target_dir 
+      target_dir: target_dir
     }
   end
 

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -1,0 +1,75 @@
+defmodule Rustler.Compiler.Config do
+  @type rust_version :: :stable | :beta | :nightly | binary()
+  @type cargo :: :system | {:rustup, rust_version()} | {:bin, Path.t()}
+  @type crate :: atom()
+  @type default_features :: [binary()]
+  @type env :: [{binary(), binary()}]
+  @type features :: [binary()]
+  @type mode :: :debug | :release
+  @type load_data :: term()
+  @type path :: Path.t()
+
+  defstruct cargo: :system,
+            crate: nil,
+            default_features: true,
+            env: [],
+            external_resources: [],
+            features: [],
+            load_data: 0,
+            load_from: nil,
+            mode: :release,
+            otp_app: nil,
+            path: "",
+            priv_dir: "",
+            skip_compilation?: false,
+            target: nil,
+            target_dir: ""
+
+  alias Rustler.Compiler.Config
+
+  def from(otp_app, module, opts) do
+    config = Application.get_env(otp_app, module, [])
+
+    cargo = Keyword.get(config, :cargo, :system)
+    crate = config[:crate] || opts[:crate] || otp_app
+    default_features = Keyword.get(config, :default_features, true)
+    env = Keyword.get(config, :env, [])
+    features = Keyword.get(config, :features, [])
+    mode = config[:mode] || opts[:mode] || build_mode(Mix.env())
+    load_data = config[:load_data] || opts[:load_data] || 0
+    load_from = {(config[:load_from] || otp_app), "priv/native/lib#{crate}"}
+    path = config[:path] || "native/#{crate}"
+    target = config[:target]
+    external_resources = external_resources(path)
+    target_dir = Keyword.get(config, :target_dir, Application.app_dir(otp_app, "native/#{crate}"))
+    skip_compilation? = Keyword.get(config, :skip_compilation?, false)
+
+    %Config{
+      cargo: cargo,
+      crate: crate,
+      default_features: default_features,
+      env: env,
+      external_resources: external_resources,
+      features: features,
+      load_data: load_data,
+      load_from: load_from,
+      mode: mode,
+      otp_app: otp_app,
+      path: path,
+      skip_compilation?: skip_compilation?,
+      target: target,
+      target_dir: target_dir 
+    }
+  end
+
+  defp external_resources(crate_path) do
+    "#{crate_path}/**/*"
+    |> Path.wildcard()
+    |> Enum.reject(fn path ->
+      String.starts_with?(path, "#{crate_path}/target/")
+    end)
+  end
+
+  defp build_mode(env) when env in [:prod, :bench], do: :release
+  defp build_mode(_), do: :debug
+end

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -1,8 +1,10 @@
 defmodule Rustler.Compiler.Config do
+  @moduledoc false
+
   @type rust_version :: :stable | :beta | :nightly | binary()
   @type cargo :: :system | {:rustup, rust_version()} | {:bin, Path.t()}
   @type crate :: atom()
-  @type default_features :: [binary()]
+  @type default_features :: boolean()
   @type env :: [{binary(), binary()}]
   @type features :: [binary()]
   @type mode :: :debug | :release
@@ -37,7 +39,13 @@ defmodule Rustler.Compiler.Config do
     features = Keyword.get(config, :features, [])
     mode = config[:mode] || opts[:mode] || build_mode(Mix.env())
     load_data = config[:load_data] || opts[:load_data] || 0
-    load_from = {config[:load_from] || otp_app, "priv/native/lib#{crate}"}
+
+    load_from =
+      case config[:load_from] do
+        {_, _} -> config[:load_from]
+        _ -> {otp_app, "priv/native/lib#{crate}"}
+      end
+
     path = config[:path] || "native/#{crate}"
     target = config[:target]
     external_resources = external_resources(path)

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -8,7 +8,7 @@ defmodule Rustler.Mixfile do
       elixir: "~> 1.6",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      name: "Rustler Mix",
+      name: "Rustler",
       source_url: "https://github.com/rustlerium/rustler",
       homepage_url: "https://github.com/rusterlium/rustler",
       deps: deps(),
@@ -32,7 +32,7 @@ defmodule Rustler.Mixfile do
   defp deps do
     [
       {:toml, "~> 0.5.2", runtime: false},
-      {:ex_doc, "~> 0.19", only: :dev}
+      {:ex_doc, "~> 0.21", only: :dev}
     ]
   end
 

--- a/rustler_mix/mix.lock
+++ b/rustler_mix/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.2", "3aa0bd23bc4c61cf2f1e5d752d1bb470560a6f8539974f767a38923bb20e1d7f", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm"},
   "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
 }

--- a/rustler_mix/priv/templates/basic/Cargo.toml.eex
+++ b/rustler_mix/priv/templates/basic/Cargo.toml.eex
@@ -7,7 +7,7 @@ edition = "2018"
 [lib]
 name = "<%= library_name %>"
 path = "src/lib.rs"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "<%= rustler_version %>"

--- a/rustler_mix/priv/templates/basic/README.md
+++ b/rustler_mix/priv/templates/basic/README.md
@@ -2,8 +2,6 @@
 
 ## To build the NIF module:
 
-- Make sure your projects `mix.exs` has the `:rustler` compiler listed in the `project` function: `compilers: [:rustler] ++ Mix.compilers()` If there already is a `:compilers` list, you should append `:rustler` to it.
-- Add your crate to the `rustler_crates` attribute in the `project function. [See here](https://hexdocs.pm/rustler/basics.html#crate-configuration).
 - Your NIF will now build along with your project.
 
 ## To load the NIF:

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -29,6 +29,7 @@ cd $tmp
 
 mix new test_rustler_mix
 cd test_rustler_mix
+mkdir -p priv/native
 
 cat >mix.exs <<EOF
 defmodule TestRustlerMix.MixProject do
@@ -56,30 +57,6 @@ mix deps.compile
 mix rustler.new --module RustlerMixTest --name rustler_mix_test
 
 sed -i "s|^rustler.*$|rustler = { path = \"$rustler\" }|" native/rustler_mix_test/Cargo.toml
-
-cat >mix.exs <<EOF
-defmodule TestRustlerMix.MixProject do
-  use Mix.Project
-
-  def project do
-    [
-      app: :test_rustler_mix,
-      version: "0.1.0",
-      elixir: "~> 1.6",
-      start_permanent: Mix.env() == :prod,
-      deps: deps(),
-      compilers: [:rustler] ++ Mix.compilers(),
-      rustler_crates: rustler_crates()
-    ]
-  end
-
-  def application, do: [ ]
-
-  defp deps, do: [ {:rustler, path: "$rustler_mix"} ]
-
-  defp rustler_crates, do: [rustler_mix_test: []]
-end
-EOF
 
 mix compile
 

--- a/rustler_tests/lib/binary_example.ex
+++ b/rustler_tests/lib/binary_example.ex
@@ -1,0 +1,6 @@
+defmodule BinaryExample do
+  use Rustler,
+    otp_app: :rustler_test,
+    crate: :binary_example,
+    lib: false
+end

--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -17,6 +17,6 @@ defmodule RustlerTest.Mixfile do
   end
 
   defp deps do
-    [{:rustler, path: "../rustler_mix"}]
+    [{:rustler, path: "../rustler_mix", runtime: false}]
   end
 end

--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -8,12 +8,6 @@ defmodule RustlerTest.Mixfile do
       elixir: "~> 1.2",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      compilers: [:rustler] ++ Mix.compilers(),
-      rustler_crates: [
-        binary_example: [mode: :debug],
-        rustler_test: [mode: :debug],
-        deprecated_macros: [mode: :debug]
-      ],
       deps: deps()
     ]
   end

--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -6,6 +6,7 @@ defmodule RustlerTest.Mixfile do
       app: :rustler_test,
       version: "0.0.1",
       elixir: "~> 1.2",
+      compilers: [:rustler] ++ Mix.compilers(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -13,6 +13,10 @@ crate-type = ["cdylib"]
 name = "hello_rust"
 path = "src/main.rs"
 
+[[bin]]
+name = "hello_rust2"
+path = "src/main.rs"
+
 [dependencies]
 lazy_static = "1.4"
 rustler = { path = "../../../rustler" }

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -9,6 +9,10 @@ name = "rustler_test"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
+[[bin]]
+name = "hello_rust"
+path = "src/main.rs"
+
 [dependencies]
 lazy_static = "1.4"
 rustler = { path = "../../../rustler" }

--- a/rustler_tests/native/rustler_test/src/main.rs
+++ b/rustler_tests/native/rustler_test/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello Rust!");
+}

--- a/rustler_tests/test/binary_example_test.exs
+++ b/rustler_tests/test/binary_example_test.exs
@@ -1,0 +1,9 @@
+defmodule BinaryExampleTest do
+  use ExUnit.Case
+
+  test "binary is compiled" do
+    assert File.exists?("priv/native/binary_example")
+    assert File.exists?("priv/native/hello_rust")
+    assert File.exists?("priv/native/hello_rust2")
+  end
+end

--- a/rustler_tests/test/binary_example_test.exs
+++ b/rustler_tests/test/binary_example_test.exs
@@ -2,8 +2,22 @@ defmodule BinaryExampleTest do
   use ExUnit.Case
 
   test "binary is compiled" do
-    assert File.exists?("priv/native/binary_example")
-    assert File.exists?("priv/native/hello_rust")
-    assert File.exists?("priv/native/hello_rust2")
+    bins = ~w(binary_example hello_rust hello_rust2)
+
+    for bin <- bins do
+      assert_exists(bin)
+    end
+  end
+
+  defp assert_exists(name) do
+    assert_exists(name, :os.type())
+  end
+
+  defp assert_exists(name, {:win32, _} = type) do
+    assert File.exists?("priv/native/#{name}.exe")
+  end
+
+  defp assert_exists(name, type) do
+    assert File.exists?("priv/native/#{name}")
   end
 end


### PR DESCRIPTION
Currently the mix compiler adds additional work for users in order to get started. The changes proposed in this PR aims to make this go away completely and allow users to turn off compilation completely in favor of loading a pre-compiled binary.

**Pros**

* Users no longer need to add the `rustler` compiler in `mix.exs`
* Users no longer need to add the `rustler_crates` option in `mix.exs`
* Crates are automatically compiled when the associated NIF module is compiled.
* Recompilation only happens when one of Rust files or the NIF module are updated (see [`@external_resource`](https://hexdocs.pm/elixir/Module.html#module-external_resource)).

**Cons**

~* Currently, when changes are made to the rust files in the project, `mix compile` does not recompile unless the NIF module has been saved.~
* This change breaks existing binary compilation (but I think this can be fixed pretty easily).

There might be more cons than I can think of right now...

**TODO**

- [x] Revamp the docs
- [x] Support compiling rust binaries
- [x] Support loading pre-compiled libs/binaries