### PR TITLE
Require step for range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer ver
 
 - `NifException` for using Elixir exception structs
 
+### Changed
+
+- The decoder for `Range` requires that `:step` equals `1`. The `:step` field was introduced with
+  Elixir v1.12 and cannot be represented with Rust's `RangeInclusive`.
+
 ## [0.22.2] - 2021-10-07
 
 ### Fixed

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -305,4 +305,7 @@ atoms! {
 
     /// The `last` atom used by `Elixir.Range`.
     last,
+
+    /// The `step` atom used by `Elixir.Range` vor Elixir >= v1.12
+    step,
 }

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -220,6 +220,12 @@ where
 
         let first = term.map_get(atom::first().to_term(env))?.decode::<T>()?;
         let last = term.map_get(atom::last().to_term(env))?.decode::<T>()?;
+        if let Ok(step) = term.map_get(atom::step().to_term(env)) {
+            match step.decode::<i64>()? {
+                1 => (),
+                _ => return Err(Error::BadArg),
+            }
+        }
 
         Ok(first..=last)
     }

--- a/rustler_tests/test/term_test.exs
+++ b/rustler_tests/test/term_test.exs
@@ -7,8 +7,16 @@ defmodule RustlerTest.TermTest do
     assert RustlerTest.term_debug("饂") == "<<233,165,130>>"
     assert RustlerTest.term_debug({:atom, :pair}) == "{atom,pair}"
 
-    assert RustlerTest.term_debug(0..1000) ==
-             "\#{'__struct__'=>'Elixir.Range',first=>0,last=>1000}"
+    range = 0..1000
+
+    # For Elixir >= v1.12, Range has a :step field.
+    if Map.has_key?(range, :step) do
+      assert RustlerTest.term_debug(range) ==
+               "\#{'__struct__'=>'Elixir.Range',first=>0,last=>1000,step=>1}"
+    else
+      assert RustlerTest.term_debug(range) ==
+               "\#{'__struct__'=>'Elixir.Range',first=>0,last=>1000}"
+    end
 
     assert RustlerTest.term_debug(Enum.to_list(0..5)) == "[0,1,2,3,4,5]"
     assert RustlerTest.term_debug(Enum.to_list(0..1000)) == "[#{Enum.join(0..1000, ",")}]"


### PR DESCRIPTION
This fixes #392 by requiring that the `:step` field in `Range` is optional. If it is set, it must be 1 (as we cannot represent another value with Rust's `RangeInclusive`).