### PR TITLE
Fix moving out terms

### DIFF
--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -108,7 +108,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                         T: rustler::Decoder<'a>,
                     {
                         use rustler::Encoder;
-                        match ::rustler::Decoder::decode(term.map_get(field)?) {
+                        match ::rustler::Decoder::decode(term.map_get(&field)?) {
                             Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(format!(
                                             "Could not decode field :{:?} on %{}{{}}",
                                             field, #struct_name_str

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -89,7 +89,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                         T: rustler::Decoder<'a>,
                     {
                         use rustler::Encoder;
-                        match ::rustler::Decoder::decode(term.map_get(field)?) {
+                        match ::rustler::Decoder::decode(term.map_get(&field)?) {
                             Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(format!(
                                             "Could not decode field :{:?} on %{{}}",
                                             field
@@ -118,7 +118,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             let atom_fun = Context::field_to_atom_fun(field);
 
             quote_spanned! { field.span() =>
-                map = map.map_put(#atom_fun(), self.#field_ident).unwrap();
+                map = map.map_put(#atom_fun(), &self.#field_ident).unwrap();
             }
         })
         .collect();

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -117,7 +117,7 @@ fn gen_decoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
                         T: ::rustler::Decoder<'a>,
                 {
                     use ::rustler::Encoder;
-                    match ::rustler::Decoder::decode(term.map_get(field)?) {
+                    match ::rustler::Decoder::decode(term.map_get(&field)?) {
                         Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(format!(
                                         "Could not decode field :{:?} on %{{}}",
                                         field


### PR DESCRIPTION
In #453 , I missed some codegen logic that moves certain terms. Originally, they were encoded and passed into the `map_put` or `map_get` function so the move operation occurs, but currently, they are just passed so the move occurs. So I fixed them to pass them as references.

Sorry for making errors! 