### PR TITLE
Change supported Elixir and OTP versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Install Erlang/Elixir
         uses: erlef/setup-elixir@v1
         with:
-          otp-version: 22.1.3
-          elixir-version: 1.9.2
+          otp-version: "22.3.4"
+          elixir-version: "1.11.4"
 
       - name: Check cargo fmt
         uses: actions-rs/cargo@v1
@@ -140,28 +140,13 @@ jobs:
     strategy:
       matrix:
         pair:
-          - erlang: "24.1.7"
-            elixir: "1.13.0"
-          - erlang: "24.1.7"
-            elixir: "1.12.3"
-          - erlang: "24.1.7"
-            elixir: "1.11.4"
+          - { erlang: "24.1.7", elixir: "1.13.0" }
+          - { erlang: "24.1.7", elixir: "1.12.3" }
+          - { erlang: "24.1.7", elixir: "1.11.4" }
 
-          - erlang: "23.3"
-            elixir: "1.11.4"
-          - erlang: "23.0.3"
-            elixir: "1.10.3"
+          - { erlang: "23.3.4", elixir: "1.11.4" }
 
-          - erlang: 22.x
-            elixir: "1.10.1"
-          - erlang: 22.x
-            elixir: 1.9
-          - erlang: 22.x
-            elixir: 1.8
-          - erlang: 22.x
-            elixir: 1.7
-          - erlang: 22.x
-            elixir: 1.6
+          - { erlang: "22.3.4", elixir: "1.11.4" }
 
         rust:
           - stable

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ rustler::init!("Elixir.Math", [add]);
 
 #### Supported OTP and Elixir Versions
 
-Rustler aims to support the newest three OTP versions as well as Elixir versions capable of running the supported versions of OTP.
+Rustler aims to support the newest three major OTP versions as well as newest three minor Elixir versions.
 
 #### Supported NIF version
 

--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -9,7 +9,7 @@ defmodule Rustler.Mixfile do
       app: :rustler,
       name: "Rustler",
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -39,7 +39,7 @@ defmodule TestRustlerMix.MixProject do
     [
       app: :test_rustler_mix,
       version: "0.1.0",
-      elixir: "~> 1.6",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]

--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -5,7 +5,7 @@ defmodule RustlerTest.Mixfile do
     [
       app: :rustler_test,
       version: "0.0.1",
-      elixir: "~> 1.2",
+      elixir: "~> 1.11",
       compilers: [:rustler] ++ Mix.compilers(),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/rustler_tests/test/binary_example_test.exs
+++ b/rustler_tests/test/binary_example_test.exs
@@ -13,11 +13,11 @@ defmodule BinaryExampleTest do
     assert_exists(name, :os.type())
   end
 
-  defp assert_exists(name, {:win32, _} = type) do
+  defp assert_exists(name, {:win32, _} = _type) do
     assert File.exists?("priv/native/#{name}.exe")
   end
 
-  defp assert_exists(name, type) do
+  defp assert_exists(name, _type) do
     assert File.exists?("priv/native/#{name}")
   end
 end


### PR DESCRIPTION
The idea is to restrict the versions we support to be the latest 3
versions of Elixir and OTP.
So right now we support Elixir ~> 1.11 and OTP ~> 22.