### PR TITLE
Point to HexDocs base URL for Rustler in lib.rs

### DIFF
--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -21,7 +21,7 @@
 //! automatic NIF compiler for Mix, and utilities for loading the compiled NIF.
 //!
 //! For more information about this, see [the documentation for
-//! rustler_mix](https://hexdocs.pm/rustler/basics.html).
+//! rustler](https://hexdocs.pm/rustler).
 
 #[macro_use(enif_snprintf)]
 extern crate rustler_sys;


### PR DESCRIPTION
Hey folks! 

Was checking this out and I noticed that the URL in `lib.rs` is pointing to a dead link. I _think_ it's related to #270 as it looks like this is when the `mix` documentation was updated. I compared the docs and it looks like the base Rustler module docs cover pretty much everything there. Happy to update this PR if I'm mistaken though.

Thanks for making the project 😄 