### PR TITLE
Run github actions on windows-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,40 @@ jobs:
         working-directory: rustler_mix
         run: ./test.sh
 
+  test_windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install Erlang/Elixir
+        run: choco install elixir
+
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Extend PATH
+        run: echo "::add-path::C:\\ProgramData\\chocolatey\\lib\\Elixir\\bin"
+
+      - name: Hex
+        run: mix local.hex --force
+
+      - name: Test rustler_mix
+        working-directory: rustler_mix
+        run: |
+          mix deps.get
+          mix test
+
+      - name: Test rustler_tests
+        working-directory: rustler_tests
+        run: |
+          mix deps.get
+          mix test
+
   test:
     name: OTP ${{matrix.pair.erlang}} / Elixir ${{matrix.pair.elixir}} / Rust ${{matrix.rust}}
     runs-on: ubuntu-latest

--- a/rustler/src/dynamic.rs
+++ b/rustler/src/dynamic.rs
@@ -53,7 +53,7 @@ macro_rules! impl_check {
         pub fn $check_fun(self) -> bool {
             unsafe { check::$check_fun(self.get_env().as_c_arg(), self.as_c_arg()) }
         }
-    }
+    };
 }
 
 /// ## Type checks


### PR DESCRIPTION
This PR extends the CI pipeline to run the tests on windows as well. I added a specific test for windows, as installing different versions of Elixir and Erlang is cumbersome using chocolatey.