### PR TITLE
Prepare rustler_bigint release

### DIFF
--- a/rustler_bigint/Cargo.toml
+++ b/rustler_bigint/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "rustler_bigint"
+description = "Handle Erlang's arbitrarily-sized integers"
+repository = "https://github.com/rusterlium/rustler"
+authors = ["Thomas Timmer"]
+license = "MIT/Apache-2.0"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+readme = "README.md"
+keywords = ["bigint", "Erlang", "Elixir"]
 
 [dependencies]
 num-bigint = {version = "0.4"}
-rustler = {path = "../rustler"}
+rustler = {path = "../rustler", version = "0.25.0"}

--- a/rustler_bigint/README.md
+++ b/rustler_bigint/README.md
@@ -1,5 +1,9 @@
 # Rustler BigInt
 
+[Documentation](https://docs.rs/rustler_bigint/latest/rustler_bigint)
+[![Build Status](https://github.com/rusterlium/rustler/workflows/CI/badge.svg?branch=master)](https://github.com/rusterlium/rustler/actions/workflows/main.yml)
+[![Crates.io package version](https://img.shields.io/crates/v/rustler_bigint.svg)](https://crates.io/crates/rustler_bigint)
+
 `rustler_bigint` provides support for Erlang's arbitrarily-sized integers.
 
 ## Installation
@@ -17,7 +21,7 @@ Lets assume that we need to handle integers of variable size. Some might fit
 into Rust's `i64`, but others might not. For example:
 
 ```elixir
-large = 2**65 # This does not fit into i64, it is an Erlang big integer
+large = Bitwise.bsl(2, 65) # This does not fit into i64, it is an Erlang big integer
 ```
 
 In Rust, we can use `rustler_bigint::BigInt` to pass integer values of

--- a/rustler_bigint/README.md
+++ b/rustler_bigint/README.md
@@ -1,0 +1,34 @@
+# Rustler BigInt
+
+`rustler_bigint` provides support for Erlang's arbitrarily-sized integers.
+
+## Installation
+
+Add this to `Cargo.toml`:
+
+```toml
+[dependencies]
+rustler_bigint = { version = "0.1" }
+```
+
+## Example
+
+Lets assume that we need to handle integers of variable size. Some might fit
+into Rust's `i64`, but others might not. For example:
+
+```elixir
+large = 2**65 # This does not fit into i64, it is an Erlang big integer
+```
+
+In Rust, we can use `rustler_bigint::BigInt` to pass integer values of
+different sizes into a NIF. The type `rustler_bigint::BigInt` is a newtype
+wrapping `num_bigint::BigInt` and implements `std::ops::Deref`, so functions
+from `num_bigint::BigInt` can be called directly.
+
+```rust
+/// Simply echo `large` back to the caller.
+#[rustler::nif]
+pub fn handle_large(large: rustler_bigint::BigInt) -> NifResult<BigInt> {
+  Ok(large)
+}
+```

--- a/rustler_bigint/README.md
+++ b/rustler_bigint/README.md
@@ -32,7 +32,7 @@ from `num_bigint::BigInt` can be called directly.
 ```rust
 /// Simply echo `large` back to the caller.
 #[rustler::nif]
-pub fn handle_large(large: rustler_bigint::BigInt) -> NifResult<BigInt> {
+pub fn handle_large(large: rustler_bigint::BigInt) -> NifResult<rustler_bigint::BigInt> {
   Ok(large)
 }
 ```


### PR DESCRIPTION
This PR adds a `README.md` and relevant information in `Cargo.toml` to `rustler_bigint`. With that, we should be able to release the crate soon-ish as a v0.1. @thomas9911  please take a look if I missed something, or maybe if we should add additional information to the README.