### PR TITLE
Don't call cargo when skip_compilation? is true

### DIFF
--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -61,9 +61,13 @@ defmodule Rustler.Compiler.Config do
     crate = Keyword.fetch!(opts, :crate)
 
     resources =
-      opts
-      |> Keyword.get(:path)
-      |> external_resources(crate)
+      if opts[:skip_compilation?] do
+        []
+      else
+        opts
+        |> Keyword.get(:path)
+        |> external_resources(crate)
+      end
 
     opts = Keyword.put(opts, :external_resources, resources)
 


### PR DESCRIPTION
This fixes a regression from #386 which made rustler_mix call `cargo metadata` even when skip_compilation? is set to true,
breaking setups in which the rust library is built separately, e.g. in separate docker stage with proper rust versioning and in which the elixir compilation stage doesn't have cargo.

This fix assumes that the external_resources attribute is irrelevant when skip_compilation? is set to true.