### PR TITLE
Speed up generated decoder compilation times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ rustler::atoms! {
 }
 ```
 
+### Fixed
+
+* Compilation time of generated decoders has been reduced significantly.
+
+
 ## [0.21.0] - 2019-09-07
 
 ### Added

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -122,15 +122,20 @@ impl<'a> Context<'a> {
 
     pub fn escape_ident_with_index(ident_str: &str, index: usize, infix: &str) -> Ident {
         Ident::new(
-            &format!("RUSTLER_{}_field_{}_{}", infix, index, Self::remove_raw(ident_str)),
-            Span::call_site()
+            &format!(
+                "RUSTLER_{}_field_{}_{}",
+                infix,
+                index,
+                Self::remove_raw(ident_str)
+            ),
+            Span::call_site(),
         )
     }
 
     pub fn escape_ident(ident_str: &str, infix: &str) -> Ident {
         Ident::new(
             &format!("RUSTLER_{}_field_{}", infix, Self::remove_raw(ident_str)),
-            Span::call_site()
+            Span::call_site(),
         )
     }
 

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -120,6 +120,20 @@ impl<'a> Context<'a> {
         Ident::new(&format!("atom_{}", ident_str), Span::call_site())
     }
 
+    pub fn escape_ident_with_index(ident_str: &str, index: usize, infix: &str) -> Ident {
+        Ident::new(
+            &format!("RUSTLER_{}_field_{}_{}", infix, index, Self::remove_raw(ident_str)),
+            Span::call_site()
+        )
+    }
+
+    pub fn escape_ident(ident_str: &str, infix: &str) -> Ident {
+        Ident::new(
+            &format!("RUSTLER_{}_field_{}", infix, Self::remove_raw(ident_str)),
+            Span::call_site()
+        )
+    }
+
     fn remove_raw(ident_str: &str) -> &str {
         ident_str
             .split("r#")

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -67,13 +67,8 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .zip(idents.iter())
         .enumerate()
         .map(|(index, (field, ident))| {
-            let ident_str = ident.to_string();
             let atom_fun = Context::field_to_atom_fun(field);
-
-            let variable = Ident::new(
-                &format!("RUSTLER_struct_field_{}_{}", index, ident_str),
-                Span::call_site(),
-            );
+            let variable = Context::escape_ident_with_index(&ident.to_string(), index, "struct");
 
             let assignment = quote! {
                 let #variable = try_decode_field(env, term, #atom_fun())?;

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -56,18 +56,28 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .map(|field| field.ident.as_ref().unwrap())
         .collect();
 
-    let field_defs: Vec<TokenStream> = idents
+    let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = idents
         .iter()
-        .map(|ident| {
+        .enumerate()
+        .map(|(index, ident)| {
             let ident_str = ident.to_string();
-
             let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
-            quote! {
-                let #ident = try_decode_field(env, term, #atom_fun())?;
 
-            }
+            let variable = Ident::new(
+                &format!("RUSTLER_map_field_{}_{}", index, ident_str),
+                Span::call_site(),
+            );
+
+            let assignment = quote! {
+            let #variable = try_decode_field(env, term, #atom_fun())?;
+            };
+
+            let field_def = quote! {
+                #ident: #variable
+            };
+            (assignment, field_def)
         })
-        .collect();
+        .unzip();
 
     let gen = quote! {
         impl<'a> ::rustler::Decoder<'a> for #struct_type {
@@ -94,9 +104,9 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                         }
                     };
 
-                #(#field_defs);*
+                #(#assignments);*
 
-                Ok(#struct_name { #(#idents),* })
+                Ok(#struct_name { #(#field_defs),* })
             }
         }
     };

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -61,13 +61,8 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .zip(idents.iter())
         .enumerate()
         .map(|(index, (field, ident))| {
-            let ident_str = ident.to_string();
             let atom_fun = Context::field_to_atom_fun(field);
-
-            let variable = Ident::new(
-                &format!("RUSTLER_map_field_{}_{}", index, ident_str),
-                Span::call_site(),
-            );
+            let variable = Context::escape_ident_with_index(&ident.to_string(), index, "map");
 
             let assignment = quote! {
             let #variable = try_decode_field(env, term, #atom_fun())?;

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -64,10 +64,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             };
             let actual_index = index + 1;
 
-            let variable = Ident::new(
-                &format!("RUSTLER_RECORD_field_{}", pos_in_struct),
-                Span::call_site(),
-            );
+            let variable = Context::escape_ident(&pos_in_struct, "record");
 
             let assignment = quote! {
                 let #variable = try_decode_index(&terms, #pos_in_struct, #actual_index)?;

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -52,7 +52,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
     let struct_name = ctx.ident;
 
     // Make a decoder for each of the fields in the struct.
-    let field_defs: Vec<TokenStream> = fields
+    let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
@@ -62,25 +62,27 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             } else {
                 index.to_string()
             };
-            let error_message = format!(
-                "Could not decode field {} on Record {}",
-                pos_in_struct,
-                struct_name.to_string()
-            );
             let actual_index = index + 1;
-            let decoder = quote! {
-                match ::rustler::Decoder::decode(terms[#actual_index]) {
-                    Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
-                    Ok(value) => value
+
+            let variable = Ident::new(
+                &format!("RUSTLER_RECORD_field_{}", pos_in_struct),
+                Span::call_site(),
+            );
+
+            let assignment = quote! {
+                let #variable = try_decode_index(&terms, #pos_in_struct, #actual_index)?;
+            };
+
+            let field_def = match ident {
+                None => quote! { #variable },
+                Some(ident) => {
+                    quote! { #ident: #variable }
                 }
             };
 
-            match ident {
-                None => quote! { #decoder },
-                Some(ident) => quote! { #ident: #decoder },
-            }
+            (assignment, field_def)
         })
-        .collect();
+        .unzip();
 
     let field_num = field_defs.len();
     let struct_name_str = struct_name.to_string();
@@ -88,11 +90,13 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
     // The implementation itself
     let construct = if ctx.is_tuple_struct {
         quote! {
-            #struct_name ( #(#field_defs),* )
+            #(#assignments);*
+            Ok(#struct_name ( #(#field_defs),* ))
         }
     } else {
         quote! {
-            #struct_name { #(#field_defs),* }
+            #(#assignments);*
+            Ok(#struct_name { #(#field_defs),* })
         }
     };
     let gen = quote! {
@@ -116,9 +120,18 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                     return Err(::rustler::Error::Atom("invalid_record"));
                 }
 
-                Ok(
-                    #construct
-                )
+                fn try_decode_index<'a, T>(terms: &[::rustler::Term<'a>], pos_in_struct: &str, index: usize) -> Result<T, rustler::Error>
+                    where
+                        T: rustler::Decoder<'a>,
+                {
+                    match ::rustler::Decoder::decode(terms[index]) {
+                        Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(
+                                    format!("Could not decode field {} on Record {}", pos_in_struct, #struct_name_str)))),
+                        Ok(value) => Ok(value)
+                    }
+                }
+
+                #construct
             }
         }
     };

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,6 +1,6 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Field, Index};
+use syn::{self, Field, Ident, Index};
 
 use super::context::Context;
 
@@ -35,9 +35,10 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
     let struct_type = &ctx.ident_with_lifetime;
     let struct_name = ctx.ident;
+    let struct_name_str = struct_name.to_string();
 
     // Make a decoder for each of the fields in the struct.
-    let field_defs: Vec<TokenStream> = fields
+    let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
@@ -47,36 +48,39 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
             } else {
                 index.to_string()
             };
-            let error_message = format!(
-                "Could not decode field {} on {}",
-                pos_in_struct,
-                struct_name.to_string()
+
+            let variable = Ident::new(
+                &format!("RUSTLER_TUPLE_field_{}", pos_in_struct),
+                Span::call_site(),
             );
 
-            let decoder = quote! {
-                match ::rustler::Decoder::decode(terms[#index]) {
-                    Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
-                    Ok(value) => value
+            let assignment = quote! {
+                let #variable = try_decode_index(&terms, #pos_in_struct, #index)?;
+            };
+
+            let field_def = match ident {
+                None => quote! { #variable },
+                Some(ident) => {
+                    quote! { #ident: #variable }
                 }
             };
 
-            match ident {
-                None => quote! { #decoder },
-                Some(ident) => quote! { #ident: #decoder },
-            }
+            (assignment, field_def)
         })
-        .collect();
+        .unzip();
 
     let field_num = field_defs.len();
 
     // The implementation itself
     let construct = if ctx.is_tuple_struct {
         quote! {
-            #struct_name ( #(#field_defs),* )
+            #(#assignments);*
+            Ok(#struct_name ( #(#field_defs),* ))
         }
     } else {
         quote! {
-            #struct_name { #(#field_defs),* }
+            #(#assignments);*
+            Ok(#struct_name { #(#field_defs),* })
         }
     };
     let gen = quote! {
@@ -86,9 +90,18 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
                 if terms.len() != #field_num {
                     return Err(::rustler::Error::BadArg);
                 }
-                Ok(
-                    #construct
-                )
+
+                fn try_decode_index<'a, T>(terms: &[::rustler::Term<'a>], pos_in_struct: &str, index: usize) -> Result<T, rustler::Error>
+                    where
+                        T: rustler::Decoder<'a>,
+                {
+                    match ::rustler::Decoder::decode(terms[index]) {
+                        Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(
+                                    format!("Could not decode field {} on {}", pos_in_struct, #struct_name_str)))),
+                        Ok(value) => Ok(value)
+                    }
+                }
+                #construct
             }
         }
     };

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,6 +1,6 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::TokenStream;
 
-use syn::{self, Field, Ident, Index};
+use syn::{self, Field, Index};
 
 use super::context::Context;
 
@@ -49,10 +49,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
                 index.to_string()
             };
 
-            let variable = Ident::new(
-                &format!("RUSTLER_TUPLE_field_{}", pos_in_struct),
-                Span::call_site(),
-            );
+            let variable = Context::escape_ident(&pos_in_struct, "struct");
 
             let assignment = quote! {
                 let #variable = try_decode_index(&terms, #pos_in_struct, #index)?;

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -1,5 +1,4 @@
 use rustler::types::truthy::Truthy;
-use rustler::Encoder;
 use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};
 
 #[derive(NifTuple)]
@@ -121,7 +120,7 @@ pub fn tuplestruct_record_echo(tuplestruct: TupleStructRecord) -> TupleStructRec
 }
 
 pub mod reserved_keywords {
-    use rustler::{Encoder, NifMap, NifRecord, NifStruct, NifTuple, NifUntaggedEnum};
+    use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUntaggedEnum};
 
     #[derive(NifMap, Debug)]
     pub struct Map {


### PR DESCRIPTION
This pull request speeds up compilation by extracting common code from field assignments into helper functions, and by preferring local variables for initial assignment instead of assigning struct fields directly. See #299 for the corresponding issue.

Fix #299.