### PR TITLE
add `NewBinary` (`enif_make_new_binary`)

### DIFF
--- a/rustler/src/wrapper/binary.rs
+++ b/rustler/src/wrapper/binary.rs
@@ -1,4 +1,4 @@
-use crate::wrapper::size_t;
+use crate::{wrapper::size_t, Env, Term};
 pub(in crate) use rustler_sys::ErlNifBinary;
 use std::mem::MaybeUninit;
 
@@ -14,4 +14,13 @@ pub unsafe fn alloc(size: size_t) -> Option<ErlNifBinary> {
 pub unsafe fn realloc(binary: &mut ErlNifBinary, size: size_t) -> bool {
     let success = rustler_sys::enif_realloc_binary(binary, size);
     success != 0
+}
+
+pub unsafe fn new_binary(env: Env, size: size_t) -> (*mut u8, Term) {
+    let mut term = MaybeUninit::uninit();
+    let buf = rustler_sys::enif_make_new_binary(env.as_c_arg(), size, term.as_mut_ptr());
+    if buf.is_null() {
+        panic!("enif_make_new_binary: allocation failed");
+    }
+    (buf, Term::new(env, term.assume_init()))
 }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -41,6 +41,7 @@ defmodule RustlerTest do
   def parse_integer(_), do: err()
   def binary_new(), do: err()
   def owned_binary_new(), do: err()
+  def new_binary_new(), do: err()
   def unowned_to_owned(_), do: err()
   def realloc_shrink(), do: err()
   def realloc_grow(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -45,6 +45,7 @@ rustler::init!(
         test_binary::parse_integer,
         test_binary::binary_new,
         test_binary::owned_binary_new,
+        test_binary::new_binary_new,
         test_binary::unowned_to_owned,
         test_binary::realloc_shrink,
         test_binary::realloc_grow,

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use rustler::types::binary::{Binary, OwnedBinary};
+use rustler::types::binary::{Binary, NewBinary, OwnedBinary};
 use rustler::{Env, Error, NifResult, Term};
 
 #[rustler::nif]
@@ -26,6 +26,13 @@ pub fn owned_binary_new() -> OwnedBinary {
     let mut binary = OwnedBinary::new(4).unwrap();
     binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
     binary
+}
+
+#[rustler::nif]
+pub fn new_binary_new(env: Env) -> Binary {
+    let mut binary = NewBinary::new(env, 4);
+    binary.as_mut_slice().write_all(&[1, 2, 3, 4]).unwrap();
+    binary.into()
 }
 
 #[rustler::nif]

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -21,6 +21,10 @@ defmodule RustlerTest.BinaryTest do
     assert RustlerTest.owned_binary_new() == <<1, 2, 3, 4>>
   end
 
+  test "new binary creation" do
+    assert RustlerTest.new_binary_new() == <<1, 2, 3, 4>>
+  end
+
   test "unowned binary to owned" do
     assert RustlerTest.unowned_to_owned("test") == <<1, "est">>
     assert RustlerTest.unowned_to_owned("whatisgoingon") == <<1, "hatisgoingon">>


### PR DESCRIPTION
It seems like this can improve performance a bit if you're creating a lot of small binaries