### PR TITLE
Remove superfluous 'extern crate'

### DIFF
--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -23,16 +23,13 @@
 //! For more information about this, see [the documentation for
 //! rustler](https://hexdocs.pm/rustler).
 
-#[macro_use(enif_snprintf)]
-extern crate rustler_sys;
-
 #[doc(hidden)]
 pub mod wrapper;
 
 #[doc(hidden)]
 pub mod codegen_runtime;
 
-pub extern crate lazy_static;
+pub use lazy_static;
 
 #[macro_use]
 pub mod types;

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -146,8 +146,6 @@ unsafe impl Send for Atom {}
 ///
 /// For example, this code:
 ///
-///     #[macro_use] extern crate rustler;
-///
 ///     mod my_atoms {
 ///         rustler::atoms! {
 ///             jpeg,
@@ -159,7 +157,6 @@ unsafe impl Send for Atom {}
 ///
 /// Multiple atoms can be defined. Each one can have its own doc comment and other attributes.
 ///
-///     # #[macro_use] extern crate rustler;
 ///     rustler::atoms! {
 ///         /// The `jpeg` atom.
 ///         jpeg,
@@ -175,7 +172,6 @@ unsafe impl Send for Atom {}
 /// When you need an atom that's not a legal Rust function name, write `NAME = "ATOM"`, like
 /// this:
 ///
-///     # #[macro_use] extern crate rustler;
 ///     rustler::atoms! {
 ///         /// The `mod` atom. The function isn't called `mod` because that's
 ///         /// a Rust keyword.

--- a/rustler/src/wrapper/term.rs
+++ b/rustler/src/wrapper/term.rs
@@ -9,7 +9,7 @@ pub fn fmt(term: NIF_TERM, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     let mut n = 0;
     for _ in 0..10 {
         let i = unsafe {
-            enif_snprintf!(
+            rustler_sys::enif_snprintf!(
                 bytes.as_mut_ptr() as *mut c_char,
                 bytes.capacity(),
                 b"%T\x00" as *const u8 as *const c_char,

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::match_like_matches_macro)]
 
 use proc_macro2::{Span, TokenStream};
+use quote::quote;
 use syn::{Data, Field, Fields, Ident, Lit, Meta, NestedMeta, Variant};
 
 use super::RustlerAttr;

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -1,4 +1,5 @@
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
 
 use syn::{self, spanned::Spanned, Field, Ident};
 

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -1,14 +1,6 @@
 #![recursion_limit = "128"]
 
-extern crate proc_macro;
 use proc_macro::TokenStream;
-
-extern crate heck;
-extern crate proc_macro2;
-extern crate syn;
-
-#[macro_use]
-extern crate quote;
 
 mod context;
 mod ex_struct;

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -1,4 +1,5 @@
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
 
 use syn::{self, spanned::Spanned, Field, Ident};
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,4 +1,5 @@
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
 
 use syn::{self, spanned::Spanned, Field, Ident, Index};
 

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
 
 use syn::{self, spanned::Spanned, Field, Index};
 

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -1,4 +1,5 @@
 use proc_macro2::{Span, TokenStream};
+use quote::{quote, quote_spanned};
 
 use heck::SnakeCase;
 use syn::{self, spanned::Spanned, Fields, Ident, Variant};

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
 
 use syn::{self, spanned::Spanned, Fields, Variant};
 

--- a/rustler_sys/src/initmacro.rs
+++ b/rustler_sys/src/initmacro.rs
@@ -56,8 +56,6 @@ macro_rules! platform_nif_init {
 ///
 /// # Examples
 /// ```
-/// #[macro_use]
-/// extern crate rustler_sys;
 /// use rustler_sys::*;
 /// use std::mem;
 ///

--- a/rustler_sys/src/lib.rs
+++ b/rustler_sys/src/lib.rs
@@ -11,8 +11,6 @@ A NIF module is built by creating a new crate that uses `erlang_nif-sys` as a de
 All NIF functions must have the following signature:
 
 ```
-#[macro_use]
-extern crate rustler_sys;
 use rustler_sys::*;
 # fn main(){} //0
 fn my_nif(env: *mut ErlNifEnv,
@@ -28,8 +26,6 @@ fn my_nif(env: *mut ErlNifEnv,
 
 ## For the Impatient
 ```
-#[macro_use]
-extern crate rustler_sys;
 use rustler_sys::*;
 
 nif_init!("my_nif_module",[
@@ -71,8 +67,6 @@ Each is optional and is specified in struct-init style if present.  If no option
 the curly braces may be elided.  Stub implementation of all these functions looks something like:
 
 ```
-#[macro_use]
-extern crate rustler_sys;
 use rustler_sys::*;
 
 nif_init!("mymod", [], {load: load, reload: reload, upgrade: upgrade, unload: unload});
@@ -103,9 +97,9 @@ Below is an example of invoking NIF APIs along with an approach for dealing with
 the the `args` parameter.
 
 ```
-extern crate rustler_sys;
 use rustler_sys::*;
 use std::mem;
+
 fn native_add(env: *mut ErlNifEnv,
               argc: c_int,
               args: *const ERL_NIF_TERM) -> ERL_NIF_TERM {
@@ -129,9 +123,6 @@ fn native_add(env: *mut ErlNifEnv,
 
 // Don't throw warnings on NIF naming conventions
 #![allow(non_camel_case_types)]
-
-#[cfg(windows)]
-extern crate unreachable;
 
 #[macro_use]
 mod initmacro;

--- a/rustler_sys/tests/struct_size.rs
+++ b/rustler_sys/tests/struct_size.rs
@@ -1,5 +1,3 @@
-extern crate rustler_sys;
-
 #[cfg(unix)]
 #[test]
 fn test1() {


### PR DESCRIPTION
This PR removes `extern crate XYZ` where unnecessary. See the [edition guide](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html) for edition 2018.