### PR TITLE
Add workaround for missing lib

### DIFF
--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -37,7 +37,7 @@ defmodule Rustler.Compiler do
       end
 
       handle_artifacts(crate_full_path, config)
-      workaround_mix_priv_dir(config)
+      workaround_mix_priv_dir(config.__project_config__)
     end
 
     config
@@ -131,12 +131,12 @@ defmodule Rustler.Compiler do
 
   # Workaround for a mix problem. We should REALLY get this fixed properly. Originally introduced
   # with d053522fe8b08bdacacb64592b22536e23ff3853.
-  defp workaround_mix_priv_dir(config) do
+  defp workaround_mix_priv_dir(project_config) do
     _ =
       symlink_or_copy(
-        config,
+        project_config,
         Path.expand("priv"),
-        Path.join(Mix.Project.app_path(config), "priv")
+        Path.join(Mix.Project.app_path(project_config), "priv")
       )
   end
 

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -37,6 +37,7 @@ defmodule Rustler.Compiler do
       end
 
       handle_artifacts(crate_full_path, config)
+      workaround_mix_priv_dir(config)
     end
 
     config
@@ -126,6 +127,31 @@ defmodule Rustler.Compiler do
       File.rm(destination_lib)
       File.cp!(compiled_lib, destination_lib)
     end)
+  end
+
+  # Workaround for a mix problem. We should REALLY get this fixed properly. Originally introduced
+  # with d053522fe8b08bdacacb64592b22536e23ff3853.
+  defp workaround_mix_priv_dir(config) do
+    _ =
+      symlink_or_copy(
+        config,
+        Path.expand("priv"),
+        Path.join(Mix.Project.app_path(config), "priv")
+      )
+  end
+
+  # https://github.com/elixir-lang/elixir/blob/b13404e913fff70e080c08c2da3dbd5c41793b54/lib/mix/lib/mix/project.ex#L553-L562
+  defp symlink_or_copy(config, source, target) do
+    if config[:build_embedded] do
+      if File.exists?(source) do
+        File.rm_rf!(target)
+        File.cp_r!(source, target)
+      end
+
+      :ok
+    else
+      Mix.Utils.symlink_or_copy(source, target)
+    end
   end
 
   defp get_name(toml, section) do

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -26,7 +26,8 @@ defmodule Rustler.Compiler.Config do
             priv_dir: "",
             skip_compilation?: false,
             target: nil,
-            target_dir: ""
+            target_dir: "",
+            __project_config__: nil
 
   alias Rustler.Compiler.Config
 
@@ -54,6 +55,7 @@ defmodule Rustler.Compiler.Config do
     |> Keyword.merge(legacy_config)
     |> Keyword.merge(opts)
     |> Keyword.merge(config)
+    |> Keyword.merge(__project_config__: Mix.Project.config())
     |> build()
   end
 

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -26,8 +26,7 @@ defmodule Rustler.Compiler.Config do
             priv_dir: "",
             skip_compilation?: false,
             target: nil,
-            target_dir: "",
-            __project_config__: nil
+            target_dir: ""
 
   alias Rustler.Compiler.Config
 
@@ -55,7 +54,6 @@ defmodule Rustler.Compiler.Config do
     |> Keyword.merge(legacy_config)
     |> Keyword.merge(opts)
     |> Keyword.merge(config)
-    |> Keyword.merge(__project_config__: Mix.Project.config())
     |> build()
   end
 


### PR DESCRIPTION
This fixes f01719c: We accidentally removed a workaround for mix, which copied the libraries to the target directory in `_build`. d053522f originally introduced a workaround, copying `symlink_or_copy`. Here, we call into a public function of `Mix.Project` instead (which might be more future proof).

Fix #326