### PR TITLE
Add Elixir v1.10 to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,6 +116,8 @@ jobs:
       matrix:
         pair:
           - erlang: 22.x
+            elixir: "1.10"
+          - erlang: 22.x
             elixir: 1.9
           - erlang: 22.x
             elixir: 1.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       matrix:
         pair:
           - erlang: 22.x
-            elixir: "1.10"
+            elixir: "1.10.1"
           - erlang: 22.x
             elixir: 1.9
           - erlang: 22.x

--- a/rustler_tests/test/env_test.exs
+++ b/rustler_tests/test/env_test.exs
@@ -25,7 +25,7 @@ defmodule RustlerTest.EnvTest do
         receive do
           # Collect the pids that the child processes send back.
           {child_pid, {:hello, :world}} -> child_pid
-          _ -> raise :fail
+          _ -> raise "fail"
         end
       end
 

--- a/rustler_tests/test/thread_test.exs
+++ b/rustler_tests/test/thread_test.exs
@@ -13,7 +13,7 @@ defmodule RustlerTest.ThreadTest do
     RustlerTest.threaded_sleep(200)
 
     receive do
-      _ -> raise :timeout_expected
+      _ -> raise "timeout_expected"
     after
       100 ->
         nil
@@ -23,7 +23,7 @@ defmodule RustlerTest.ThreadTest do
       x -> assert x == 200
     after
       1000 ->
-        raise :message_expected
+        raise "message_expected"
     end
   end
 


### PR DESCRIPTION
This adds Elixir v1.10 to the CI pipeline. It seems that the setup-elixir action does not yet support this version. See [here](https://github.com/actions/setup-elixir/issues/16).