### PR TITLE
file extensions should be set based on the compile target

### DIFF
--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -138,11 +138,10 @@ defmodule Rustler.Compiler do
         %{pattern: ~r/.*-solaris.*/, os_type: {:unix, :solaris}}
       ]
       |> Enum.map(&%{matched: Regex.match?(&1.pattern, target), os_type: &1.os_type})
-      |> Enum.reject(&(&1.matched == false))
-      |> Enum.map(& &1.os_type)
+      |> Enum.find(&(&1.matched == true))
 
-    if Enum.count(os_type) == 1 do
-      Enum.at(os_type, 0)
+    if os_type do
+      os_type.os_type
     else
       throw_error({:unknown_target, target})
     end

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -307,7 +307,7 @@ defmodule Rustler.Compiler do
 
     output_dir =
       if is_binary(target) do
-        config.target <> "/" <> Atom.to_string(config.mode)
+        Path.join([config.target, Atom.to_string(config.mode)])
       else
         Atom.to_string(config.mode)
       end

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -127,176 +127,24 @@ defmodule Rustler.Compiler do
   end
 
   defp get_target_os_type(target) when is_binary(target) do
-    case target do
-      "aarch64-apple-darwin" -> {:unix, :darwin}
-      "aarch64-apple-ios" -> {:unix, :darwin}
-      "aarch64-apple-ios-macabi" -> {:unix, :darwin}
-      "aarch64-apple-ios-sim" -> {:unix, :darwin}
-      "aarch64-apple-tvos" -> {:unix, :darwin}
-      "aarch64-fuchsia" -> {:unix, :linux}
-      "aarch64-linux-android" -> {:unix, :linux}
-      "aarch64-pc-windows-msvc" -> {:win32, :nt}
-      "aarch64-unknown-freebsd" -> {:unix, :freebsd}
-      "aarch64-unknown-hermit" -> {:unix, :linux}
-      "aarch64-unknown-linux-gnu" -> {:unix, :linux}
-      "aarch64-unknown-linux-gnu_ilp32" -> {:unix, :linux}
-      "aarch64-unknown-linux-musl" -> {:unix, :linux}
-      "aarch64-unknown-netbsd" -> {:unix, :netbsd}
-      "aarch64-unknown-none" -> {:unix, :linux}
-      "aarch64-unknown-none-softfloat" -> {:unix, :linux}
-      "aarch64-unknown-openbsd" -> {:unix, :openbsd}
-      "aarch64-unknown-redox" -> {:unix, :linux}
-      "aarch64-unknown-uefi" -> {:unix, :linux}
-      "aarch64-uwp-windows-msvc" -> {:win32, :nt}
-      "aarch64-wrs-vxworks" -> {:unix, :linux}
-      "aarch64_be-unknown-linux-gnu" -> {:unix, :linux}
-      "aarch64_be-unknown-linux-gnu_ilp32" -> {:unix, :linux}
-      "arm-linux-androideabi" -> {:unix, :linux}
-      "arm-unknown-linux-gnueabi" -> {:unix, :linux}
-      "arm-unknown-linux-gnueabihf" -> {:unix, :linux}
-      "arm-unknown-linux-musleabi" -> {:unix, :linux}
-      "arm-unknown-linux-musleabihf" -> {:unix, :linux}
-      "armebv7r-none-eabi" -> {:unix, :linux}
-      "armebv7r-none-eabihf" -> {:unix, :linux}
-      "armv4t-unknown-linux-gnueabi" -> {:unix, :linux}
-      "armv5te-unknown-linux-gnueabi" -> {:unix, :linux}
-      "armv5te-unknown-linux-musleabi" -> {:unix, :linux}
-      "armv5te-unknown-linux-uclibceabi" -> {:unix, :linux}
-      "armv6-unknown-freebsd" -> {:unix, :freebsd}
-      "armv6-unknown-netbsd-eabihf" -> {:unix, :netbsd}
-      "armv7-apple-ios" -> {:unix, :darwin}
-      "armv7-linux-androideabi" -> {:unix, :linux}
-      "armv7-unknown-freebsd" -> {:unix, :freebsd}
-      "armv7-unknown-linux-gnueabi" -> {:unix, :linux}
-      "armv7-unknown-linux-gnueabihf" -> {:unix, :linux}
-      "armv7-unknown-linux-musleabi" -> {:unix, :linux}
-      "armv7-unknown-linux-musleabihf" -> {:unix, :linux}
-      "armv7-unknown-netbsd-eabihf" -> {:unix, :netbsd}
-      "armv7-wrs-vxworks-eabihf" -> {:unix, :linux}
-      "armv7a-none-eabi" -> {:unix, :linux}
-      "armv7a-none-eabihf" -> {:unix, :linux}
-      "armv7r-none-eabi" -> {:unix, :linux}
-      "armv7r-none-eabihf" -> {:unix, :linux}
-      "armv7s-apple-ios" -> {:unix, :darwin}
-      "asmjs-unknown-emscripten" -> {:unix, :linux}
-      "avr-unknown-gnu-atmega328" -> {:unix, :linux}
-      "bpfeb-unknown-none" -> {:unix, :linux}
-      "bpfel-unknown-none" -> {:unix, :linux}
-      "hexagon-unknown-linux-musl" -> {:unix, :linux}
-      "i386-apple-ios" -> {:unix, :darwin}
-      "i586-pc-windows-msvc" -> {:win32, :nt}
-      "i586-unknown-linux-gnu" -> {:unix, :linux}
-      "i586-unknown-linux-musl" -> {:unix, :linux}
-      "i686-apple-darwin" -> {:unix, :darwin}
-      "i686-linux-android" -> {:unix, :linux}
-      "i686-pc-windows-gnu" -> {:win32, :nt}
-      "i686-pc-windows-msvc" -> {:win32, :nt}
-      "i686-unknown-freebsd" -> {:unix, :freebsd}
-      "i686-unknown-haiku" -> {:unix, :linux}
-      "i686-unknown-linux-gnu" -> {:unix, :linux}
-      "i686-unknown-linux-musl" -> {:unix, :linux}
-      "i686-unknown-netbsd" -> {:unix, :netbsd}
-      "i686-unknown-openbsd" -> {:unix, :openbsd}
-      "i686-unknown-uefi" -> {:unix, :linux}
-      "i686-uwp-windows-gnu" -> {:win32, :nt}
-      "i686-uwp-windows-msvc" -> {:win32, :nt}
-      "i686-wrs-vxworks" -> {:unix, :linux}
-      "mips-unknown-linux-gnu" -> {:unix, :linux}
-      "mips-unknown-linux-musl" -> {:unix, :linux}
-      "mips-unknown-linux-uclibc" -> {:unix, :linux}
-      "mips64-unknown-linux-gnuabi64" -> {:unix, :linux}
-      "mips64-unknown-linux-muslabi64" -> {:unix, :linux}
-      "mips64el-unknown-linux-gnuabi64" -> {:unix, :linux}
-      "mips64el-unknown-linux-muslabi64" -> {:unix, :linux}
-      "mipsel-sony-psp" -> {:unix, :linux}
-      "mipsel-unknown-linux-gnu" -> {:unix, :linux}
-      "mipsel-unknown-linux-musl" -> {:unix, :linux}
-      "mipsel-unknown-linux-uclibc" -> {:unix, :linux}
-      "mipsel-unknown-none" -> {:unix, :linux}
-      "mipsisa32r6-unknown-linux-gnu" -> {:unix, :linux}
-      "mipsisa32r6el-unknown-linux-gnu" -> {:unix, :linux}
-      "mipsisa64r6-unknown-linux-gnuabi64" -> {:unix, :linux}
-      "mipsisa64r6el-unknown-linux-gnuabi64" -> {:unix, :linux}
-      "msp430-none-elf" -> {:unix, :linux}
-      "nvptx64-nvidia-cuda" -> {:unix, :linux}
-      "powerpc-unknown-freebsd" -> {:unix, :freebsd}
-      "powerpc-unknown-linux-gnu" -> {:unix, :linux}
-      "powerpc-unknown-linux-gnuspe" -> {:unix, :linux}
-      "powerpc-unknown-linux-musl" -> {:unix, :linux}
-      "powerpc-unknown-netbsd" -> {:unix, :netbsd}
-      "powerpc-unknown-openbsd" -> {:unix, :openbsd}
-      "powerpc-wrs-vxworks" -> {:unix, :linux}
-      "powerpc-wrs-vxworks-spe" -> {:unix, :linux}
-      "powerpc64-unknown-freebsd" -> {:unix, :freebsd}
-      "powerpc64-unknown-linux-gnu" -> {:unix, :linux}
-      "powerpc64-unknown-linux-musl" -> {:unix, :linux}
-      "powerpc64-wrs-vxworks" -> {:unix, :linux}
-      "powerpc64le-unknown-freebsd" -> {:unix, :freebsd}
-      "powerpc64le-unknown-linux-gnu" -> {:unix, :linux}
-      "powerpc64le-unknown-linux-musl" -> {:unix, :linux}
-      "riscv32gc-unknown-linux-gnu" -> {:unix, :linux}
-      "riscv32gc-unknown-linux-musl" -> {:unix, :linux}
-      "riscv32i-unknown-none-elf" -> {:unix, :linux}
-      "riscv32imac-unknown-none-elf" -> {:unix, :linux}
-      "riscv32imc-esp-espidf" -> {:unix, :linux}
-      "riscv32imc-unknown-none-elf" -> {:unix, :linux}
-      "riscv64gc-unknown-linux-gnu" -> {:unix, :linux}
-      "riscv64gc-unknown-linux-musl" -> {:unix, :linux}
-      "riscv64gc-unknown-none-elf" -> {:unix, :linux}
-      "riscv64imac-unknown-none-elf" -> {:unix, :linux}
-      "s390x-unknown-linux-gnu" -> {:unix, :linux}
-      "s390x-unknown-linux-musl" -> {:unix, :linux}
-      "sparc-unknown-linux-gnu" -> {:unix, :linux}
-      "sparc64-unknown-linux-gnu" -> {:unix, :linux}
-      "sparc64-unknown-netbsd" -> {:unix, :netbsd}
-      "sparc64-unknown-openbsd" -> {:unix, :openbsd}
-      "sparcv9-sun-solaris" -> {:unix, :sunos}
-      "thumbv4t-none-eabi" -> {:unix, :linux}
-      "thumbv6m-none-eabi" -> {:unix, :linux}
-      "thumbv7a-pc-windows-msvc" -> {:win32, :nt}
-      "thumbv7a-uwp-windows-msvc" -> {:win32, :nt}
-      "thumbv7em-none-eabi" -> {:unix, :linux}
-      "thumbv7em-none-eabihf" -> {:unix, :linux}
-      "thumbv7m-none-eabi" -> {:unix, :linux}
-      "thumbv7neon-linux-androideabi" -> {:unix, :linux}
-      "thumbv7neon-unknown-linux-gnueabihf" -> {:unix, :linux}
-      "thumbv7neon-unknown-linux-musleabihf" -> {:unix, :linux}
-      "thumbv8m.base-none-eabi" -> {:unix, :linux}
-      "thumbv8m.main-none-eabi" -> {:unix, :linux}
-      "thumbv8m.main-none-eabihf" -> {:unix, :linux}
-      "wasm32-unknown-emscripten" -> {:unix, :linux}
-      "wasm32-unknown-unknown" -> {:unix, :linux}
-      "wasm32-wasi" -> {:unix, :linux}
-      "wasm64-unknown-unknown" -> {:unix, :linux}
-      "x86_64-apple-darwin" -> {:unix, :darwin}
-      "x86_64-apple-ios" -> {:unix, :darwin}
-      "x86_64-apple-ios-macabi" -> {:unix, :darwin}
-      "x86_64-apple-tvos" -> {:unix, :darwin}
-      "x86_64-fortanix-unknown-sgx" -> {:unix, :linux}
-      "x86_64-fuchsia" -> {:unix, :linux}
-      "x86_64-linux-android" -> {:unix, :linux}
-      "x86_64-pc-solaris" -> {:unix, :linux}
-      "x86_64-pc-windows-gnu" -> {:win32, :nt}
-      "x86_64-pc-windows-msvc" -> {:win32, :nt}
-      "x86_64-sun-solaris" -> {:unix, :sunos}
-      "x86_64-unknown-dragonfly" -> {:unix, :linux}
-      "x86_64-unknown-freebsd" -> {:unix, :freebsd}
-      "x86_64-unknown-haiku" -> {:unix, :linux}
-      "x86_64-unknown-hermit" -> {:unix, :linux}
-      "x86_64-unknown-illumos" -> {:unix, :linux}
-      "x86_64-unknown-l4re-uclibc" -> {:unix, :linux}
-      "x86_64-unknown-linux-gnu" -> {:unix, :linux}
-      "x86_64-unknown-linux-gnux32" -> {:unix, :linux}
-      "x86_64-unknown-linux-musl" -> {:unix, :linux}
-      "x86_64-unknown-netbsd" -> {:unix, :netbsd}
-      "x86_64-unknown-none-hermitkernel" -> {:unix, :linux}
-      "x86_64-unknown-none-linuxkernel" -> {:unix, :linux}
-      "x86_64-unknown-openbsd" -> {:unix, :openbsd}
-      "x86_64-unknown-redox" -> {:unix, :linux}
-      "x86_64-unknown-uefi" -> {:unix, :linux}
-      "x86_64-uwp-windows-gnu" -> {:win32, :nt}
-      "x86_64-uwp-windows-msvc" -> {:win32, :nt}
-      "x86_64-wrs-vxworks" -> {:unix, :linux}
+    os_type =
+      [
+        %{pattern: ~r/.*-linux.*/, os_type: {:unix, :linux}},
+        %{pattern: ~r/.*-windows.*/, os_type: {:win32, :nt}},
+        %{pattern: ~r/.*-apple.*/, os_type: {:unix, :darwin}},
+        %{pattern: ~r/.*-freebsd.*/, os_type: {:unix, :freebsd}},
+        %{pattern: ~r/.*-netbsd.*/, os_type: {:unix, :netbsd}},
+        %{pattern: ~r/.*-openbsd.*/, os_type: {:unix, :openbsd}},
+        %{pattern: ~r/.*-solaris.*/, os_type: {:unix, :solaris}}
+      ]
+      |> Enum.map(&%{matched: Regex.match?(&1.pattern, target), os_type: &1.os_type})
+      |> Enum.reject(&(&1.matched == false))
+      |> Enum.map(& &1.os_type)
+
+    if Enum.count(os_type) == 1 do
+      Enum.at(os_type, 0)
+    else
+      throw_error({:unknown_target, target})
     end
   end
 

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -122,6 +122,10 @@ defmodule Rustler.Compiler do
   defp make_build_mode_flag(args, :release), do: args ++ ["--release"]
   defp make_build_mode_flag(args, :debug), do: args
 
