### PR TITLE
Update rust linker flags to apply to macOS

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",


### PR DESCRIPTION
The previous target works on Intel based Macs but was causing an issue on the new Apple Silicon based Macs.