### PR TITLE
Force panic unwind implementation for users of rustler

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -17,6 +17,12 @@ lazy_static = "1.4"
 rustler_codegen = { path = "../rustler_codegen", version = "0.22.0-rc.0", optional = true}
 rustler_sys = { path = "../rustler_sys", version = "~2.1" }
 
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+
 [package.metadata.release]
 
 [[package.metadata.release.pre-release-replacements]]


### PR DESCRIPTION
Since safety of this library relies on `std::panic::catch_unwind`, we need to configure `rustler` to force `panic = "unwind"` in its `Cargo.toml` according to https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/controlling-panics-with-std-panic.html.