+  defp get_target_os_type(nil) do
+    :os.type()
+  end
+
   defp get_target_os_type(target) when is_binary(target) do
     case target do
       "aarch64-apple-darwin" -> {:unix, :darwin}
@@ -132,15 +136,15 @@ defmodule Rustler.Compiler do
       "aarch64-fuchsia" -> {:unix, :linux}
       "aarch64-linux-android" -> {:unix, :linux}
       "aarch64-pc-windows-msvc" -> {:win32, :nt}
-      "aarch64-unknown-freebsd" -> {:unix, :bsd}
+      "aarch64-unknown-freebsd" -> {:unix, :freebsd}
       "aarch64-unknown-hermit" -> {:unix, :linux}
       "aarch64-unknown-linux-gnu" -> {:unix, :linux}
       "aarch64-unknown-linux-gnu_ilp32" -> {:unix, :linux}
       "aarch64-unknown-linux-musl" -> {:unix, :linux}
-      "aarch64-unknown-netbsd" -> {:unix, :bsd}
+      "aarch64-unknown-netbsd" -> {:unix, :netbsd}
       "aarch64-unknown-none" -> {:unix, :linux}
       "aarch64-unknown-none-softfloat" -> {:unix, :linux}
-      "aarch64-unknown-openbsd" -> {:unix, :linux}
+      "aarch64-unknown-openbsd" -> {:unix, :openbsd}
       "aarch64-unknown-redox" -> {:unix, :linux}
       "aarch64-unknown-uefi" -> {:unix, :linux}
       "aarch64-uwp-windows-msvc" -> {:win32, :nt}
