### PR TITLE
import NewBinary in lib

### DIFF
--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -38,7 +38,7 @@ mod term;
 
 pub use crate::term::Term;
 pub use crate::types::{
-    Atom, Binary, Decoder, Encoder, ListIterator, LocalPid, MapIterator, OwnedBinary,
+    Atom, Binary, Decoder, Encoder, ListIterator, LocalPid, MapIterator, NewBinary, OwnedBinary,
 };
 pub mod resource;
 pub use crate::resource::ResourceArc;

--- a/rustler/src/types/mod.rs
+++ b/rustler/src/types/mod.rs
@@ -5,7 +5,7 @@ pub mod atom;
 pub use crate::types::atom::Atom;
 
 pub mod binary;
-pub use crate::types::binary::{Binary, OwnedBinary};
+pub use crate::types::binary::{Binary, NewBinary, OwnedBinary};
 
 #[doc(hidden)]
 pub mod list;


### PR DESCRIPTION
Thank you for releasing 0.24.0

I tested it and it works great.

This pr just imports `NewBinary` into lib, so `NewBinary` can be imported as `use rustler::NewBinary` instead of `use rustler::types::binary::NewBinary`