### PR TITLE
Make OwnedBinary NifReturnable

### DIFF
--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -37,6 +37,7 @@ defmodule RustlerTest do
   def make_shorter_subbinary(_), do: err()
   def parse_integer(_), do: err()
   def binary_new(), do: err()
+  def owned_binary_new(), do: err()
   def unowned_to_owned(_), do: err()
   def realloc_shrink(), do: err()
   def realloc_grow(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -41,6 +41,7 @@ rustler::init!(
         test_binary::make_shorter_subbinary,
         test_binary::parse_integer,
         test_binary::binary_new,
+        test_binary::owned_binary_new,
         test_binary::unowned_to_owned,
         test_binary::realloc_shrink,
         test_binary::realloc_grow,

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -22,6 +22,13 @@ pub fn binary_new(env: Env) -> Binary {
 }
 
 #[rustler::nif]
+pub fn owned_binary_new() -> OwnedBinary {
+    let mut binary = OwnedBinary::new(4).unwrap();
+    binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
+    binary
+}
+
+#[rustler::nif]
 pub fn unowned_to_owned<'a>(env: Env<'a>, binary: Binary<'a>) -> NifResult<Binary<'a>> {
     let mut copied = binary.to_owned().unwrap();
     copied.as_mut_slice()[0] = 1;

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -13,8 +13,12 @@ defmodule RustlerTest.BinaryTest do
     assert_raise ArgumentError, fn -> RustlerTest.parse_integer("999999999999999999999") end
   end
 
-  test "OwnedNifBinary creation" do
+  test "binary creation" do
     assert RustlerTest.binary_new() == <<1, 2, 3, 4>>
+  end
+
+  test "owned binary creation" do
+    assert RustlerTest.owned_binary_new() == <<1, 2, 3, 4>>
   end
 
   test "unowned binary to owned" do


### PR DESCRIPTION
This implements #286 by allowing a way to return `OwnedBinary` without explicitly converting it into a `Binary`. I also changed the generic signature of `NifReturnable for Result<T, crate::error::Error>` so it works with all `NifReturnable` types.