@@ -158,16 +162,16 @@ defmodule Rustler.Compiler do
       "armv5te-unknown-linux-gnueabi" -> {:unix, :linux}
       "armv5te-unknown-linux-musleabi" -> {:unix, :linux}
       "armv5te-unknown-linux-uclibceabi" -> {:unix, :linux}
-      "armv6-unknown-freebsd" -> {:unix, :bsd}
-      "armv6-unknown-netbsd-eabihf" -> {:unix, :bsd}
+      "armv6-unknown-freebsd" -> {:unix, :freebsd}
+      "armv6-unknown-netbsd-eabihf" -> {:unix, :netbsd}
       "armv7-apple-ios" -> {:unix, :darwin}
       "armv7-linux-androideabi" -> {:unix, :linux}
-      "armv7-unknown-freebsd" -> {:unix, :bsd}
+      "armv7-unknown-freebsd" -> {:unix, :freebsd}
       "armv7-unknown-linux-gnueabi" -> {:unix, :linux}
       "armv7-unknown-linux-gnueabihf" -> {:unix, :linux}
       "armv7-unknown-linux-musleabi" -> {:unix, :linux}
       "armv7-unknown-linux-musleabihf" -> {:unix, :linux}
-      "armv7-unknown-netbsd-eabihf" -> {:unix, :bsd}
+      "armv7-unknown-netbsd-eabihf" -> {:unix, :netbsd}
       "armv7-wrs-vxworks-eabihf" -> {:unix, :linux}
       "armv7a-none-eabi" -> {:unix, :linux}
       "armv7a-none-eabihf" -> {:unix, :linux}
