### PR TITLE
ci: Run jobs on wednesday night

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
     tags: ["*"]
   pull_request:
     branches: ["*"]
+  schedule:
+    - cron: '0 0 * * 3'
 
 jobs:
   clippy:


### PR DESCRIPTION
Run the CI jobs periodically to ensure that we keep up with nightly.

This is an alternative to https://github.com/rusterlium/rustler/pull/343.