### PR TITLE
Fix clippy

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -118,7 +118,7 @@ impl<'a> OwnedBinary {
     /// If allocation fails, `None` is returned.
     pub fn from_unowned(src: &Binary) -> Option<OwnedBinary> {
         OwnedBinary::new(src.len()).map(|mut b| {
-            b.as_mut_slice().copy_from_slice(&src);
+            b.as_mut_slice().copy_from_slice(src);
             b
         })
     }

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -29,13 +29,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let atoms_module_name = ctx.atoms_module_name(Span::call_site());
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_decoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_encoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -24,13 +24,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let atoms_module_name = ctx.atoms_module_name(Span::call_site());
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_decoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_encoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -24,13 +24,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let atoms_module_name = ctx.atoms_module_name(Span::call_site());
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_decoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &struct_fields, &atoms_module_name)
+        gen_encoder(&ctx, struct_fields, &atoms_module_name)
     } else {
         quote! {}
     };

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -13,13 +13,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
         .expect("NifTuple can only be used with structs");
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &struct_fields)
+        gen_decoder(&ctx, struct_fields)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &struct_fields)
+        gen_encoder(&ctx, struct_fields)
     } else {
         quote! {}
     };

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -42,13 +42,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let atoms_module_name = ctx.atoms_module_name(Span::call_site());
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &variants, &atoms_module_name)
+        gen_decoder(&ctx, variants, &atoms_module_name)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &variants, &atoms_module_name)
+        gen_encoder(&ctx, variants, &atoms_module_name)
     } else {
         quote! {}
     };

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -27,13 +27,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     }
 
     let decoder = if ctx.decode() {
-        gen_decoder(&ctx, &variants)
+        gen_decoder(&ctx, variants)
     } else {
         quote! {}
     };
 
     let encoder = if ctx.encode() {
-        gen_encoder(&ctx, &variants)
+        gen_encoder(&ctx, variants)
     } else {
         quote! {}
     };

--- a/rustler_sys/src/initmacro.rs
+++ b/rustler_sys/src/initmacro.rs
@@ -209,7 +209,7 @@ macro_rules! make_func_entry {
     };
 
     (($name:expr, $arity:expr, $function:expr)) => {
-        make_func_entry!(($name, $arity, $function, 0));
+        make_func_entry!(($name, $arity, $function, 0))
     };
 }
 


### PR DESCRIPTION
Fixes a few small clippy lints:

1. Trailing semicolon in macro
2. Needless borrowing