### PR TITLE
Add `Term::map_from_pairs`

### DIFF
--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -25,6 +25,8 @@ impl<'a> Term<'a> {
     ///
     /// ### Elixir equivalent
     /// ```elixir
+    /// keys = ["foo", "bar"]
+    /// values = [1, 2]
     /// List.zip(keys, values) |> Map.new()
     /// ```
     pub fn map_from_arrays(
@@ -42,6 +44,28 @@ impl<'a> Term<'a> {
             }
         } else {
             Err(Error::BadArg)
+        }
+    }
+
+    /// Construct a new map from pairs of terms
+    ///
+    /// It is similar to `map_from_arrays` but
+    /// receives only one vector with the pairs
+    /// of `(key, value)`.
+    ///
+    /// ### Elixir equivalent
+    /// ```elixir
+    /// Map.new([{"foo", 1}, {"bar", 2}])
+    /// ```
+    pub fn map_from_pairs(env: Env<'a>, pairs: &[(Term<'a>, Term<'a>)]) -> NifResult<Term<'a>> {
+        let (keys, values): (Vec<_>, Vec<_>) = pairs
+            .iter()
+            .map(|(k, v)| (k.as_c_arg(), v.as_c_arg()))
+            .unzip();
+
+        unsafe {
+            map::make_map_from_arrays(env.as_c_arg(), &keys, &values)
+                .map_or_else(|| Err(Error::BadArg), |map| Ok(Term::new(env, map)))
         }
     }
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -29,6 +29,7 @@ defmodule RustlerTest do
   def sum_map_values(_), do: err()
   def map_entries_sorted(_), do: err()
   def map_from_arrays(_keys, _values), do: err()
+  def map_from_pairs(_pairs), do: err()
   def map_generic(_), do: err()
 
   def resource_make(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -31,6 +31,7 @@ rustler::init!(
         test_map::sum_map_values,
         test_map::map_entries_sorted,
         test_map::map_from_arrays,
+        test_map::map_from_pairs,
         test_map::map_generic,
         test_resource::resource_make,
         test_resource::resource_set_integer_field,

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -1,6 +1,6 @@
 use rustler::types::map::MapIterator;
 use rustler::types::tuple::make_tuple;
-use rustler::{Encoder, Env, NifResult, Term};
+use rustler::{Encoder, Env, Error, ListIterator, NifResult, Term};
 
 #[rustler::nif]
 pub fn sum_map_values(iter: MapIterator) -> NifResult<i64> {
@@ -33,6 +33,13 @@ pub fn map_from_arrays<'a>(
     values: Vec<Term<'a>>,
 ) -> NifResult<Term<'a>> {
     Term::map_from_arrays(env, &keys, &values)
+}
+
+#[rustler::nif]
+pub fn map_from_pairs<'a>(env: Env<'a>, pairs: ListIterator<'a>) -> NifResult<Term<'a>> {
+    let res: Result<Vec<(Term, Term)>, Error> = pairs.map(|x| x.decode()).collect();
+
+    res.and_then(|v| Term::map_from_pairs(env, &v))
 }
 
 #[rustler::nif]

--- a/rustler_tests/test/map_test.exs
+++ b/rustler_tests/test/map_test.exs
@@ -32,4 +32,34 @@ defmodule RustlerTest.MapTest do
       RustlerTest.map_generic(%{1 => "hello", not_a_number: "world"})
     end)
   end
+
+  test "map from pairs" do
+    pairs = []
+
+    assert %{} == RustlerTest.map_from_pairs(pairs)
+
+    pairs = [{"a", 1}, {"b", 7}, {"c", 6}, {"d", 0}, {"e", 4.1}, {"foo", "bar"}]
+
+    assert %{"d" => 0, "a" => 1, "b" => 7, "e" => 4.1, "c" => 6, "foo" => "bar"} ==
+             RustlerTest.map_from_pairs(pairs)
+
+    pairs = [foo: [complex: true], bar: %{"simple" => false}]
+
+    assert %{bar: %{"simple" => false}, foo: [complex: true]} ==
+             RustlerTest.map_from_pairs(pairs)
+  end
+
+  test "map from pairs with incorrect type" do
+    pairs = [{"a", 1}, {"b", 7}, {"c", 6}, {"d", 0}, nil]
+
+    assert_raise(ArgumentError, fn ->
+      RustlerTest.map_from_pairs(pairs)
+    end)
+
+    pairs = [false, true]
+
+    assert_raise(ArgumentError, fn ->
+      RustlerTest.map_from_pairs(pairs)
+    end)
+  end
 end


### PR DESCRIPTION
This function creates a new map based on a vector of tuples of terms.
It's an alternative to `Term::map_from_arrays`, but it can assert the
shape of pairs in compile time.