@@ -187,12 +191,12 @@ defmodule Rustler.Compiler do
       "i686-linux-android" -> {:unix, :linux}
       "i686-pc-windows-gnu" -> {:win32, :nt}
       "i686-pc-windows-msvc" -> {:win32, :nt}
-      "i686-unknown-freebsd" -> {:unix, :bsd}
+      "i686-unknown-freebsd" -> {:unix, :freebsd}
       "i686-unknown-haiku" -> {:unix, :linux}
       "i686-unknown-linux-gnu" -> {:unix, :linux}
       "i686-unknown-linux-musl" -> {:unix, :linux}
-      "i686-unknown-netbsd" -> {:unix, :bsd}
-      "i686-unknown-openbsd" -> {:unix, :linux}
+      "i686-unknown-netbsd" -> {:unix, :netbsd}
+      "i686-unknown-openbsd" -> {:unix, :openbsd}
       "i686-unknown-uefi" -> {:unix, :linux}
       "i686-uwp-windows-gnu" -> {:win32, :nt}
       "i686-uwp-windows-msvc" -> {:win32, :nt}
@@ -215,19 +219,19 @@ defmodule Rustler.Compiler do
       "mipsisa64r6el-unknown-linux-gnuabi64" -> {:unix, :linux}
       "msp430-none-elf" -> {:unix, :linux}
       "nvptx64-nvidia-cuda" -> {:unix, :linux}
-      "powerpc-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc-unknown-freebsd" -> {:unix, :freebsd}
       "powerpc-unknown-linux-gnu" -> {:unix, :linux}
       "powerpc-unknown-linux-gnuspe" -> {:unix, :linux}
       "powerpc-unknown-linux-musl" -> {:unix, :linux}
-      "powerpc-unknown-netbsd" -> {:unix, :bsd}
-      "powerpc-unknown-openbsd" -> {:unix, :linux}
+      "powerpc-unknown-netbsd" -> {:unix, :netbsd}
+      "powerpc-unknown-openbsd" -> {:unix, :openbsd}
       "powerpc-wrs-vxworks" -> {:unix, :linux}
       "powerpc-wrs-vxworks-spe" -> {:unix, :linux}
-      "powerpc64-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc64-unknown-freebsd" -> {:unix, :freebsd}
       "powerpc64-unknown-linux-gnu" -> {:unix, :linux}
       "powerpc64-unknown-linux-musl" -> {:unix, :linux}
       "powerpc64-wrs-vxworks" -> {:unix, :linux}
-      "powerpc64le-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc64le-unknown-freebsd" -> {:unix, :freebsd}
       "powerpc64le-unknown-linux-gnu" -> {:unix, :linux}
       "powerpc64le-unknown-linux-musl" -> {:unix, :linux}
       "riscv32gc-unknown-linux-gnu" -> {:unix, :linux}
@@ -244,8 +248,8 @@ defmodule Rustler.Compiler do
       "s390x-unknown-linux-musl" -> {:unix, :linux}
       "sparc-unknown-linux-gnu" -> {:unix, :linux}
       "sparc64-unknown-linux-gnu" -> {:unix, :linux}
