### PR TITLE
Fix clippy lints

### DIFF
--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -229,7 +229,7 @@ impl OwnedEnv {
     ///
     /// **Note: There is no way to save terms across `OwnedEnv::send()` or `clear()`.**
     /// If you try, the `.load()` call will panic.
-    pub fn save<'a>(&self, term: Term<'a>) -> SavedTerm {
+    pub fn save(&self, term: Term) -> SavedTerm {
         SavedTerm {
             term: self.run(|env| term.in_env(env).as_c_arg()),
             env_generation: Arc::downgrade(&self.env),

--- a/rustler/src/resource.rs
+++ b/rustler/src/resource.rs
@@ -72,8 +72,8 @@ extern "C" fn resource_destructor<T>(_env: NIF_ENV, handle: MUTABLE_NIF_RESOURCE
 ///
 /// Panics if `name` isn't null-terminated.
 #[doc(hidden)]
-pub fn open_struct_resource_type<'a, T: ResourceTypeProvider>(
-    env: Env<'a>,
+pub fn open_struct_resource_type<T: ResourceTypeProvider>(
+    env: Env,
     name: &str,
     flags: NifResourceFlags,
 ) -> Option<ResourceType<T>> {

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -35,7 +35,7 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if `bytes.len() > 255`.
-    pub fn from_bytes<'a>(env: Env<'a>, bytes: &[u8]) -> NifResult<Atom> {
+    pub fn from_bytes(env: Env, bytes: &[u8]) -> NifResult<Atom> {
         if bytes.len() > 255 {
             return Err(Error::BadArg);
         }
@@ -46,7 +46,7 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if `bytes.len() > 255`.
-    pub fn try_from_bytes<'a>(env: Env<'a>, bytes: &[u8]) -> NifResult<Option<Atom>> {
+    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Atom>> {
         if bytes.len() > 255 {
             return Err(Error::BadArg);
         }
@@ -63,7 +63,7 @@ impl Atom {
     /// # Errors
     /// `Error::BadArg` if `string` contains characters that aren't in Latin-1, or if it's too
     /// long. The maximum length is 255 characters.
-    pub fn from_str<'a>(env: Env<'a>, string: &str) -> NifResult<Atom> {
+    pub fn from_str(env: Env, string: &str) -> NifResult<Atom> {
         if string.is_ascii() {
             // Fast path.
             Atom::from_bytes(env, string.as_bytes())

--- a/rustler/src/types/tuple.rs
+++ b/rustler/src/types/tuple.rs
@@ -15,7 +15,7 @@ use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 ///
 /// # Errors
 /// `badarg` if `term` is not a tuple.
-pub fn get_tuple<'a>(term: Term<'a>) -> Result<Vec<Term<'a>>, Error> {
+pub fn get_tuple(term: Term) -> Result<Vec<Term>, Error> {
     let env = term.get_env();
     unsafe {
         match tuple::get_tuple(env.as_c_arg(), term.as_c_arg()) {

--- a/rustler_codegen/src/nif.rs
+++ b/rustler_codegen/src/nif.rs
@@ -109,7 +109,7 @@ fn extract_attr_value(args: syn::AttributeArgs, name: &str) -> Option<String> {
 
 fn extract_inputs(inputs: Punctuated<syn::FnArg, Comma>) -> TokenStream {
     let mut tokens = TokenStream::new();
-    let mut idx = 0 as usize;
+    let mut idx: usize = 0;
 
     for item in inputs.iter() {
         if let syn::FnArg::Typed(ref typed) = item {

--- a/rustler_sys/src/rustler_sys_api.rs
+++ b/rustler_sys/src/rustler_sys_api.rs
@@ -280,7 +280,7 @@ pub struct ErlNifPort {
 
 /// See [ErlNifBinaryToTerm](http://erlang.org/doc/man/erl_nif.html#ErlNifBinaryToTerm) in the Erlang docs.
 pub type ErlNifBinaryToTerm = c_int;
-pub const ERL_NIF_BIN2TERM_SAFE: ErlNifBinaryToTerm = 0x20_000_000;
+pub const ERL_NIF_BIN2TERM_SAFE: ErlNifBinaryToTerm = 0x2000_0000;
 
 pub const ERL_NIF_THR_UNDEFINED: c_int = 0;
 pub const ERL_NIF_THR_NORMAL_SCHEDULER: c_int = 1;


### PR DESCRIPTION
This PR fixes the following clippy lints:

* `unusual_byte_groupings`
* `needless_lifetimes`
* `unnecessary_cast`