### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,7 +138,7 @@ jobs:
     strategy:
       matrix:
         pair:
-          - erlang: "23.1.1"
+          - erlang: "23.1"
             elixir: "1.11.1"
           - erlang: "23.0.3"
             elixir: "1.10.3"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,8 @@ jobs:
     strategy:
       matrix:
         pair:
+          - erlang: "23.1.1"
+            elixir: "1.11.1"
           - erlang: "23.0.3"
             elixir: "1.10.3"
 

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -26,7 +26,7 @@ defmodule Rustler.Mixfile do
   def rustler_version, do: "0.22.0-rc.0"
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger, :eex]]
   end
 
   defp deps do


### PR DESCRIPTION
## Motivation

In elixir 1.11 I'm getting the following compile warnings during rustler compilation.

```
==> rustler
Compiling 5 files (.ex)
warning: EEx.eval_string/3 defined in application :eex is used by the current application but the current application does not directly depend on :eex. To fix this, you must
do one of:

  1. If :eex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :eex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :eex, you may optionally skip this warning by adding [xref: [exclude: EEx]] to your "def project" in mix.exs

  lib/mix/tasks/rustler.new.ex:79: Mix.Tasks.Rustler.New.copy_from/3

warning: Toml.decode!/1 defined in application :toml is used by the current application but the current application does not directly depend on :toml. To fix this, you must d
o one of:

  1. If :toml is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :toml is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :toml, you may optionally skip this warning by adding [xref: [exclude: Toml]] to your "def project" in mix.exs

  lib/mix/tasks/compile.rustler.ex:177: Mix.Tasks.Compile.Rustler.check_crate_env/1
```

## Proposed Solution

- Add `logger` and `eex`  to the `extra_applications` option
- ~~Add elixir 1.11 to CI~~ (the new version is not available at https://www.erlang-solutions.com/resources/download.html)