### PR TITLE
ci: Add macos runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,3 +181,35 @@ jobs:
         run: |
           mix deps.get
           mix test
+
+  test_macos:
+    name: macos-11 test
+    runs-on: macos-11
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install Erlang/Elixir
+        run: |
+          brew install elixir
+          mix local.hex --force
+
+      - name: Install Rust ${{matrix.rust}} toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - run: cargo test
+
+      - name: Test rustler_mix
+        working-directory: rustler_mix
+        run: |
+          mix deps.get
+          mix test
+
+      - name: Test rustler_tests
+        working-directory: rustler_tests
+        run: |
+          mix deps.get
+          mix test


### PR DESCRIPTION
Add a CI runner for macOS. On macos, we need to run `rustc` separately for each target in the `Cargo.toml`. The reason is that we currently pass extra linker arguments to `rustc`. This is not possible if multiple targets need to be build.