### PR TITLE
Fix clippy lints

### DIFF
--- a/rustler/src/codegen_runtime.rs
+++ b/rustler/src/codegen_runtime.rs
@@ -16,14 +16,14 @@ pub use crate::wrapper::{
 pub use rustler_sys::{TWinDynNifCallbacks, WIN_DYN_NIF_CALLBACKS};
 
 pub unsafe trait NifReturnable {
-    unsafe fn as_returned(self, env: Env) -> NifReturned;
+    unsafe fn into_returned(self, env: Env) -> NifReturned;
 }
 
 unsafe impl<T> NifReturnable for T
 where
     T: crate::Encoder,
 {
-    unsafe fn as_returned(self, env: Env) -> NifReturned {
+    unsafe fn into_returned(self, env: Env) -> NifReturned {
         NifReturned::Term(self.encode(env).as_c_arg())
     }
 }
@@ -32,16 +32,16 @@ unsafe impl<T> NifReturnable for Result<T, crate::error::Error>
 where
     T: NifReturnable,
 {
-    unsafe fn as_returned(self, env: Env) -> NifReturned {
+    unsafe fn into_returned(self, env: Env) -> NifReturned {
         match self {
-            Ok(inner) => inner.as_returned(env),
-            Err(inner) => inner.as_returned(env),
+            Ok(inner) => inner.into_returned(env),
+            Err(inner) => inner.into_returned(env),
         }
     }
 }
 
 unsafe impl NifReturnable for OwnedBinary {
-    unsafe fn as_returned(self, env: Env) -> NifReturned {
+    unsafe fn into_returned(self, env: Env) -> NifReturned {
         NifReturned::Term(self.release(env).encode(env).as_c_arg())
     }
 }
@@ -126,8 +126,8 @@ where
     unsafe {
         match result {
             Ok(res) => match res {
-                Ok(res) => NifReturnable::as_returned(res, env),
-                Err(err) => NifReturnable::as_returned(err, env),
+                Ok(res) => NifReturnable::into_returned(res, env),
+                Err(err) => NifReturnable::into_returned(err, env),
             },
             Err(err) => match err.downcast::<NifReturned>() {
                 Ok(ty) => NifReturned::Term(ty.apply(env)),

--- a/rustler/src/error.rs
+++ b/rustler/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 unsafe impl NifReturnable for crate::error::Error {
-    unsafe fn as_returned(self, env: Env) -> NifReturned {
+    unsafe fn into_returned(self, env: Env) -> NifReturned {
         match self {
             Error::BadArg => NifReturned::BadArg,
             Error::Atom(atom_str) => {

--- a/rustler/src/export.rs
+++ b/rustler/src/export.rs
@@ -96,7 +96,7 @@ macro_rules! rustler_export_nifs {
             .collect::<Vec<Term>>();
 
         let result: ::std::thread::Result<_> = ::std::panic::catch_unwind(move || {
-            $crate::codegen_runtime::NifReturnable::as_returned($fun(env, &terms), env)
+            $crate::codegen_runtime::NifReturnable::into_returned($fun(env, &terms), env)
         });
 
         match result {

--- a/rustler/src/return.rs
+++ b/rustler/src/return.rs
@@ -8,10 +8,10 @@ pub enum Return<'a> {
 }
 
 unsafe impl<'b> NifReturnable for Return<'b> {
-    unsafe fn as_returned(self, env: Env) -> NifReturned {
+    unsafe fn into_returned(self, env: Env) -> NifReturned {
         match self {
             Return::Term(inner) => NifReturned::Term(inner.as_c_arg()),
-            Return::Error(inner) => inner.as_returned(env),
+            Return::Error(inner) => inner.into_returned(env),
         }
     }
 }

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -164,7 +164,7 @@ impl<'a> Context<'a> {
             .filter_map(|segment| {
                 let meta = attr.parse_meta().expect("can parse meta");
                 match segment.ident.to_string().as_ref() {
-                    "rustler" => Context::parse_rustler(&meta),
+                    "rustler" => Some(Context::parse_rustler(&meta)),
                     "tag" => Context::try_parse_tag(&meta),
                     "module" => Context::try_parse_module(&meta),
                     _ => None,
@@ -174,27 +174,24 @@ impl<'a> Context<'a> {
             .collect()
     }
 
-    fn parse_rustler(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+    fn parse_rustler(meta: &Meta) -> Vec<RustlerAttr> {
         if let Meta::List(ref list) = meta {
-            return Some(
-                list.nested
-                    .iter()
-                    .map(Context::parse_nested_rustler)
-                    .collect(),
-            );
+            return list
+                .nested
+                .iter()
+                .map(Context::parse_nested_rustler)
+                .collect();
         }
 
         panic!("Expected encode and/or decode in rustler attribute");
     }
 
     fn parse_nested_rustler(nested: &NestedMeta) -> RustlerAttr {
-        if let NestedMeta::Meta(ref meta) = nested {
-            if let Meta::Path(ref path) = meta {
-                match path.segments[0].ident.to_string().as_ref() {
-                    "encode" => return RustlerAttr::Encode,
-                    "decode" => return RustlerAttr::Decode,
-                    other => panic!("Unexpected literal {}", other),
-                }
+        if let NestedMeta::Meta(Meta::Path(ref path)) = nested {
+            match path.segments[0].ident.to_string().as_ref() {
+                "encode" => return RustlerAttr::Encode,
+                "decode" => return RustlerAttr::Decode,
+                other => panic!("Unexpected literal {}", other),
             }
         }
 

--- a/rustler_codegen/src/init.rs
+++ b/rustler_codegen/src/init.rs
@@ -52,12 +52,12 @@ fn extract_option(args: Vec<syn::ExprAssign>, name: &str) -> TokenStream {
     quote!(#none)
 }
 
-impl Into<proc_macro2::TokenStream> for InitMacroInput {
-    fn into(self) -> proc_macro2::TokenStream {
-        let name = self.name;
-        let num_of_funcs = self.funcs.elems.len();
-        let funcs = nif_funcs(self.funcs.elems);
-        let load = self.load;
+impl From<InitMacroInput> for proc_macro2::TokenStream {
+    fn from(input: InitMacroInput) -> Self {
+        let name = input.name;
+        let num_of_funcs = input.funcs.elems.len();
+        let funcs = nif_funcs(input.funcs.elems);
+        let load = input.load;
 
         let inner = quote! {
             static mut NIF_ENTRY: Option<rustler::codegen_runtime::DEF_NIF_ENTRY> = None;

--- a/rustler_sys/tests/struct_size.rs
+++ b/rustler_sys/tests/struct_size.rs
@@ -6,7 +6,6 @@ fn test1() {
     use rustler_sys::*;
     use std::collections::HashMap;
     use std::env;
-    use std::iter::FromIterator;
     use std::mem::size_of;
     use std::path::Path;
     use std::process::Command;
@@ -61,12 +60,11 @@ fn test1() {
     let output: &str = std::str::from_utf8(&stdout).unwrap();
 
     // Parse C program output into hashmap of (&str, u32)
-    let sizemap = HashMap::<&str, usize>::from_iter(
-        output
-            .lines()
-            .map(|ln| ln.split(' '))
-            .map(|mut it| (it.next().unwrap(), it.next().unwrap().parse().unwrap())),
-    );
+    let sizemap: HashMap<&str, usize> = output
+        .lines()
+        .map(|ln| ln.split(' '))
+        .map(|mut it| (it.next().unwrap(), it.next().unwrap().parse().unwrap()))
+        .collect();
 
     /* types to check are:
 


### PR DESCRIPTION
The periodic CI run from https://github.com/rusterlium/rustler/pull/344 found some clippy lints.

* Prefer collect() over from_iter(): clippy::from-iter-instead-of-collect
* Prefer `From` over `Into`: clippy::from-over-into
* Avoid nested match: clippy::collapsible-match
* Avoid unnecessary wraps: clippy::unnecessary-wraps
* Obey naming convention of `as_`: clippy::wrong-self-convention