### PR TITLE
Drop dependency on 'which' crate

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -19,7 +19,6 @@ rustler_sys = { path = "../rustler_sys", version = "~2.0" }
 
 [build-dependencies]
 lazy_static = "1.4"
-which = "3"
 
 [package.metadata.release]
 

--- a/rustler/build.rs
+++ b/rustler/build.rs
@@ -5,9 +5,6 @@ use std::process::Command;
 extern crate lazy_static;
 use lazy_static::lazy_static;
 
-extern crate which;
-use which::which;
-
 lazy_static! {
     // keep this sorted by version number
     static ref NIF_VERSION: Vec<&'static str> = vec![
@@ -24,14 +21,13 @@ fn main() {
 }
 
 fn get_version_from_erl() -> Option<String> {
-    let erl = which("erl").ok()?;
     let args = vec![
         "-noshell",
         "-eval",
         r#"io:format("~s~n", [erlang:system_info(nif_version)]), init:stop()."#,
     ];
 
-    let version = Command::new(erl).args(&args).output().ok()?.stdout;
+    let version = Command::new("erl").args(&args).output().ok()?.stdout;
 
     let version = String::from_utf8(version).ok()?;
 


### PR DESCRIPTION
std::process::Command determines the path to an executable using the os-specific PATH variable. As we are only interested in calling the `erl` executable when building, but not where the executable is placed within the file system, we can attempt to call it directly. The dependency was introduced with #178.