### PR TITLE
Test renaming a NIF

### DIFF
--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -77,4 +77,6 @@ defmodule RustlerTest do
   def raise_term_with_string_error(), do: err()
   def raise_term_with_atom_error(), do: err()
   def term_with_tuple_error(), do: err()
+
+  def nif_attrs_can_rename(), do: err()
 end

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -11,6 +11,7 @@ mod test_range;
 mod test_resource;
 mod test_term;
 mod test_thread;
+mod test_nif_attrs;
 
 rustler::init!(
     "Elixir.RustlerTest",
@@ -69,6 +70,7 @@ rustler::init!(
         test_error::raise_term_with_string_error,
         test_error::raise_term_with_atom_error,
         test_error::term_with_tuple_error,
+        test_nif_attrs::can_rename,
     ],
     load = load
 );

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -6,12 +6,12 @@ mod test_env;
 mod test_error;
 mod test_list;
 mod test_map;
+mod test_nif_attrs;
 mod test_primitives;
 mod test_range;
 mod test_resource;
 mod test_term;
 mod test_thread;
-mod test_nif_attrs;
 
 rustler::init!(
     "Elixir.RustlerTest",

--- a/rustler_tests/native/rustler_test/src/test_nif_attrs.rs
+++ b/rustler_tests/native/rustler_test/src/test_nif_attrs.rs
@@ -1,0 +1,4 @@
+#[rustler::nif(name="nif_attrs_can_rename")]
+pub fn can_rename() -> bool {
+    true
+}

--- a/rustler_tests/native/rustler_test/src/test_nif_attrs.rs
+++ b/rustler_tests/native/rustler_test/src/test_nif_attrs.rs
@@ -1,4 +1,4 @@
-#[rustler::nif(name="nif_attrs_can_rename")]
+#[rustler::nif(name = "nif_attrs_can_rename")]
 pub fn can_rename() -> bool {
     true
 }

--- a/rustler_tests/test/nif_attrs_test.exs
+++ b/rustler_tests/test/nif_attrs_test.exs
@@ -1,0 +1,7 @@
+defmodule NifAttrsTest do
+  use ExUnit.Case
+
+  test "can rename a NIF with an attribute" do
+    assert RustlerTest.nif_attrs_can_rename()
+  end
+end


### PR DESCRIPTION
Test that a NIF can be renamed using the `name` attribute.