### PR TITLE
Revert "Remove superfluous use statements from proc-macros (#240)"

### DIFF
--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -80,6 +80,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         impl<'a> ::rustler::Decoder<'a> for #struct_type {
             fn decode(term: ::rustler::Term<'a>) -> Result<Self, ::rustler::Error> {
                 use #atoms_module_name::*;
+                use ::rustler::Encoder;
 
                 let env = term.get_env();
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -158,6 +158,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
 
+                use ::rustler::Encoder;
                 let arr = #field_list_ast;
                 ::rustler::types::tuple::make_tuple(env, &arr)
             }

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -123,6 +123,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
     let gen = quote! {
         impl<'b> ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
+                use ::rustler::Encoder;
                 let arr = #field_list_ast;
                 ::rustler::types::tuple::make_tuple(env, &arr)
             }


### PR DESCRIPTION
This reverts commit afda9b886c694366af8460dc5e9940808a7f6670. The `use` statements are needed when a user did not already `use rustler::Encoder`. A  user would have to manually add the `use` statement, which is cumbersome.