### PR TITLE
Improve error messages on failure to derive

### DIFF
--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Field, Ident};
+use syn::{self, spanned::Spanned, Field, Ident};
 
 use super::context::Context;
 use super::RustlerAttr;
@@ -70,7 +70,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             let atom_fun = Context::field_to_atom_fun(field);
             let variable = Context::escape_ident_with_index(&ident.to_string(), index, "struct");
 
-            let assignment = quote! {
+            let assignment = quote_spanned! { field.span() =>
                 let #variable = try_decode_field(env, term, #atom_fun())?;
             };
 
@@ -131,7 +131,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .map(|field| {
             let field_ident = field.ident.as_ref().unwrap();
             let atom_fun = Context::field_to_atom_fun(field);
-            quote! {
+            quote_spanned! { field.span() =>
                 map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
             }
         })

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Field, Ident};
+use syn::{self, spanned::Spanned, Field, Ident};
 
 use super::context::Context;
 
@@ -64,7 +64,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             let atom_fun = Context::field_to_atom_fun(field);
             let variable = Context::escape_ident_with_index(&ident.to_string(), index, "map");
 
-            let assignment = quote! {
+            let assignment = quote_spanned! { field.span() =>
             let #variable = try_decode_field(env, term, #atom_fun())?;
             };
 
@@ -119,7 +119,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             let field_ident = field.ident.as_ref().unwrap();
             let atom_fun = Context::field_to_atom_fun(field);
 
-            quote! {
+            quote_spanned! { field.span() =>
                 map = map.map_put(#atom_fun().encode(env), self.#field_ident.encode(env)).unwrap();
             }
         })

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 
-use syn::{self, Field, Ident, Index};
+use syn::{self, spanned::Spanned, Field, Ident, Index};
 
 use super::context::Context;
 use super::RustlerAttr;
@@ -66,7 +66,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 
             let variable = Context::escape_ident(&pos_in_struct, "record");
 
-            let assignment = quote! {
+            let assignment = quote_spanned! { field.span() =>
                 let #variable = try_decode_index(&terms, #pos_in_struct, #actual_index)?;
             };
 
@@ -150,7 +150,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote! { #field_source.encode(env) }
+            quote_spanned! { field.span() => #field_source.encode(env) }
         })
         .collect();
 

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Field, Index};
+use syn::{self, spanned::Spanned, Field, Index};
 
 use super::context::Context;
 
@@ -51,7 +51,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
 
             let variable = Context::escape_ident(&pos_in_struct, "struct");
 
-            let assignment = quote! {
+            let assignment = quote_spanned! { field.span() =>
                 let #variable = try_decode_index(&terms, #pos_in_struct, #index)?;
             };
 
@@ -120,7 +120,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote! { #field_source.encode(env) }
+            quote_spanned! { field.span() => #field_source.encode(env) }
         })
         .collect();
 

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Span, TokenStream};
 
 use heck::SnakeCase;
-use syn::{self, Fields, Ident, Variant};
+use syn::{self, spanned::Spanned, Fields, Ident, Variant};
 
 use super::context::Context;
 
@@ -16,7 +16,9 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     for variant in variants {
         if let Fields::Unit = variant.fields {
         } else {
-            panic!("NifUnitEnum can only be used with enums that contain all unit variants.");
+            return quote_spanned! { variant.span() =>
+                compile_error!("NifUnitEnum can only be used with enums containing unit variants.");
+            };
         }
     }
 

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use syn::{self, Fields, Variant};
+use syn::{self, spanned::Spanned, Fields, Variant};
 
 use super::context::Context;
 
@@ -15,12 +15,14 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     for variant in variants {
         if let Fields::Unnamed(_) = variant.fields {
             if variant.fields.iter().count() != 1 {
-                panic!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
+                return quote_spanned! { variant.span() =>
+                    compile_error!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
+                };
             }
         } else {
-            panic!(
-                "NifUntaggedEnum can only be used with enums that contain all NewType variants."
-            );
+            return quote_spanned! { variant.span() =>
+                compile_error!("NifUntaggedEnum can only be used with enums that contain all NewType variants.");
+            };
         }
     }
 


### PR DESCRIPTION
This PR uses spans to add source-of-error messages when a rustler derive macro fails.

### Example invalid input

```rust
use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUnitEnum, NifUntaggedEnum};

/// This struct does not implement Encoder/Decoder
pub struct C(i32);

#[derive(NifStruct)]
#[module = "AddStruct"]
struct AddStruct {
    lhs: i32,
    rhs: C,
}

#[derive(NifMap)]
struct AddMap {
    lhs: i32,
    rhs: C,
}

#[derive(NifRecord)]
#[tag = "record"]
struct AddRecord {
    lhs: i32,
    rhs: C,
}

#[derive(NifTuple)]
struct AddTuple {
    lhs: i32,
    rhs: C,
}

#[derive(NifUnitEnum)]
enum UnitEnum {
    FooBar,
    Baz(u8),
}

#[derive(NifUntaggedEnum)]
enum UntaggedEnum {
    Foo(u32),
    Bar(String),
    Baz(i32,i32),
}
```


### Improved messages

```
error: NifUnitEnum can only be used with enums containing unit variants.
  --> src/nifmap.rs:34:5
   |
34 |     Baz(u8),
   |     ^^^

error: NifUntaggedEnum can only be used with enums that contain all NewType variants.
  --> src/nifmap.rs:41:5
   |
41 |     Baz(i32,i32),
   |     ^^^

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
 --> src/nifmap.rs:9:5
  |
5 | #[derive(NifStruct)]
  |          --------- required by this bound in `<nifmap::AddStruct as rustler::Decoder<'a>>::decode::try_decode_field`
...
9 |     rhs: C,
  |     ^^^ the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
 --> src/nifmap.rs:9:5
  |
3 | pub struct C(i32);
  | ------------------ method `encode` not found for this
...
9 |     rhs: C,
  |     ^^^ method not found in `nifmap::C`
  |
  = help: items from traits can only be used if the trait is implemented and in scope
  = note: the following trait defines an item `encode`, perhaps you need to implement it:
          candidate #1: `rustler::Encoder`

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:15:5
   |
12 | #[derive(NifMap)]
   |          ------ required by this bound in `<nifmap::AddMap as rustler::Decoder<'a>>::decode::try_decode_field`
...
15 |     rhs: C,
   |     ^^^ the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:15:5
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
15 |     rhs: C,
   |     ^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:22:5
   |
18 | #[derive(NifRecord)]
   |          --------- required by this bound in `<nifmap::AddRecord as rustler::Decoder<'a>>::decode::try_decode_index`
...
22 |     rhs: C,
   |     ^^^ the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:22:5
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
22 |     rhs: C,
   |     ^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:28:5
   |
25 | #[derive(NifTuple)]
   |          -------- required by this bound in `<nifmap::AddTuple as rustler::Decoder<'a>>::decode::try_decode_index`
...
28 |     rhs: C,
   |     ^^^ the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:28:5
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
28 |     rhs: C,
   |     ^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`

error: aborting due to 10 previous errors

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `nifmap`.
```

### Current error messages

```
error: proc-macro derive panicked
  --> src/nifmap.rs:31:10
   |
31 | #[derive(NifUnitEnum)]
   |          ^^^^^^^^^^^
   |
   = help: message: NifUnitEnum can only be used with enums that contain all unit variants.

error: proc-macro derive panicked
  --> src/nifmap.rs:37:10
   |
37 | #[derive(NifUntaggedEnum)]
   |          ^^^^^^^^^^^^^^^
   |
   = help: message: NifUntaggedEnum can only be used with enums that contain all NewType variants.

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
 --> src/nifmap.rs:5:10
  |
5 | #[derive(NifStruct)]
  |          ^^^^^^^^^
  |          |
  |          the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`
  |          required by this bound in `<nifmap::AddStruct as rustler::Decoder<'a>>::decode::try_decode_field`
  |
  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
 --> src/nifmap.rs:5:10
  |
3 | pub struct C(i32);
  | ------------------ method `encode` not found for this
4 |
5 | #[derive(NifStruct)]
  |          ^^^^^^^^^ method not found in `nifmap::C`
  |
  = help: items from traits can only be used if the trait is implemented and in scope
  = note: the following trait defines an item `encode`, perhaps you need to implement it:
          candidate #1: `rustler::Encoder`
  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:12:10
   |
12 | #[derive(NifMap)]
   |          ^^^^^^
   |          |
   |          the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`
   |          required by this bound in `<nifmap::AddMap as rustler::Decoder<'a>>::decode::try_decode_field`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:12:10
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
12 | #[derive(NifMap)]
   |          ^^^^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:18:10
   |
18 | #[derive(NifRecord)]
   |          ^^^^^^^^^
   |          |
   |          the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`
   |          required by this bound in `<nifmap::AddRecord as rustler::Decoder<'a>>::decode::try_decode_index`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:18:10
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
18 | #[derive(NifRecord)]
   |          ^^^^^^^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `nifmap::C: rustler::Decoder<'_>` is not satisfied
  --> src/nifmap.rs:25:10
   |
25 | #[derive(NifTuple)]
   |          ^^^^^^^^
   |          |
   |          the trait `rustler::Decoder<'_>` is not implemented for `nifmap::C`
   |          required by this bound in `<nifmap::AddTuple as rustler::Decoder<'a>>::decode::try_decode_index`
   |
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `encode` found for struct `nifmap::C` in the current scope
  --> src/nifmap.rs:25:10
   |
3  | pub struct C(i32);
   | ------------------ method `encode` not found for this
...
25 | #[derive(NifTuple)]
   |          ^^^^^^^^ method not found in `nifmap::C`
   |
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following trait defines an item `encode`, perhaps you need to implement it:
           candidate #1: `rustler::Encoder`
   = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to 10 previous errors

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `nifmap`.

To learn more, run the command again with --verbose
```
