### PR TITLE
Fix clippy warning

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -102,7 +102,7 @@ use std::{
 /// See [module-level doc](index.html) for more information.
 pub struct OwnedBinary(ErlNifBinary);
 
-impl<'a> OwnedBinary {
+impl OwnedBinary {
     pub unsafe fn from_raw(inner: ErlNifBinary) -> OwnedBinary {
         OwnedBinary(inner)
     }

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -86,18 +86,11 @@ impl<'a> Decoder<'a> for ListIterator<'a> {
     }
 }
 
-//impl<'a, T> Encoder for Iterator<Item = T> where T: Encoder {
-//    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-//        let term_arr: Vec<NIF_TERM> =
-//            self.map(|x| x.encode(env).as_c_arg()).collect();
-//    }
-//}
-
-impl<'a, T> Encoder for Vec<T>
+impl<T> Encoder for Vec<T>
 where
     T: Encoder,
 {
-    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         self.as_slice().encode(env)
     }
 }
@@ -113,11 +106,11 @@ where
     }
 }
 
-impl<'a, T> Encoder for [T]
+impl<T> Encoder for [T]
 where
     T: Encoder,
 {
-    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
         unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
     }

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -160,7 +160,7 @@ fn gen_encoder(
     };
 
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_type {
+        impl ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
                 let mut map = ::rustler::types::map::map_new(env);

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -124,7 +124,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .collect();
 
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_type {
+        impl ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -165,7 +165,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 
     // The implementation itself
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_type {
+        impl ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
 

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -159,7 +159,7 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
         .collect();
 
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #enum_type {
+        impl ::rustler::Encoder for #enum_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
 

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -132,7 +132,7 @@ fn gen_encoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
 
     // The implementation itself
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_type {
+        impl ::rustler::Encoder for #struct_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use ::rustler::Encoder;
                 let arr = #field_list_ast;

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -120,7 +120,7 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
         .collect();
 
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #enum_type {
+        impl ::rustler::Encoder for #enum_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 use #atoms_module_name::*;
 

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -94,7 +94,7 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
         .collect();
 
     let gen = quote! {
-        impl<'b> ::rustler::Encoder for #enum_type {
+        impl ::rustler::Encoder for #enum_type {
             fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
                 match *self {
                     #(#variant_defs)*


### PR DESCRIPTION
By rust-lang/rust-clippy#8737, Clippy now warns cases about unused lifetime in the `impl` block.