### PR TITLE
Fix Segfault in OwnedEnv::send_and_clear

### DIFF
--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -178,11 +178,11 @@ impl OwnedEnv {
 
         let message = self.run(|env| closure(env).as_c_arg());
 
-        let c_env = *self.env;
-        self.env = Arc::new(c_env); // invalidate SavedTerms
         unsafe {
-            rustler_sys::enif_send(ptr::null_mut(), recipient.as_c_arg(), c_env, message);
+            rustler_sys::enif_send(ptr::null_mut(), recipient.as_c_arg(), *self.env, message);
         }
+
+        self.clear();
     }
 
     /// Free all terms in this environment and clear it for reuse.


### PR DESCRIPTION
This change fixes a segfault we found today. This was the diff that @evnu posted which does indeed fix the segfault.

I built `OTP-22.2` with `valgrind` and ran it before and after, which can be seen [here].

[here]: https://gist.github.com/scrogson/d4e11b23b946ef9fa2c7e09a4b38709d