### PR TITLE
ci: Run only on stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,8 +172,6 @@ jobs:
 
         rust:
           - stable
-          - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1


### PR DESCRIPTION
Testing against stable and nightly is useful to find upcoming problems early. But this only works properly if testing happens fairly often in the test environment. As we do not have that much activity on this repository, I propose to only build on stable. This reduces the number of runners needed to execute the tests, and should result in a (slightly) quicker turn-around for pull requests (the windows checks still dwarf all other tests).