### PR TITLE
Fix clippy lint

### DIFF
--- a/rustler/src/types/mod.rs
+++ b/rustler/src/types/mod.rs
@@ -135,7 +135,7 @@ where
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let size = term.map_size()?;
 
-        let it = MapIterator::new(term).ok_or_else(|| Error::BadArg)?;
+        let it = MapIterator::new(term).ok_or(Error::BadArg)?;
 
         let mut map = std::collections::HashMap::with_capacity(size);
 


### PR DESCRIPTION
```
    --> rustler/src/types/mod.rs:138:18
    |
138 |         let it = MapIterator::new(term).ok_or_else(|| Error::BadArg)?;
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: Use `ok_or` instead: `MapIterator::new(term).ok_or(Error::BadArg)`
    |
    = note: `-D clippy::unnecessary-lazy-evaluations` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
```