### PR TITLE
Do not include toml in runtime

### DIFF
--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -31,7 +31,7 @@ defmodule Rustler.Mixfile do
 
   defp deps do
     [
-      {:toml, "~> 0.5.2"},
+      {:toml, "~> 0.5.2", runtime: false},
       {:ex_doc, "~> 0.19", only: :dev}
     ]
   end


### PR DESCRIPTION
Toml is only used when compiling.

Fix #287.