### PR TITLE
Disable lint for rustler_sys_api

### DIFF
--- a/rustler/src/wrapper.rs
+++ b/rustler/src/wrapper.rs
@@ -5,6 +5,7 @@
 //! should try to stick as close as possible to the original C API.
 //!
 //! Making the APIs nice to use from Rust should be done in the root `rustler` crate.
+#![allow(clippy::upper_case_acronyms)]
 
 pub mod atom;
 pub mod binary;

--- a/rustler_sys/src/rustler_sys_api.rs
+++ b/rustler_sys/src/rustler_sys_api.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![allow(clippy::upper_case_acronyms)]
 
 #[cfg(windows)]
 use unreachable::UncheckedOptionExt; // unchecked unwrap used in generated Windows code


### PR DESCRIPTION
This disables `clippy::upper-case-acronyms` for `rustler_sys_api.rs` and `wrapper.rs`:

```
error: name `ERL_NIF_UINT` contains a capitalized acronym
  --> rustler_sys/src/rustler_sys_api.rs:17:10
   |
17 | pub type ERL_NIF_UINT = size_t;
   |          ^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `Erl_Nif_Uint`
   |
   = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms
```