### PR TITLE
Fix snake case warnings for rust analyzer

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -126,7 +126,7 @@ impl<'a> Context<'a> {
     pub fn escape_ident_with_index(ident_str: &str, index: usize, infix: &str) -> Ident {
         Ident::new(
             &format!(
-                "RUSTLER_{}_field_{}_{}",
+                "rustler_{}_field_{}_{}",
                 infix,
                 index,
                 Self::remove_raw(ident_str)
@@ -137,7 +137,7 @@ impl<'a> Context<'a> {
 
     pub fn escape_ident(ident_str: &str, infix: &str) -> Ident {
         Ident::new(
-            &format!("RUSTLER_{}_field_{}", infix, Self::remove_raw(ident_str)),
+            &format!("rustler_{}_field_{}", infix, Self::remove_raw(ident_str)),
             Span::call_site(),
         )
     }


### PR DESCRIPTION
Those warnings are present when deriving from `NifStruct`.
The convention says that we can't mix
"SCREAMING_SNAKE_CASE_with_snake_case".
https://doc.rust-lang.org/1.0.0/style/style/naming/README.html

![lint-warning](https://user-images.githubusercontent.com/381213/159728884-f7925cfe-d6e4-4c67-b1d5-f898bcb24c35.png)
