### PR TITLE
Remove DUMMY variant from ErlNifCharEncoding

### DIFF
--- a/rustler_sys/src/rustler_sys_api.rs
+++ b/rustler_sys/src/rustler_sys_api.rs
@@ -187,7 +187,6 @@ pub enum ErlNifResourceFlags {
 #[repr(C)]
 pub enum ErlNifCharEncoding {
     ERL_NIF_LATIN1 = 1,
-    DUMMY = 999, // prevents "univariant enum" compile error
 }
 
 /// See [ErlNifPid](http://www.erlang.org/doc/man/erl_nif.html#ErlNifPid) in the Erlang docs.


### PR DESCRIPTION
This removes the `DUMMY` variant from `ErlNifCharEncoding` as suggested by @koba-e964 in #385.