### PR TITLE
Relax Jason version requirement to ~> 1.0

### DIFF
--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -26,7 +26,7 @@ defmodule Rustler.Mixfile do
     [
       {:toml, "~> 0.5.2", runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:jason, "~> 1.2", runtime: false}
+      {:jason, "~> 1.0", runtime: false}
     ]
   end
 


### PR DESCRIPTION
Hello there 👋🏼 

This PR changes the required version of the `jason` dependency for `rustler_mix`. Translating the effect into more readable terms, it aims to do this:

```
      mix.exs  effective range
Old:  ~> 1.2   1.2.0 <= x < 2.0.0
New:  ~> 1.0   1.0.0 <= x < 2.0.0
```

Reading through the [`jason` changelog](https://github.com/michalmuskala/jason/blob/master/CHANGELOG.md), it does not appear that this library makes use of any changes that were made between `1.0` and `1.2`. The locked version of `jason` used during development of this library (`1.2.2`) will remain the same.

**Why?** This relaxed version requirement will make it less likely that users of rustler will need to override the version of `jason` used in their project. Occasionally another dependency will lock to a particular version of `jason` (in my case, something requires `1.1.0`). Without manual intervention, dependency installation will fail. (I'll also open a similar PR on other dependencies that have strict version requirements.)

Thank you for your consideration!