### PR TITLE
ci: Fix adding erlang to PATH in windows runnner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Erlang/Elixir
         run: choco install elixir
       - name: Extend PATH
-        run: echo "::add-path::C:\\ProgramData\\chocolatey\\lib\\Elixir\\bin"
+        run: echo "C:\\ProgramData\\chocolatey\\lib\\Elixir\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build API
         working-directory: rustler_sys
         run: |
@@ -115,7 +115,7 @@ jobs:
           override: true
 
       - name: Extend PATH
-        run: echo "::add-path::C:\\ProgramData\\chocolatey\\lib\\Elixir\\bin"
+        run: echo "C:\\ProgramData\\chocolatey\\lib\\Elixir\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Hex
         run: mix local.hex --force


### PR DESCRIPTION
Github [no longer allows](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) using stdout to extend the PATH variable:

![image](https://user-images.githubusercontent.com/224554/100275757-b847a100-2f60-11eb-9fbf-a4e1eadcab3c.png)

This pull request migrates to the new [format](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path).