### PR TITLE
Remove lazy_static build dependency

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -17,9 +17,6 @@ lazy_static = "1.4"
 rustler_codegen = { path = "../rustler_codegen", version = "0.21.0", optional = true }
 rustler_sys = { path = "../rustler_sys", version = "~2.0" }
 
-[build-dependencies]
-lazy_static = "1.4"
-
 [package.metadata.release]
 
 [[package.metadata.release.pre-release-replacements]]

--- a/rustler/build.rs
+++ b/rustler/build.rs
@@ -2,15 +2,10 @@
 use std::env;
 use std::process::Command;
 
-extern crate lazy_static;
-use lazy_static::lazy_static;
-
-lazy_static! {
-    // keep this sorted by version number
-    static ref NIF_VERSION: Vec<&'static str> = vec![
-        "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15"
-    ];
-}
+// keep this sorted by version number
+const NIF_VERSION: &[&str] = &[
+    "2.7", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14", "2.15",
+];
 
 fn main() {
     let latest_version = NIF_VERSION.last().unwrap().to_string();


### PR DESCRIPTION
This PR removes the build dependency on `lazy_static` from `rustler`.