### PR TITLE
Tag releases and make release script more resilient

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -40,6 +40,7 @@ echo "Bumping versions.."
 
 # Update versions in manifests
 sed -i "s/^version = \"[^\"]*\" # rustler version$/version = \"$VERSION\" # rustler version/" rustler/Cargo.toml
+sed -i "s/^rustler_codegen.*$/rustler_codegen = { path = \"..\/rustler_codegen\", version = \"$VERSION\", optional = true}/" rustler/Cargo.toml
 sed -i "s/^version = \"[^\"]*\" # rustler_codegen version$/version = \"$VERSION\" # rustler_codegen version/" rustler_codegen/Cargo.toml
 sed -i "s/def rustler_version, do: \"[^\"]*\"$/def rustler_version, do: \"$VERSION\"/" rustler_mix/mix.exs rustler_mix/lib/rustler.ex
 sed -i "s/{:rustler, \".*\"}/{:rustler, \"~> $VERSION\"}/" rustler_mix/README.md

--- a/release.sh
+++ b/release.sh
@@ -9,6 +9,8 @@ if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     exit -1
 fi
 
+TAG="rustler-$VERSION"
+
 # Check version unpublished
 #CRATES_RET=`curl "https://crates.io/api/v1/crates/rustler/$VERSION/dependencies"`
 #if ! [[ $CRATES_RET =~ "does not have a version" ]]; then
@@ -37,6 +39,7 @@ git status
 echo
 echo "This script will run:"
 echo "                $ git commit -m \"(release) $VERSION\""
+echo "		      $ git tag \"$TAG\""
 echo "rustler_mix     $ mix hex.publish"
 echo "rustler         $ cargo publish"
 echo "rustler_codegen $ cargo publish"
@@ -47,8 +50,9 @@ read -p "Everything OK? [yN] " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
 
-    # Commit
+    # Commit and tag
     git commit -m "(release) $VERSION"
+    git tag "$TAG"
 
     # Update and publish
     pushd rustler_mix
@@ -62,5 +66,6 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     popd
 
     git push
+    git push origin "$TAG"
 
 fi

--- a/release.sh
+++ b/release.sh
@@ -7,7 +7,7 @@
 # ## Environment Variables
 #
 # * DRYRUN: Check release, but do not publish
-# * DONTREVERT: Do not revert on error
+# * DONTREVERT: Do not revert on error or DRYRUN
 #
 set -e
 

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -16,7 +16,7 @@ defmodule Rustler.Mixfile do
         main: "readme",
         extras: ["README.md", "../CHANGELOG.md"],
         source_url_pattern:
-          "https://github.com/rusterlium/rustler/blob/master/rustler_mix/%{path}#L%{line}"
+          "https://github.com/rusterlium/rustler/blob/rustler-#{rustler_version()}/rustler_mix/%{path}#L%{line}"
       ],
       package: package(),
       description: description()


### PR DESCRIPTION
This changes the `release.sh` script to create releases.

* The release commit is tagged
* The `rustler_mix` documentation points to that tag
* If an error occurs during verification by compile, the commit is reverted. This is not done when publishing is already underway!

The PR adds two environment variables for the script to simplify testing:

* `DRYRUN`: Do not publish
* `DONTREVERT`: Do not revert the changes if an error happened or if `DRYRUN` was used