### PR TITLE
Duplicate "add" function in the docs.

### DIFF
--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -38,7 +38,7 @@ enum RustlerAttr {
 /// }
 ///
 /// #[rustler::nif]
-/// fn add(a: i64, b: i64) -> i64 {
+/// fn sub(a: i64, b: i64) -> i64 {
 ///     a - b
 /// }
 ///


### PR DESCRIPTION
Just a trivial change. The second, duplicated `add` should actually be a `sub`.