### PR TITLE
Allow specifying a channel for the system rustc

### DIFF
--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -22,10 +22,11 @@ defmodule Rustler do
 
     * `:cargo` - Specify how to envoke the rust compiler. Options are:
         - `:system` (default) - use `cargo` from the system (must be in `$PATH`)
-        - `{:system, <channel>}` - use `cargo` from the system with the given channel
+        - `{:system, <channel>}` - use `cargo` from the system with the given channel.
+          Specified as a string, passed directly to `cargo` (e.g. "+nightly").
         - `{:rustup, <version>}` - use `rustup` to specify which channel to use.
           Available options include: `:stable`, `:beta`, `:nightly`, or a string
-          which specifies a specific version (i.e. `"1.39.0"`).
+          which specifies a specific version (e.g. `"1.39.0"`).
         - `{:bin, "/path/to/binary"}` - provide a specific path to `cargo`.
 
     * `:crate` - the name of the Rust crate, if different from your `otp_app`

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -21,7 +21,8 @@ defmodule Rustler do
   ## Configuration options
 
     * `:cargo` - Specify how to envoke the rust compiler. Options are:
-        - `:system` (default) - use `cargo` from the system (must by in `$PATH`)
+        - `:system` (default) - use `cargo` from the system (must be in `$PATH`)
+        - `{:system, <channel>}` - use `cargo` from the system with the given channel
         - `{:rustup, <version>}` - use `rustup` to specify which channel to use.
           Available options include: `:stable`, `:beta`, `:nightly`, or a string
           which specifies a specific version (i.e. `"1.39.0"`).

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -48,6 +48,7 @@ defmodule Rustler.Compiler do
   defp make_base_command(:system), do: ["cargo", "rustc"]
   defp make_base_command({:system, channel}), do: ["cargo", channel, "rustc"]
   defp make_base_command({:bin, path}), do: [path, "rustc"]
+
   defp make_base_command({:rustup, version}) do
     if Rustup.version() == :none do
       throw_error(:rustup_not_installed)

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -46,8 +46,8 @@ defmodule Rustler.Compiler do
   end
 
   defp make_base_command(:system), do: ["cargo", "rustc"]
+  defp make_base_command({:system, channel}), do: ["cargo", channel, "rustc"]
   defp make_base_command({:bin, path}), do: [path, "rustc"]
-
   defp make_base_command({:rustup, version}) do
     if Rustup.version() == :none do
       throw_error(:rustup_not_installed)


### PR DESCRIPTION
This is useful if you want to use e.g. `{:system, "+nightly"}`