### PR TITLE
Make map_from_arrays and map_from_pairs generic

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -102,7 +102,7 @@ use std::{
 /// See [module-level doc](index.html) for more information.
 pub struct OwnedBinary(ErlNifBinary);
 
-impl<'a> OwnedBinary {
+impl OwnedBinary {
     pub unsafe fn from_raw(inner: ErlNifBinary) -> OwnedBinary {
         OwnedBinary(inner)
     }

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -93,7 +93,7 @@ impl<'a> Decoder<'a> for ListIterator<'a> {
 //    }
 //}
 
-impl<'a, T> Encoder for Vec<T>
+impl<T> Encoder for Vec<T>
 where
     T: Encoder,
 {
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<'a, T> Encoder for [T]
+impl<T> Encoder for [T]
 where
     T: Encoder,
 {

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -62,11 +62,11 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// Map.new([{"foo", 1}, {"bar", 2}])
     /// ```
-    pub fn map_from_pairs<K, V, I>(env: Env<'a>, pairs: I) -> NifResult<Term<'a>>
+    pub fn map_from_pairs<'t, K, V, I>(env: Env<'a>, pairs: I) -> NifResult<Term<'a>>
     where
-        I: IntoIterator<Item = (K, V)>,
-        K: Encoder,
-        V: Encoder,
+        I: IntoIterator<Item = &'t (K, V)>,
+        K: Encoder + 't,
+        V: Encoder + 't,
     {
         let (keys, values): (Vec<_>, Vec<_>) = pairs
             .into_iter()

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -37,9 +37,10 @@ pub fn map_from_arrays<'a>(
 
 #[rustler::nif]
 pub fn map_from_pairs<'a>(env: Env<'a>, pairs: ListIterator<'a>) -> NifResult<Term<'a>> {
-    let res: Result<Vec<(Term, Term)>, Error> = pairs.map(|x| x.decode()).collect();
-
-    res.and_then(|v| Term::map_from_pairs(env, &v))
+    let res = pairs
+        .map(|x| x.decode())
+        .collect::<NifResult<Vec<(Term, Term)>>>()?;
+    Term::map_from_pairs(env, res)
 }
 
 #[rustler::nif]

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -37,10 +37,9 @@ pub fn map_from_arrays<'a>(
 
 #[rustler::nif]
 pub fn map_from_pairs<'a>(env: Env<'a>, pairs: ListIterator<'a>) -> NifResult<Term<'a>> {
-    let res = pairs
-        .map(|x| x.decode())
-        .collect::<NifResult<Vec<(Term, Term)>>>()?;
-    Term::map_from_pairs(env, res)
+    let res: Result<Vec<(Term, Term)>, Error> = pairs.map(|x| x.decode()).collect();
+
+    res.and_then(|v| Term::map_from_pairs(env, &v))
 }
 
 #[rustler::nif]


### PR DESCRIPTION
This PR makes the `map_from_arrays` and `map_from_pairs` accept values that can be turned into an iterator. This avoids additional allocations required to have a slice when calling these functions.