### PR TITLE
Allow using reserved keywords as field names in codegen

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -98,10 +98,11 @@ impl<'a> Context<'a> {
             struct_fields
                 .iter()
                 .map(|field| {
+                    let atom_fun = Self::field_to_atom_fun(field);
+
                     let ident = field.ident.as_ref().unwrap();
                     let ident_str = ident.to_string();
-
-                    let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
+                    let ident_str = Self::remove_raw(&ident_str);
 
                     quote! {
                         #atom_fun = #ident_str,
@@ -109,6 +110,21 @@ impl<'a> Context<'a> {
                 })
                 .collect()
         })
+    }
+
+    pub fn field_to_atom_fun(field: &Field) -> Ident {
+        let ident = field.ident.as_ref().unwrap();
+        let ident_str = ident.to_string();
+        let ident_str = Self::remove_raw(&ident_str);
+
+        Ident::new(&format!("atom_{}", ident_str), Span::call_site())
+    }
+
+    fn remove_raw(ident_str: &str) -> &str {
+        ident_str
+            .split("r#")
+            .last()
+            .expect("split has always at least one element")
     }
 
     fn encode_decode_attr_set(attrs: &[RustlerAttr]) -> bool {

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -60,8 +60,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .iter()
         .map(|field| {
             let ident = field.ident.as_ref().unwrap();
-            let ident_str = ident.to_string();
-            let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
+            let atom_fun = Context::field_to_atom_fun(field);
             let error_message = format!(
                 "Could not decode field :{} on %{}{{}}",
                 ident.to_string(),
@@ -104,8 +103,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .iter()
         .map(|field| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_ident_str = field_ident.to_string();
-            let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
+            let atom_fun = Context::field_to_atom_fun(field);
             quote! {
                 map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
             }

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -55,16 +55,14 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .iter()
         .map(|field| {
             let ident = field.ident.as_ref().unwrap();
-            let ident_str = ident.to_string();
 
-            let atom_fun = Ident::new(&format!("atom_{}", ident_str), Span::call_site());
+            let atom_fun = Context::field_to_atom_fun(field);
             let error_message = format!("Could not decode field :{} on %{{}}", ident.to_string());
             quote! {
                 #ident: match ::rustler::Decoder::decode(term.map_get(#atom_fun().encode(env))?) {
                     Err(_) => return Err(::rustler::Error::RaiseTerm(Box::new(#error_message))),
-                    Ok(value) => value
+                    Ok(value) => value,
                 }
-
             }
         })
         .collect();
@@ -90,9 +88,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .iter()
         .map(|field| {
             let field_ident = field.ident.as_ref().unwrap();
-            let field_ident_str = field_ident.to_string();
-
-            let atom_fun = Ident::new(&format!("atom_{}", field_ident_str), Span::call_site());
+            let atom_fun = Context::field_to_atom_fun(field);
 
             quote! {
                 map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -66,6 +66,7 @@ defmodule RustlerTest do
   def tuplestruct_echo(_), do: err()
   def newtype_record_echo(_), do: err()
   def tuplestruct_record_echo(_), do: err()
+  def reserved_keywords_type_echo(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -72,6 +72,7 @@ rustler::init!(
         test_error::raise_term_with_atom_error,
         test_error::term_with_tuple_error,
         test_nif_attrs::can_rename,
+        test_codegen::reserved_keywords::reserved_keywords_type_echo
     ],
     load = load
 );

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -119,3 +119,42 @@ pub struct TupleStructRecord(i64, i64, i64);
 pub fn tuplestruct_record_echo(tuplestruct: TupleStructRecord) -> TupleStructRecord {
     tuplestruct
 }
+
+pub mod reserved_keywords {
+    use rustler::{Encoder, NifMap, NifRecord, NifStruct, NifTuple, NifUntaggedEnum};
+
+    #[derive(NifMap, Debug)]
+    pub struct Map {
+        r#override: i32,
+    }
+
+    #[derive(NifStruct, Debug)]
+    #[module = "Struct"]
+    pub struct Struct {
+        r#override: i32,
+    }
+
+    #[derive(NifTuple, Debug)]
+    pub struct Tuple {
+        r#override: i32,
+    }
+
+    #[derive(NifRecord, Debug)]
+    #[tag = "record"]
+    pub struct Record {
+        r#override: i32,
+    }
+
+    #[derive(NifUntaggedEnum)]
+    pub enum ReservedKeywords {
+        Struct(Struct),
+        Map(Map),
+        Tuple(Tuple),
+        Record(Record)
+    }
+
+    #[rustler::nif]
+    pub fn reserved_keywords_type_echo(reserved: ReservedKeywords) -> ReservedKeywords {
+        reserved
+    }
+}

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -150,7 +150,7 @@ pub mod reserved_keywords {
         Struct(Struct),
         Map(Map),
         Tuple(Tuple),
-        Record(Record)
+        Record(Record),
     }
 
     #[rustler::nif]

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -181,8 +181,10 @@ defmodule RustlerTest.CodegenTest do
 
   test "reserved keywords" do
     assert %{override: 1} == RustlerTest.reserved_keywords_type_echo(%{override: 1})
+
     assert %{__struct__: Struct, override: 1} ==
-      RustlerTest.reserved_keywords_type_echo(%{__struct__: Struct, override: 1})
+             RustlerTest.reserved_keywords_type_echo(%{__struct__: Struct, override: 1})
+
     assert {1} == RustlerTest.reserved_keywords_type_echo({1})
     assert {:record, 1} == RustlerTest.reserved_keywords_type_echo({:record, 1})
   end

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -178,4 +178,12 @@ defmodule RustlerTest.CodegenTest do
                    RustlerTest.tuplestruct_record_echo("error")
                  end
   end
+
+  test "reserved keywords" do
+    assert %{override: 1} == RustlerTest.reserved_keywords_type_echo(%{override: 1})
+    assert %{__struct__: Struct, override: 1} ==
+      RustlerTest.reserved_keywords_type_echo(%{__struct__: Struct, override: 1})
+    assert {1} == RustlerTest.reserved_keywords_type_echo({1})
+    assert {:record, 1} == RustlerTest.reserved_keywords_type_echo({:record, 1})
+  end
 end


### PR DESCRIPTION
This pull request enables using reserved keywords as fields in structs when using the `r#` syntax.

Fix #297 