### PR TITLE
Add support for enif_whereis_pid

### DIFF
--- a/rustler/src/types/local_pid.rs
+++ b/rustler/src/types/local_pid.rs
@@ -1,5 +1,5 @@
 use crate::wrapper::{pid, ErlNifPid};
-use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
+use crate::{Decoder, Encoder, Env, Error, NifResult, Term, Atom};
 use std::mem::MaybeUninit;
 
 #[derive(Clone)]
@@ -10,6 +10,13 @@ pub struct LocalPid {
 impl LocalPid {
     pub fn as_c_arg(&self) -> &ErlNifPid {
         &self.c
+    }
+
+    ///
+    /// Look up a local process by its registered name.
+    ///
+    pub fn whereis<'a>(env: Env<'a>, name: Atom) -> Option<Self> {
+        unsafe { pid::whereis(env.as_c_arg(), name.as_c_arg()).map(|pid| LocalPid { c: pid }) }
     }
 }
 

--- a/rustler/src/wrapper.rs
+++ b/rustler/src/wrapper.rs
@@ -21,8 +21,9 @@ pub mod tuple;
 pub use rustler_sys::{
     enif_clear_env, enif_free_env, enif_get_local_pid, enif_make_pid, enif_map_iterator_create,
     enif_map_iterator_destroy, enif_map_iterator_get_pair, enif_map_iterator_next, enif_self,
-    ErlNifMapIterator, ErlNifMapIteratorEntry, ErlNifPid, ERL_NIF_THR_DIRTY_CPU_SCHEDULER,
-    ERL_NIF_THR_DIRTY_IO_SCHEDULER, ERL_NIF_THR_NORMAL_SCHEDULER, ERL_NIF_THR_UNDEFINED,
+    enif_whereis_pid, ErlNifMapIterator, ErlNifMapIteratorEntry, ErlNifPid,
+    ERL_NIF_THR_DIRTY_CPU_SCHEDULER, ERL_NIF_THR_DIRTY_IO_SCHEDULER, ERL_NIF_THR_NORMAL_SCHEDULER,
+    ERL_NIF_THR_UNDEFINED,
 };
 
 pub use std::os::raw::{c_double, c_int, c_uchar, c_uint, c_void};

--- a/rustler/src/wrapper/pid.rs
+++ b/rustler/src/wrapper/pid.rs
@@ -17,6 +17,14 @@ pub unsafe fn make_pid(env: NIF_ENV, pid: ErlNifPid) -> NIF_TERM {
     rustler_sys::enif_make_pid(env, pid)
 }
 
+///
+/// Look up a local process by its registered name.
+///
+/// # Safety
+///
+/// `env` must only be null if the calling process is a created process. Otherwise,
+/// it must not be null.
+///
 pub unsafe fn whereis(env: NIF_ENV, name: NIF_TERM) -> Option<ErlNifPid> {
     let mut pid = MaybeUninit::uninit();
     if rustler_sys::enif_whereis_pid(env, name, pid.as_mut_ptr()) == 0 {

--- a/rustler/src/wrapper/pid.rs
+++ b/rustler/src/wrapper/pid.rs
@@ -16,3 +16,12 @@ pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
 pub unsafe fn make_pid(env: NIF_ENV, pid: ErlNifPid) -> NIF_TERM {
     rustler_sys::enif_make_pid(env, pid)
 }
+
+pub unsafe fn whereis(env: NIF_ENV, name: NIF_TERM) -> Option<ErlNifPid> {
+    let mut pid = MaybeUninit::uninit();
+    if rustler_sys::enif_whereis_pid(env, name, pid.as_mut_ptr()) == 0 {
+        return None;
+    }
+
+    Some(pid.assume_init())
+}

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -81,4 +81,6 @@ defmodule RustlerTest do
   def term_with_tuple_error(), do: err()
 
   def nif_attrs_can_rename(), do: err()
+
+  def whereis(_), do: err()
 end

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -5,6 +5,7 @@ mod test_dirty;
 mod test_env;
 mod test_error;
 mod test_list;
+mod test_local_pid;
 mod test_map;
 mod test_nif_attrs;
 mod test_primitives;
@@ -72,7 +73,8 @@ rustler::init!(
         test_error::raise_term_with_atom_error,
         test_error::term_with_tuple_error,
         test_nif_attrs::can_rename,
-        test_codegen::reserved_keywords::reserved_keywords_type_echo
+        test_codegen::reserved_keywords::reserved_keywords_type_echo,
+        test_local_pid::whereis,
     ],
     load = load
 );


### PR DESCRIPTION
This pull request adds support for `enif_whereis_pid`, introduced with OTP 20. Currently, the implementation always requires a valid `Env`. The safety section of the unsafe wrapper indicates that `enif_whereis_pid` can also be called with `env == null`, iff the caller is a created process. With the current implementation, this cannot be triggered, as an `Env` must always be passed into the safe wrapper.