### PR TITLE
ci: Use stable toolchain for clippy and format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: clippy
             override: true
       - uses: actions-rs/clippy-check@v1
@@ -38,7 +38,7 @@ jobs:
             cargo build
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: clippy
             override: true
       - uses: actions-rs/clippy-check@v1
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: rustfmt
             override: true
 


### PR DESCRIPTION
Clippy regularly fails on new pull requests due to changes in nightly. We only find out about that if somebody actually publishes a PR. As people publishing PRs are unlikely to run nightly, we can't really assume that they can or will take care of such lints. Instead, we should simply change the toolchain to nightly.