-      "sparc64-unknown-netbsd" -> {:unix, :bsd}
-      "sparc64-unknown-openbsd" -> {:unix, :linux}
+      "sparc64-unknown-netbsd" -> {:unix, :netbsd}
+      "sparc64-unknown-openbsd" -> {:unix, :openbsd}
       "sparcv9-sun-solaris" -> {:unix, :sunos}
       "thumbv4t-none-eabi" -> {:unix, :linux}
       "thumbv6m-none-eabi" -> {:unix, :linux}
@@ -276,7 +280,7 @@ defmodule Rustler.Compiler do
       "x86_64-pc-windows-msvc" -> {:win32, :nt}
       "x86_64-sun-solaris" -> {:unix, :sunos}
       "x86_64-unknown-dragonfly" -> {:unix, :linux}
-      "x86_64-unknown-freebsd" -> {:unix, :bsd}
+      "x86_64-unknown-freebsd" -> {:unix, :freebsd}
       "x86_64-unknown-haiku" -> {:unix, :linux}
       "x86_64-unknown-hermit" -> {:unix, :linux}
       "x86_64-unknown-illumos" -> {:unix, :linux}
@@ -284,20 +288,16 @@ defmodule Rustler.Compiler do
       "x86_64-unknown-linux-gnu" -> {:unix, :linux}
       "x86_64-unknown-linux-gnux32" -> {:unix, :linux}
       "x86_64-unknown-linux-musl" -> {:unix, :linux}
-      "x86_64-unknown-netbsd" -> {:unix, :bsd}
+      "x86_64-unknown-netbsd" -> {:unix, :netbsd}
       "x86_64-unknown-none-hermitkernel" -> {:unix, :linux}
       "x86_64-unknown-none-linuxkernel" -> {:unix, :linux}
-      "x86_64-unknown-openbsd" -> {:unix, :linux}
+      "x86_64-unknown-openbsd" -> {:unix, :openbsd}
       "x86_64-unknown-redox" -> {:unix, :linux}
       "x86_64-unknown-uefi" -> {:unix, :linux}
       "x86_64-uwp-windows-gnu" -> {:win32, :nt}
       "x86_64-uwp-windows-msvc" -> {:win32, :nt}
       "x86_64-wrs-vxworks" -> {:unix, :linux}
     end
-  end
-
-  defp get_target_os_type(_) do
-    :os.type()
   end
 
   defp handle_artifacts(path, config) do
@@ -307,7 +307,7 @@ defmodule Rustler.Compiler do
 
     output_dir =
       if is_binary(target) do
-        Path.join([config.target, Atom.to_string(config.mode)])
+        Path.join([target, Atom.to_string(config.mode)])
       else
         Atom.to_string(config.mode)
       end
@@ -351,6 +351,7 @@ defmodule Rustler.Compiler do
 
   defp make_file_names(base_name, :lib, target) do
     suffix = get_suffix(target, :lib)
+
     case get_target_os_type(target) do
       {:win32, _} -> {"#{base_name}.#{suffix}", "lib#{base_name}.dll"}
       {:unix, :darwin} -> {"lib#{base_name}.#{suffix}", "lib#{base_name}.so"}
@@ -360,6 +361,7 @@ defmodule Rustler.Compiler do
 
   defp make_file_names(base_name, :bin, target) do
     suffix = get_suffix(target, :bin)
+
     case get_target_os_type(target) do
       {:win32, _} -> {"#{base_name}.#{suffix}", "#{base_name}.exe"}
       {:unix, _} -> {base_name, base_name}

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -137,7 +137,7 @@ defmodule Rustler.Compiler do
         %{pattern: ~r/.*-openbsd.*/, os_type: {:unix, :openbsd}},
         %{pattern: ~r/.*-solaris.*/, os_type: {:unix, :solaris}}
       ]
-      |> Enum.find(&(Regex.match?(&1.pattern, target)))
+      |> Enum.find(&Regex.match?(&1.pattern, target))
 
     if os_type do
       os_type.os_type

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -143,7 +143,10 @@ defmodule Rustler.Compiler do
     if os_type do
       os_type.os_type
     else
-      throw_error({:unknown_target, target})
+      throw_error(
+        {:unknown_target,
+         "#{target} is not in the support list yet, we'd like to investigate on this if you agree to report this error to https://github.com/rusterlium/rustler/issues"}
+      )
     end
   end
 

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -145,7 +145,7 @@ defmodule Rustler.Compiler do
     else
       throw_error(
         {:unknown_target,
-         "#{target} is not in the support list yet, we'd like to investigate on this if you agree to report this error to https://github.com/rusterlium/rustler/issues"}
+         "#{target} is not in the support list yet. Please report it on https://github.com/rusterlium/rustler/issues."}
       )
     end
   end

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -137,8 +137,7 @@ defmodule Rustler.Compiler do
         %{pattern: ~r/.*-openbsd.*/, os_type: {:unix, :openbsd}},
         %{pattern: ~r/.*-solaris.*/, os_type: {:unix, :solaris}}
       ]
-      |> Enum.map(&%{matched: Regex.match?(&1.pattern, target), os_type: &1.os_type})
-      |> Enum.find(&(&1.matched == true))
+      |> Enum.find(&(Regex.match?(&1.pattern, target)))
 
     if os_type do
       os_type.os_type

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -122,13 +122,199 @@ defmodule Rustler.Compiler do
   defp make_build_mode_flag(args, :release), do: args ++ ["--release"]
   defp make_build_mode_flag(args, :debug), do: args
 
