### PR TITLE
Readd Copy and Clone on Binary

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -123,7 +123,7 @@ impl Drop for OwnedBinary {
 unsafe impl Send for OwnedBinary {}
 
 // Borrowed
-
+#[derive(Copy, Clone)]
 pub struct Binary<'a> {
     inner: ErlNifBinary,
     term: Term<'a>,


### PR DESCRIPTION
Got removed in PR #239, reported in #315.

I'll port this back to 0.21 if it gets merged.

I'm not sure why I removed those `derive`s, maybe it was a merge error.