### PR TITLE
Crash if metadata cannot be retrieved

### DIFF
--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -83,7 +83,7 @@ defmodule Rustler.Compiler.Config do
           metadata
 
         {output, code} ->
-          raise "calling `cargo metadata` failed. Output:\n" <> output
+          raise "calling `cargo metadata` failed.\n" <> output
       end
 
     json = Jason.decode!(metadata)


### PR DESCRIPTION
This PR fixes #394 by crashing if `cargo metadata` fails. Example error:

```
== Compilation error in file lib/binary_example.ex ==
** (RuntimeError) calling `cargo metadata` failed.

    (rustler 0.22.2) lib/rustler/compiler/config.ex:87: Rustler.Compiler.Config.external_resources/2
    (rustler 0.22.2) lib/rustler/compiler/config.ex:69: Rustler.Compiler.Config.build/1
    (rustler 0.22.2) lib/rustler/compiler.ex:9: Rustler.Compiler.compile_crate/2
    lib/binary_example.ex:2: (module)
```