### PR TITLE
ci: Switch from actions/setup-elixir to erlef/setup-elixir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
             override: true
 
       - name: Install Erlang/Elixir
-        uses: actions/setup-elixir@v1.0.0
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 22.1.3
           elixir-version: 1.9.2
@@ -91,7 +91,7 @@ jobs:
           override: true
 
       - name: Install Erlang/Elixir
-        uses: actions/setup-elixir@v1.0.0
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 21.x
           elixir-version: 1.6
@@ -181,7 +181,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Erlang/Elixir
-        uses: actions/setup-elixir@v1.0.0
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}


### PR DESCRIPTION
From [here](https://github.com/actions/setup-elixir/blob/main/README.md):

> Please note: This repository is currently unmaintained by a team of developers at GitHub. It is now maintained by the Erlang Ecosystem Foundation at erlef/setup-elixir.