### PR TITLE
clippy: Allow breaking convention to avoid breaking change

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -242,6 +242,7 @@ impl<'a> Binary<'a> {
     /// # Errors
     ///
     /// If allocation fails, an error will be returned.
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_owned(&self) -> Option<OwnedBinary> {
         OwnedBinary::from_unowned(self)
     }
@@ -293,6 +294,7 @@ impl<'a> Binary<'a> {
     }
 
     /// Returns an Erlang term representation of `self`.
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_term<'b>(&self, env: Env<'b>) -> Term<'b> {
         self.term.in_env(env)
     }


### PR DESCRIPTION
This PR disables `clippy::wrong-self-convention` for two public functions:

```
error: methods with the following characteristics: (`to_*` and `self` type is `Copy`) usually take `self` by value
   --> rustler/src/types/binary.rs:245:21
    |
245 |     pub fn to_owned(&self) -> Option<OwnedBinary> {
    |                     ^^^^^
    |
    = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```