### PR TITLE
Make the generated nif_init private

### DIFF
--- a/rustler/src/export.rs
+++ b/rustler/src/export.rs
@@ -112,14 +112,14 @@ macro_rules! rustler_export_nifs {
         #[cfg(not(feature = "alternative_nif_init_name"))]
         #[cfg(unix)]
         #[no_mangle]
-        pub extern "C" fn nif_init() -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
+        extern "C" fn nif_init() -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
             $inner
         }
 
         #[cfg(not(feature = "alternative_nif_init_name"))]
         #[cfg(windows)]
         #[no_mangle]
-        pub extern "C" fn nif_init(callbacks: *mut $crate::codegen_runtime::TWinDynNifCallbacks) -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
+        extern "C" fn nif_init(callbacks: *mut $crate::codegen_runtime::TWinDynNifCallbacks) -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
             unsafe {
                 $crate::codegen_runtime::WIN_DYN_NIF_CALLBACKS = Some(*callbacks);
             }
@@ -130,14 +130,14 @@ macro_rules! rustler_export_nifs {
         #[cfg(feature = "alternative_nif_init_name")]
         #[cfg(unix)]
         #[no_mangle]
-        pub extern "C" fn rustler_nif_init() -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
+        extern "C" fn rustler_nif_init() -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
             $inner
         }
 
         #[cfg(feature = "alternative_nif_init_name")]
         #[cfg(windows)]
         #[no_mangle]
-        pub extern "C" fn rustler_nif_init(callbacks: *mut $crate::codegen_runtime::TWinDynNifCallbacks) -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
+        extern "C" fn rustler_nif_init(callbacks: *mut $crate::codegen_runtime::TWinDynNifCallbacks) -> *const $crate::codegen_runtime::DEF_NIF_ENTRY {
             unsafe {
                 $crate::codegen_runtime::WIN_DYN_NIF_CALLBACKS = Some(*callbacks);
             }

--- a/rustler_codegen/src/init.rs
+++ b/rustler_codegen/src/init.rs
@@ -99,13 +99,13 @@ impl Into<proc_macro2::TokenStream> for InitMacroInput {
         quote! {
             #[cfg(unix)]
             #[no_mangle]
-            pub extern "C" fn nif_init() -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
+            extern "C" fn nif_init() -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
                 #inner
             }
 
             #[cfg(windows)]
             #[no_mangle]
-            pub extern "C" fn nif_init(callbacks: *mut rustler::codegen_runtime::TWinDynNifCallbacks) -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
+            extern "C" fn nif_init(callbacks: *mut rustler::codegen_runtime::TWinDynNifCallbacks) -> *const rustler::codegen_runtime::DEF_NIF_ENTRY {
                 unsafe {
                     rustler::codegen_runtime::WIN_DYN_NIF_CALLBACKS = Some(*callbacks);
                 }


### PR DESCRIPTION
This function is not supposed to get called by anyone but the BEAM, so we can make it private. This also fixes #319 since we don't dereference a pointer in a public "safe" function anymore.