### PR TITLE
Fix 'multiple build target' warning

### DIFF
--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -9,14 +9,6 @@ name = "rustler_test"
 path = "src/lib.rs"
 crate-type = ["cdylib"]
 
-[[bin]]
-name = "hello_rust"
-path = "src/main.rs"
-
-[[bin]]
-name = "hello_rust2"
-path = "src/main.rs"
-
 [dependencies]
 lazy_static = "1.4"
 rustler = { path = "../../../rustler" }

--- a/rustler_tests/native/rustler_test/src/main.rs
+++ b/rustler_tests/native/rustler_test/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello Rust!");
-}


### PR DESCRIPTION
This fixes the following warning:

```
warning: <path>/rustler_tests/native/rustler_test/Cargo.toml: file found to be present in multiple build targets: <path>/rustler_tests/native/rustler_test/src/main.rs
```

As far as I understand, `main.rs` in `rustler_test` does not serve a purpose any longer. @scrogson Feel free to close if the file is actually needed.