### PR TITLE
Disambiguate `encode` and `decode`

### DIFF
--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -151,11 +151,11 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote_spanned! { field.span() => #field_source.encode(env) }
+            quote_spanned! { field.span() => ::rustler::Encoder::encode(&#field_source, env) }
         })
         .collect();
 
-    let tag_encoder = quote! { atom_tag().encode(env) };
+    let tag_encoder = quote! { ::rustler::Encoder::encode(&atom_tag(), env) };
 
     // Build a slice ast from the field_encoders
 

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -194,7 +194,7 @@ fn gen_unnamed_decoder<'a>(
             let i = i + 1;
             let ty = &f.ty;
             quote! {
-                <#ty>::decode(tuple[#i]).map_err(|_| ::rustler::Error::RaiseTerm(
+                <#ty as ::rustler::Decoder>::decode(tuple[#i]).map_err(|_| ::rustler::Error::RaiseTerm(
                     Box::new(format!("Could not decode field on position {}", #i))
                 ))?
             }

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -278,7 +278,7 @@ fn gen_named_decoder(
 
 fn gen_unit_encoder(enum_name: &Ident, variant_ident: &Ident, atom_fn: Ident) -> TokenStream {
     quote! {
-        #enum_name :: #variant_ident => #atom_fn().encode(env),
+        #enum_name :: #variant_ident => ::rustler::Encoder::encode(&#atom_fn(), env),
     }
 }
 
@@ -293,7 +293,7 @@ fn gen_unnamed_encoder(
         .map(|i| Ident::new(&format!("inner{}", i), Span::call_site()))
         .collect::<Vec<_>>();
     quote! {
-        #enum_name :: #variant_ident ( #(ref #inners),* ) => (#atom_fn(), #(#inners),*).encode(env),
+        #enum_name :: #variant_ident ( #(ref #inners),* ) => ::rustler::Encoder::encode(&(#atom_fn(), #(#inners),*), env),
     }
 }
 
@@ -331,7 +331,7 @@ fn gen_named_encoder(
         } => {
             let map = ::rustler::Term::map_from_arrays(env, &[#(#keys()),*], &[#(#values),*])
                 .expect("Failed to create map");
-            ::rustler::types::tuple::make_tuple(env, &[#atom_fn().encode(env), map])
+            ::rustler::types::tuple::make_tuple(env, &[::rustler::Encoder::encode(&#atom_fn(), env), map])
         }
     }
 }

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -121,7 +121,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote_spanned! { field.span() => #field_source.encode(env) }
+            quote_spanned! { field.span() => ::rustler::Encoder::encode(&#field_source, env) }
         })
         .collect();
 

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -114,7 +114,7 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
             let atom_fn = Ident::new(&format!("atom_{}", atom_str), Span::call_site());
 
             quote! {
-                #enum_name :: #variant_ident => #atom_fn().encode(env),
+                #enum_name :: #variant_ident => ::rustler::Encoder::encode(&#atom_fn(), env),
             }
         })
         .collect();

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -88,7 +88,7 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
             let variant_name = &variant.ident;
 
             quote! {
-                #enum_name :: #variant_name ( ref inner ) => inner.encode(env),
+                #enum_name :: #variant_name ( ref inner ) => ::rustler::Encoder::encode(&inner, env),
             }
         })
         .collect();

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -58,7 +58,7 @@ fn gen_decoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
             let field_type = &variant.fields.iter().next().unwrap().ty;
 
             quote! {
-                if let Ok(inner) = <#field_type>::decode(term) {
+                if let Ok(inner) = <#field_type as ::rustler::Decoder>::decode(term) {
                     return Ok( #enum_name :: #variant_name ( inner ) )
                 }
             }

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -4,13 +4,13 @@ use rustler::{
     NifUntaggedEnum,
 };
 
-/// A test trait for testing the ambiguity of `encode` and `decode`.
-pub trait TestMessage {
+/// A trait for testing the ambiguity of `encode` and `decode`.
+pub trait EmptyTranscoder {
     fn encode(&self);
     fn decode();
 }
 
-impl<T> TestMessage for T {
+impl<T> EmptyTranscoder for T {
     fn encode(&self) {}
     fn decode() {}
 }

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -4,6 +4,17 @@ use rustler::{
     NifUntaggedEnum,
 };
 
+/// A test trait for testing the ambiguity of `encode` and `decode`.
+pub trait TestMessage {
+    fn encode(&self);
+    fn decode();
+}
+
+impl<T> TestMessage for T {
+    fn encode(&self) {}
+    fn decode() {}
+}
+
 #[derive(NifTuple)]
 pub struct AddTuple {
     lhs: i32,


### PR DESCRIPTION
Since `encode` and `decode` are very common names, if any traits have those names that exist, the compiler complains about its ambiguity.