+  defp get_target_os_type(target) when is_binary(target) do
+    case target do
+      "aarch64-apple-darwin" -> {:unix, :darwin}
+      "aarch64-apple-ios" -> {:unix, :darwin}
+      "aarch64-apple-ios-macabi" -> {:unix, :darwin}
+      "aarch64-apple-ios-sim" -> {:unix, :darwin}
+      "aarch64-apple-tvos" -> {:unix, :darwin}
+      "aarch64-fuchsia" -> {:unix, :linux}
+      "aarch64-linux-android" -> {:unix, :linux}
+      "aarch64-pc-windows-msvc" -> {:win32, :nt}
+      "aarch64-unknown-freebsd" -> {:unix, :bsd}
+      "aarch64-unknown-hermit" -> {:unix, :linux}
+      "aarch64-unknown-linux-gnu" -> {:unix, :linux}
+      "aarch64-unknown-linux-gnu_ilp32" -> {:unix, :linux}
+      "aarch64-unknown-linux-musl" -> {:unix, :linux}
+      "aarch64-unknown-netbsd" -> {:unix, :bsd}
+      "aarch64-unknown-none" -> {:unix, :linux}
+      "aarch64-unknown-none-softfloat" -> {:unix, :linux}
+      "aarch64-unknown-openbsd" -> {:unix, :linux}
+      "aarch64-unknown-redox" -> {:unix, :linux}
+      "aarch64-unknown-uefi" -> {:unix, :linux}
+      "aarch64-uwp-windows-msvc" -> {:win32, :nt}
+      "aarch64-wrs-vxworks" -> {:unix, :linux}
+      "aarch64_be-unknown-linux-gnu" -> {:unix, :linux}
+      "aarch64_be-unknown-linux-gnu_ilp32" -> {:unix, :linux}
+      "arm-linux-androideabi" -> {:unix, :linux}
+      "arm-unknown-linux-gnueabi" -> {:unix, :linux}
+      "arm-unknown-linux-gnueabihf" -> {:unix, :linux}
+      "arm-unknown-linux-musleabi" -> {:unix, :linux}
+      "arm-unknown-linux-musleabihf" -> {:unix, :linux}
+      "armebv7r-none-eabi" -> {:unix, :linux}
+      "armebv7r-none-eabihf" -> {:unix, :linux}
+      "armv4t-unknown-linux-gnueabi" -> {:unix, :linux}
+      "armv5te-unknown-linux-gnueabi" -> {:unix, :linux}
+      "armv5te-unknown-linux-musleabi" -> {:unix, :linux}
+      "armv5te-unknown-linux-uclibceabi" -> {:unix, :linux}
+      "armv6-unknown-freebsd" -> {:unix, :bsd}
+      "armv6-unknown-netbsd-eabihf" -> {:unix, :bsd}
+      "armv7-apple-ios" -> {:unix, :darwin}
+      "armv7-linux-androideabi" -> {:unix, :linux}
+      "armv7-unknown-freebsd" -> {:unix, :bsd}
+      "armv7-unknown-linux-gnueabi" -> {:unix, :linux}
+      "armv7-unknown-linux-gnueabihf" -> {:unix, :linux}
+      "armv7-unknown-linux-musleabi" -> {:unix, :linux}
+      "armv7-unknown-linux-musleabihf" -> {:unix, :linux}
+      "armv7-unknown-netbsd-eabihf" -> {:unix, :bsd}
+      "armv7-wrs-vxworks-eabihf" -> {:unix, :linux}
+      "armv7a-none-eabi" -> {:unix, :linux}
+      "armv7a-none-eabihf" -> {:unix, :linux}
+      "armv7r-none-eabi" -> {:unix, :linux}
+      "armv7r-none-eabihf" -> {:unix, :linux}
+      "armv7s-apple-ios" -> {:unix, :darwin}
+      "asmjs-unknown-emscripten" -> {:unix, :linux}
+      "avr-unknown-gnu-atmega328" -> {:unix, :linux}
+      "bpfeb-unknown-none" -> {:unix, :linux}
+      "bpfel-unknown-none" -> {:unix, :linux}
+      "hexagon-unknown-linux-musl" -> {:unix, :linux}
+      "i386-apple-ios" -> {:unix, :darwin}
+      "i586-pc-windows-msvc" -> {:win32, :nt}
+      "i586-unknown-linux-gnu" -> {:unix, :linux}
+      "i586-unknown-linux-musl" -> {:unix, :linux}
+      "i686-apple-darwin" -> {:unix, :darwin}
+      "i686-linux-android" -> {:unix, :linux}
+      "i686-pc-windows-gnu" -> {:win32, :nt}
+      "i686-pc-windows-msvc" -> {:win32, :nt}
+      "i686-unknown-freebsd" -> {:unix, :bsd}
+      "i686-unknown-haiku" -> {:unix, :linux}
+      "i686-unknown-linux-gnu" -> {:unix, :linux}
+      "i686-unknown-linux-musl" -> {:unix, :linux}
+      "i686-unknown-netbsd" -> {:unix, :bsd}
+      "i686-unknown-openbsd" -> {:unix, :linux}
+      "i686-unknown-uefi" -> {:unix, :linux}
+      "i686-uwp-windows-gnu" -> {:win32, :nt}
+      "i686-uwp-windows-msvc" -> {:win32, :nt}
+      "i686-wrs-vxworks" -> {:unix, :linux}
+      "mips-unknown-linux-gnu" -> {:unix, :linux}
+      "mips-unknown-linux-musl" -> {:unix, :linux}
+      "mips-unknown-linux-uclibc" -> {:unix, :linux}
+      "mips64-unknown-linux-gnuabi64" -> {:unix, :linux}
+      "mips64-unknown-linux-muslabi64" -> {:unix, :linux}
+      "mips64el-unknown-linux-gnuabi64" -> {:unix, :linux}
+      "mips64el-unknown-linux-muslabi64" -> {:unix, :linux}
+      "mipsel-sony-psp" -> {:unix, :linux}
+      "mipsel-unknown-linux-gnu" -> {:unix, :linux}
+      "mipsel-unknown-linux-musl" -> {:unix, :linux}
+      "mipsel-unknown-linux-uclibc" -> {:unix, :linux}
+      "mipsel-unknown-none" -> {:unix, :linux}
+      "mipsisa32r6-unknown-linux-gnu" -> {:unix, :linux}
+      "mipsisa32r6el-unknown-linux-gnu" -> {:unix, :linux}
+      "mipsisa64r6-unknown-linux-gnuabi64" -> {:unix, :linux}
+      "mipsisa64r6el-unknown-linux-gnuabi64" -> {:unix, :linux}
+      "msp430-none-elf" -> {:unix, :linux}
+      "nvptx64-nvidia-cuda" -> {:unix, :linux}
+      "powerpc-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc-unknown-linux-gnu" -> {:unix, :linux}
+      "powerpc-unknown-linux-gnuspe" -> {:unix, :linux}
+      "powerpc-unknown-linux-musl" -> {:unix, :linux}
+      "powerpc-unknown-netbsd" -> {:unix, :bsd}
+      "powerpc-unknown-openbsd" -> {:unix, :linux}
+      "powerpc-wrs-vxworks" -> {:unix, :linux}
+      "powerpc-wrs-vxworks-spe" -> {:unix, :linux}
+      "powerpc64-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc64-unknown-linux-gnu" -> {:unix, :linux}
+      "powerpc64-unknown-linux-musl" -> {:unix, :linux}
+      "powerpc64-wrs-vxworks" -> {:unix, :linux}
+      "powerpc64le-unknown-freebsd" -> {:unix, :bsd}
+      "powerpc64le-unknown-linux-gnu" -> {:unix, :linux}
+      "powerpc64le-unknown-linux-musl" -> {:unix, :linux}
+      "riscv32gc-unknown-linux-gnu" -> {:unix, :linux}
+      "riscv32gc-unknown-linux-musl" -> {:unix, :linux}
+      "riscv32i-unknown-none-elf" -> {:unix, :linux}
+      "riscv32imac-unknown-none-elf" -> {:unix, :linux}
+      "riscv32imc-esp-espidf" -> {:unix, :linux}
+      "riscv32imc-unknown-none-elf" -> {:unix, :linux}
+      "riscv64gc-unknown-linux-gnu" -> {:unix, :linux}
+      "riscv64gc-unknown-linux-musl" -> {:unix, :linux}
+      "riscv64gc-unknown-none-elf" -> {:unix, :linux}
+      "riscv64imac-unknown-none-elf" -> {:unix, :linux}
+      "s390x-unknown-linux-gnu" -> {:unix, :linux}
+      "s390x-unknown-linux-musl" -> {:unix, :linux}
+      "sparc-unknown-linux-gnu" -> {:unix, :linux}
+      "sparc64-unknown-linux-gnu" -> {:unix, :linux}
+      "sparc64-unknown-netbsd" -> {:unix, :bsd}
+      "sparc64-unknown-openbsd" -> {:unix, :linux}
+      "sparcv9-sun-solaris" -> {:unix, :sunos}
+      "thumbv4t-none-eabi" -> {:unix, :linux}
+      "thumbv6m-none-eabi" -> {:unix, :linux}
+      "thumbv7a-pc-windows-msvc" -> {:win32, :nt}
+      "thumbv7a-uwp-windows-msvc" -> {:win32, :nt}
+      "thumbv7em-none-eabi" -> {:unix, :linux}
+      "thumbv7em-none-eabihf" -> {:unix, :linux}
+      "thumbv7m-none-eabi" -> {:unix, :linux}
+      "thumbv7neon-linux-androideabi" -> {:unix, :linux}
+      "thumbv7neon-unknown-linux-gnueabihf" -> {:unix, :linux}
+      "thumbv7neon-unknown-linux-musleabihf" -> {:unix, :linux}
+      "thumbv8m.base-none-eabi" -> {:unix, :linux}
+      "thumbv8m.main-none-eabi" -> {:unix, :linux}
+      "thumbv8m.main-none-eabihf" -> {:unix, :linux}
+      "wasm32-unknown-emscripten" -> {:unix, :linux}
+      "wasm32-unknown-unknown" -> {:unix, :linux}
+      "wasm32-wasi" -> {:unix, :linux}
+      "wasm64-unknown-unknown" -> {:unix, :linux}
+      "x86_64-apple-darwin" -> {:unix, :darwin}
+      "x86_64-apple-ios" -> {:unix, :darwin}
+      "x86_64-apple-ios-macabi" -> {:unix, :darwin}
+      "x86_64-apple-tvos" -> {:unix, :darwin}
+      "x86_64-fortanix-unknown-sgx" -> {:unix, :linux}
+      "x86_64-fuchsia" -> {:unix, :linux}
+      "x86_64-linux-android" -> {:unix, :linux}
+      "x86_64-pc-solaris" -> {:unix, :linux}
+      "x86_64-pc-windows-gnu" -> {:win32, :nt}
+      "x86_64-pc-windows-msvc" -> {:win32, :nt}
+      "x86_64-sun-solaris" -> {:unix, :sunos}
+      "x86_64-unknown-dragonfly" -> {:unix, :linux}
+      "x86_64-unknown-freebsd" -> {:unix, :bsd}
+      "x86_64-unknown-haiku" -> {:unix, :linux}
+      "x86_64-unknown-hermit" -> {:unix, :linux}
+      "x86_64-unknown-illumos" -> {:unix, :linux}
+      "x86_64-unknown-l4re-uclibc" -> {:unix, :linux}
+      "x86_64-unknown-linux-gnu" -> {:unix, :linux}
+      "x86_64-unknown-linux-gnux32" -> {:unix, :linux}
+      "x86_64-unknown-linux-musl" -> {:unix, :linux}
+      "x86_64-unknown-netbsd" -> {:unix, :bsd}
+      "x86_64-unknown-none-hermitkernel" -> {:unix, :linux}
+      "x86_64-unknown-none-linuxkernel" -> {:unix, :linux}
+      "x86_64-unknown-openbsd" -> {:unix, :linux}
+      "x86_64-unknown-redox" -> {:unix, :linux}
+      "x86_64-unknown-uefi" -> {:unix, :linux}
+      "x86_64-uwp-windows-gnu" -> {:win32, :nt}
+      "x86_64-uwp-windows-msvc" -> {:win32, :nt}
+      "x86_64-wrs-vxworks" -> {:unix, :linux}
+    end
+  end
+
+  defp get_target_os_type(_) do
+    :os.type()
+  end
+
   defp handle_artifacts(path, config) do
     toml = toml_data(path)
