### PR TITLE
Add MapSet -> HashSet decoder/encoder support out of the box

### DIFF
--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -308,4 +308,7 @@ atoms! {
 
     /// The `step` atom used by `Elixir.Range` vor Elixir >= v1.12
     step,
+
+    /// The `map` atom as used in `Elixir.MapSet`.
+    map
 }

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -310,5 +310,11 @@ atoms! {
     step,
 
     /// The `map` atom as used in `Elixir.MapSet`.
-    map
+    map,
+
+    /// The `version` atom as used in `Elixir.MapSet`. This atom is flagged for
+    /// removal in Elixir 2.0, not including it however when rebuilding the
+    /// MapSet prevents correct `==` results. Version 1 hasn't been in use since
+    /// Elixir 1.5.
+    version
 }

--- a/rustler/src/types/mod.rs
+++ b/rustler/src/types/mod.rs
@@ -189,6 +189,7 @@ where
     fn encode<'c>(&self, env: Env<'c>) -> Term<'c> {
         let mapset_struct = elixir_struct::make_ex_struct(env, "Elixir.MapSet").unwrap();
         let empty_vec: Vec<u8> = vec![];
+        let version: u8 = 2;
 
         let (keys, values): (Vec<_>, Vec<_>) = self
             .iter()
@@ -198,6 +199,8 @@ where
         let map_set = Term::map_from_arrays(env, &keys, &values).unwrap();
         mapset_struct
             .map_put(atom::map().to_term(env), map_set)
+            .unwrap()
+            .map_put(atom::version().to_term(env), version.encode(env))
             .unwrap()
     }
 }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -28,6 +28,7 @@ defmodule RustlerTest do
   def map_entries_sorted(_), do: err()
   def map_from_arrays(_keys, _values), do: err()
   def map_generic(_), do: err()
+  def mapset_generic(_), do: err()
 
   def resource_make(), do: err()
   def resource_set_integer_field(_, _), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -30,6 +30,7 @@ rustler::init!(
         test_map::map_entries_sorted,
         test_map::map_from_arrays,
         test_map::map_generic,
+        test_map::mapset_generic,
         test_resource::resource_make,
         test_resource::resource_set_integer_field,
         test_resource::resource_get_integer_field,

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -41,3 +41,8 @@ pub fn map_generic(
 ) -> std::collections::HashMap<i64, String> {
     map
 }
+
+#[rustler::nif]
+pub fn mapset_generic(mapset: std::collections::HashSet<u32>) -> std::collections::HashSet<u32> {
+    mapset
+}

--- a/rustler_tests/test/map_test.exs
+++ b/rustler_tests/test/map_test.exs
@@ -32,4 +32,13 @@ defmodule RustlerTest.MapTest do
       RustlerTest.map_generic(%{1 => "hello", not_a_number: "world"})
     end)
   end
+
+  test "generic mapsets" do
+    mapset = MapSet.new([1, 2, 3, 4, 5])
+    assert mapset == RustlerTest.mapset_generic(mapset)
+
+    assert_raise(ArgumentError, fn ->
+      RustlerTest.mapset_generic(%{1 => "I am a regular map"})
+    end)
+  end
 end


### PR DESCRIPTION
Adds a new encoder/decoder for the `MapSet.t()/HashSet<K>` type.

Not sure how the rustler team feels about contributions like this that attempt to unwind and rebuild opaque elixir types. There are some obvious drawbacks here:

* The internal representation of a MapSet could change at any time
* Version number used is static in the code
* Depending on how well tested user code is the version used by rustler could result in `==` comparisons failing silently for 2 "identical" mapsets. MapSet.equal?/2 however should always return the right result regardless...

I would be interested in feedback on how best to solve these problems and also your opinions on the value of encoding/decoding opaque types in the elixir stdlib like this...

I mostly did this work just to get hands-on in how encoders/decoders actually work so am happy for this to be closed if it isn't a direction the rustler team wish to head in.