+    target = config.target
     names = get_name(toml, :lib) ++ get_name(toml, :bin)
 
+    output_dir =
+      if is_binary(target) do
+        config.target <> "/" <> Atom.to_string(config.mode)
+      else
+        Atom.to_string(config.mode)
+      end
+
     Enum.each(names, fn {name, type} ->
-      {src_file, dst_file} = make_file_names(name, type)
-      compiled_lib = Path.join([config.target_dir, Atom.to_string(config.mode), src_file])
+      {src_file, dst_file} = make_file_names(name, type, target)
+      compiled_lib = Path.join([config.target_dir, output_dir, src_file])
       destination_lib = Path.join(priv_dir(), dst_file)
 
       # If the file exists already, we delete it first. This is to ensure that another
@@ -148,17 +334,34 @@ defmodule Rustler.Compiler do
     end
   end
 
-  defp make_file_names(base_name, :lib) do
-    case :os.type() do
-      {:win32, _} -> {"#{base_name}.dll", "lib#{base_name}.dll"}
-      {:unix, :darwin} -> {"lib#{base_name}.dylib", "lib#{base_name}.so"}
-      {:unix, _} -> {"lib#{base_name}.so", "lib#{base_name}.so"}
+  defp get_suffix(target, :lib) do
+    case get_target_os_type(target) do
+      {:win32, _} -> "dll"
+      {:unix, :darwin} -> "dylib"
+      {:unix, _} -> "so"
     end
   end
 
-  defp make_file_names(base_name, :bin) do
-    case :os.type() do
-      {:win32, _} -> {"#{base_name}.exe", "#{base_name}.exe"}
+  defp get_suffix(target, :bin) do
+    case get_target_os_type(target) do
+      {:win32, _} -> "exe"
+      {:unix, _} -> ""
+    end
+  end
+
+  defp make_file_names(base_name, :lib, target) do
+    suffix = get_suffix(target, :lib)
+    case get_target_os_type(target) do
+      {:win32, _} -> {"#{base_name}.#{suffix}", "lib#{base_name}.dll"}
+      {:unix, :darwin} -> {"lib#{base_name}.#{suffix}", "lib#{base_name}.so"}
+      {:unix, _} -> {"lib#{base_name}.#{suffix}", "lib#{base_name}.so"}
+    end
+  end
+
+  defp make_file_names(base_name, :bin, target) do
+    suffix = get_suffix(target, :bin)
+    case get_target_os_type(target) do
+      {:win32, _} -> {"#{base_name}.#{suffix}", "#{base_name}.exe"}
       {:unix, _} -> {base_name, base_name}
     end
   end


### PR DESCRIPTION
Hi, this PR aims to fix a small issue when `rustler` is used in a cross-compile environment, i.e., user sets the `target` option to a target triple that is different from the host. 

When cross-compiling from macOS to Linux, `make_file_names/2` will generate filenames based on the `:os.type/0`, which is the settings for the host.

This PR adds `get_target_os_type/1` to fetch the correct os type based on `target` for `make_file_names/2`. If `target` is not a string, i.e., user didn't set this option, then it fallbacks to use `:os.type/0`.

The target list is generated based on `rustc --print target-list`.

```
$ rustc --version
rustc 1.56.1 (59eed8a2a 2021-11-01)
```

Signed-off-by: Cocoa <r.xu.1@research.gla.ac.uk>