### PR TITLE
Add inline tags to commonly used functions

### DIFF
--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -48,6 +48,7 @@ pub struct SendError;
 
 impl<'a> Env<'a> {
     #[doc(hidden)]
+    #[inline]
     pub(crate) unsafe fn new_internal<T>(
         _lifetime_marker: &'a T,
         env: NIF_ENV,
@@ -69,11 +70,13 @@ impl<'a> Env<'a> {
     ///
     /// # Unsafe
     /// Don't create multiple `Env`s with the same lifetime.
+    #[inline]
     pub unsafe fn new<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> Env<'a> {
         Self::new_internal(_lifetime_marker, env, EnvKind::ProcessBound)
     }
 
     #[doc(hidden)]
+    #[inline]
     pub unsafe fn new_init_env<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> Env<'a> {
         Self::new_internal(_lifetime_marker, env, EnvKind::Init)
     }
@@ -83,6 +86,7 @@ impl<'a> Env<'a> {
     }
 
     /// Convenience method for building a tuple `{error, Reason}`.
+    #[inline]
     pub fn error_tuple(self, reason: impl Encoder) -> Term<'a> {
         let error = crate::types::atom::error().to_term(self);
         (error, reason).encode(self)
@@ -101,6 +105,7 @@ impl<'a> Env<'a> {
     ///
     /// The result indicates whether the send was successful, see also
     /// [enif\_send](https://www.erlang.org/doc/man/erl_nif.html#enif_send).
+    #[inline]
     pub fn send(self, pid: &LocalPid, message: impl Encoder) -> Result<(), SendError> {
         let env = if is_scheduler_thread() {
             if self.kind == EnvKind::ProcessIndependent {

--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -29,15 +29,18 @@ impl<'a> Term<'a> {
     /// # Unsafe
     /// The caller must ensure that `env` is the environment that `inner` belongs to,
     /// unless `inner` is an atom term.
+    #[inline]
     pub unsafe fn new(env: Env<'a>, inner: NIF_TERM) -> Self {
         Term { term: inner, env }
     }
     /// This extracts the raw term pointer. It is usually used in order to obtain a type that can
     /// be passed to calls into the erlang vm.
+    #[inline]
     pub fn as_c_arg(&self) -> NIF_TERM {
         self.term
     }
 
+    #[inline]
     pub fn get_env(self) -> Env<'a> {
         self.env
     }
@@ -46,6 +49,7 @@ impl<'a> Term<'a> {
     ///
     /// If the term is already is in the provided env, it will be directly returned. Otherwise
     /// the term will be copied over.
+    #[inline]
     pub fn in_env<'b>(&self, env: Env<'b>) -> Term<'b> {
         if self.get_env() == env {
             // It's safe to create a new Term<'b> without copying because we
@@ -81,6 +85,7 @@ impl<'a> Term<'a> {
     /// is needed.
     ///
     /// [`decode`]: #method.decode
+    #[inline]
     pub fn decode_as_binary(self) -> NifResult<Binary<'a>> {
         if self.is_binary() {
             return Binary::from_term(self);
@@ -88,6 +93,7 @@ impl<'a> Term<'a> {
         Binary::from_iolist(self)
     }
 
+    #[inline]
     pub fn to_binary(self) -> OwnedBinary {
         let raw_binary = unsafe { term_to_binary(self.env.as_c_arg(), self.as_c_arg()) }.unwrap();
         unsafe { OwnedBinary::from_raw(raw_binary) }

--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -248,6 +248,7 @@ pub struct Binary<'a> {
 
 impl<'a> Binary<'a> {
     /// Consumes `owned` and returns an immutable `Binary`.
+    #[inline]
     pub fn from_owned(owned: OwnedBinary, env: Env<'a>) -> Self {
         // We are transferring ownership of `owned`'s data to the
         // environment. Therefore, we need to prevent `owned`'s destructor being
@@ -269,6 +270,7 @@ impl<'a> Binary<'a> {
     ///
     /// If allocation fails, an error will be returned.
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn to_owned(&self) -> Option<OwnedBinary> {
         OwnedBinary::from_unowned(self)
     }
@@ -278,6 +280,7 @@ impl<'a> Binary<'a> {
     /// # Errors
     ///
     /// If `term` is not a binary, an error will be returned.
+    #[inline]
     pub fn from_term(term: Term<'a>) -> Result<Self, Error> {
         let mut binary = MaybeUninit::uninit();
         if unsafe {
@@ -315,6 +318,7 @@ impl<'a> Binary<'a> {
     /// # Errors
     ///
     /// If `term` is not an `iolist`, an error will be returned.
+    #[inline]
     pub fn from_iolist(term: Term<'a>) -> Result<Self, Error> {
         let mut binary = MaybeUninit::uninit();
         if unsafe {
@@ -338,11 +342,13 @@ impl<'a> Binary<'a> {
 
     /// Returns an Erlang term representation of `self`.
     #[allow(clippy::wrong_self_convention)]
+    #[inline]
     pub fn to_term<'b>(&self, env: Env<'b>) -> Term<'b> {
         self.term.in_env(env)
     }
 
     /// Extracts a slice containing the entire binary.
+    #[inline]
     pub fn as_slice(&self) -> &'a [u8] {
         unsafe { ::std::slice::from_raw_parts(self.buf, self.size) }
     }
@@ -355,6 +361,7 @@ impl<'a> Binary<'a> {
     /// # Errors
     ///
     /// If `offset + length` is out of bounds, an error will be returned.
+    #[inline]
     pub fn make_subbinary(&self, offset: usize, length: usize) -> NifResult<Binary<'a>> {
         let min_len = length.checked_add(offset);
         if min_len.ok_or(Error::BadArg)? > self.size {
@@ -452,28 +459,33 @@ pub struct NewBinary<'a> {
 
 impl<'a> NewBinary<'a> {
     /// Allocates a new `NewBinary`
+    #[inline]
     pub fn new(env: Env<'a>, size: usize) -> Self {
         let (buf, term) = unsafe { new_binary(env, size) };
         NewBinary { buf, term, size }
     }
     /// Extracts a slice containing the entire binary.
+    #[inline]
     pub fn as_slice(&self) -> &[u8] {
         unsafe { ::std::slice::from_raw_parts(self.buf, self.size) }
     }
 
     /// Extracts a mutable slice of the entire binary.
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { ::std::slice::from_raw_parts_mut(self.buf, self.size) }
     }
 }
 
 impl<'a> From<NewBinary<'a>> for Binary<'a> {
+    #[inline]
     fn from(new_binary: NewBinary<'a>) -> Self {
         Binary::from_term(new_binary.term).unwrap()
     }
 }
 
 impl<'a> From<NewBinary<'a>> for Term<'a> {
+    #[inline]
     fn from(new_binary: NewBinary<'a>) -> Self {
         new_binary.term
     }
@@ -481,11 +493,13 @@ impl<'a> From<NewBinary<'a>> for Term<'a> {
 
 impl Deref for NewBinary<'_> {
     type Target = [u8];
+    #[inline]
     fn deref(&self) -> &[u8] {
         self.as_slice()
     }
 }
 impl DerefMut for NewBinary<'_> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut [u8] {
         self.as_mut_slice()
     }

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -56,6 +56,7 @@ impl<'a> ListIterator<'a> {
 impl<'a> Iterator for ListIterator<'a> {
     type Item = Term<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Term<'a>> {
         let env = self.term.get_env();
         let cell = unsafe { list::get_list_cell(env.as_c_arg(), self.term.as_c_arg()) };
@@ -78,6 +79,7 @@ impl<'a> Iterator for ListIterator<'a> {
 }
 
 impl<'a> Decoder<'a> for ListIterator<'a> {
+    #[inline]
     fn decode(term: Term<'a>) -> NifResult<Self> {
         match ListIterator::new(term) {
             Some(iter) => Ok(iter),
@@ -96,6 +98,7 @@ impl<T> Encoder for Vec<T>
 where
     T: Encoder,
 {
+    #[inline]
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         self.as_slice().encode(env)
     }
@@ -105,6 +108,7 @@ impl<'a, T> Decoder<'a> for Vec<T>
 where
     T: Decoder<'a>,
 {
+    #[inline]
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let iter: ListIterator = term.decode()?;
         let res: NifResult<Self> = iter.map(|x| x.decode::<T>()).collect();
@@ -116,6 +120,7 @@ impl<T> Encoder for [T]
 where
     T: Encoder,
 {
+    #[inline]
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
         unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
@@ -126,6 +131,7 @@ impl<T> Encoder for &[T]
 where
     T: Encoder,
 {
+    #[inline]
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
         unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
@@ -135,6 +141,7 @@ where
 /// ## List terms
 impl<'a> Term<'a> {
     /// Returns a new empty list.
+    #[inline]
     pub fn list_new_empty(env: Env<'a>) -> Term<'a> {
         let list: &[u8] = &[];
         list.encode(env)
@@ -144,6 +151,7 @@ impl<'a> Term<'a> {
     /// See documentation for ListIterator for more information.
     ///
     /// Returns None if the term is not a list.
+    #[inline]
     pub fn into_list_iterator(self) -> NifResult<ListIterator<'a>> {
         ListIterator::new(self).ok_or(Error::BadArg)
     }
@@ -156,6 +164,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// length(self_term)
     /// ```
+    #[inline]
     pub fn list_length(self) -> NifResult<usize> {
         unsafe { list::get_list_length(self.get_env().as_c_arg(), self.as_c_arg()) }
             .ok_or(Error::BadArg)
@@ -171,6 +180,7 @@ impl<'a> Term<'a> {
     /// [head, tail] = self_term
     /// {head, tail}
     /// ```
+    #[inline]
     pub fn list_get_cell(self) -> NifResult<(Term<'a>, Term<'a>)> {
         let env = self.get_env();
         unsafe {
@@ -183,6 +193,7 @@ impl<'a> Term<'a> {
     /// Makes a copy of the self list term and reverses it.
     ///
     /// Returns Err(Error::BadArg) if the term is not a list.
+    #[inline]
     pub fn list_reverse(self) -> NifResult<Term<'a>> {
         let env = self.get_env();
         unsafe {

--- a/rustler/src/types/local_pid.rs
+++ b/rustler/src/types/local_pid.rs
@@ -10,10 +10,12 @@ pub struct LocalPid {
 }
 
 impl LocalPid {
+    #[inline]
     pub fn as_c_arg(&self) -> &ErlNifPid {
         &self.c
     }
 
+    #[inline]
     pub fn from_c_arg(erl_nif_pid: ErlNifPid) -> Self {
         LocalPid { c: erl_nif_pid }
     }
@@ -25,6 +27,7 @@ impl LocalPid {
 }
 
 impl<'a> Decoder<'a> for LocalPid {
+    #[inline]
     fn decode(term: Term<'a>) -> NifResult<LocalPid> {
         unsafe { pid::get_local_pid(term.get_env().as_c_arg(), term.as_c_arg()) }
             .map(|pid| LocalPid { c: pid })
@@ -33,6 +36,7 @@ impl<'a> Decoder<'a> for LocalPid {
 }
 
 impl Encoder for LocalPid {
+    #[inline]
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
         unsafe { Term::new(env, pid::make_pid(env.as_c_arg(), self.c)) }
     }
@@ -67,6 +71,7 @@ impl Env<'_> {
     /// Panics if this environment is process-independent.  (The only way to get such an
     /// environment is to use `OwnedEnv`.  The `Env` that Rustler passes to NIFs when they're
     /// called is always associated with the calling Erlang process.)
+    #[inline]
     pub fn pid(self) -> LocalPid {
         let mut pid = MaybeUninit::uninit();
         if unsafe { enif_self(self.as_c_arg(), pid.as_mut_ptr()) }.is_null() {

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -5,6 +5,7 @@ use crate::wrapper::map;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 use std::ops::RangeInclusive;
 
+#[inline]
 pub fn map_new(env: Env) -> Term {
     unsafe { Term::new(env, map::map_new(env.as_c_arg())) }
 }
@@ -17,6 +18,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// %{}
     /// ```
+    #[inline]
     pub fn map_new(env: Env<'a>) -> Term<'a> {
         map_new(env)
     }
@@ -29,6 +31,7 @@ impl<'a> Term<'a> {
     /// values = [1, 2]
     /// Enum.zip(keys, values) |> Map.new()
     /// ```
+    #[inline]
     pub fn map_from_arrays(
         env: Env<'a>,
         keys: &[impl Encoder],
@@ -80,6 +83,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// Map.new([{"foo", 1}, {"bar", 2}])
     /// ```
+    #[inline]
     pub fn map_from_pairs(
         env: Env<'a>,
         pairs: &[(impl Encoder, impl Encoder)],
@@ -104,6 +108,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// Map.get(self_term, key)
     /// ```
+    #[inline]
     pub fn map_get(self, key: impl Encoder) -> NifResult<Term<'a>> {
         let env = self.get_env();
         match unsafe {
@@ -122,6 +127,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// map_size(self_term)
     /// ```
+    #[inline]
     pub fn map_size(self) -> NifResult<usize> {
         let env = self.get_env();
         unsafe { map::get_map_size(env.as_c_arg(), self.as_c_arg()).ok_or(Error::BadArg) }
@@ -136,6 +142,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// Map.put(self_term, key, value)
     /// ```
+    #[inline]
     pub fn map_put(self, key: impl Encoder, value: impl Encoder) -> NifResult<Term<'a>> {
         let env = self.get_env();
 
@@ -161,6 +168,7 @@ impl<'a> Term<'a> {
     /// ```elixir
     /// Map.delete(self_term, key)
     /// ```
+    #[inline]
     pub fn map_remove(self, key: impl Encoder) -> NifResult<Term<'a>> {
         let env = self.get_env();
 
@@ -176,6 +184,7 @@ impl<'a> Term<'a> {
     ///
     /// Returns Err(Error::BadArg) if the term is not a map of if key
     /// doesn't exist.
+    #[inline]
     pub fn map_update(self, key: impl Encoder, new_value: impl Encoder) -> NifResult<Term<'a>> {
         let env = self.get_env();
 

--- a/rustler/src/types/primitive.rs
+++ b/rustler/src/types/primitive.rs
@@ -22,6 +22,7 @@ macro_rules! erl_get {
 macro_rules! impl_number_encoder {
     ($dec_type:ty, $nif_type:ty, $encode_fun:ident) => {
         impl Encoder for $dec_type {
+            #[inline]
             fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
                 erl_make!(*self, env, $encode_fun, $nif_type)
             }
@@ -32,6 +33,7 @@ macro_rules! impl_number_encoder {
 macro_rules! impl_number_decoder {
     ($dec_type:ty, $nif_type:ty, $decode_fun:ident) => {
         impl<'a> Decoder<'a> for $dec_type {
+            #[inline]
             fn decode(term: Term) -> NifResult<$dec_type> {
                 #![allow(unused_unsafe)]
                 let mut res: $nif_type = Default::default();

--- a/rustler/src/types/string.rs
+++ b/rustler/src/types/string.rs
@@ -2,12 +2,14 @@ use super::binary::{Binary, OwnedBinary};
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 
 impl<'a> Decoder<'a> for String {
+    #[inline]
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let string: &str = Decoder::decode(term)?;
         Ok(string.to_string())
     }
 }
 impl<'a> Decoder<'a> for &'a str {
+    #[inline]
     fn decode(term: Term<'a>) -> NifResult<Self> {
         let binary = Binary::from_term(term)?;
         match ::std::str::from_utf8(binary.as_slice()) {

--- a/rustler/src/wrapper/list.rs
+++ b/rustler/src/wrapper/list.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use std::mem::MaybeUninit;
 
+#[inline]
 pub unsafe fn get_list_cell(env: NIF_ENV, list: NIF_TERM) -> Option<(NIF_TERM, NIF_TERM)> {
     let mut head = MaybeUninit::uninit();
     let mut tail = MaybeUninit::uninit();
@@ -18,6 +19,7 @@ pub unsafe fn get_list_cell(env: NIF_ENV, list: NIF_TERM) -> Option<(NIF_TERM, N
     Some((head.assume_init(), tail.assume_init()))
 }
 
+#[inline]
 pub unsafe fn get_list_length(env: NIF_ENV, list: NIF_TERM) -> Option<usize> {
     let mut len: u32 = 0;
     let success = enif_get_list_length(env, list, &mut len);
@@ -28,14 +30,17 @@ pub unsafe fn get_list_length(env: NIF_ENV, list: NIF_TERM) -> Option<usize> {
     Some(len as usize)
 }
 
+#[inline]
 pub unsafe fn make_list(env: NIF_ENV, arr: &[NIF_TERM]) -> NIF_TERM {
     enif_make_list_from_array(env, arr.as_ptr(), arr.len() as u32)
 }
 
+#[inline]
 pub unsafe fn make_list_cell(env: NIF_ENV, head: NIF_TERM, tail: NIF_TERM) -> NIF_TERM {
     enif_make_list_cell(env, head, tail)
 }
 
+#[inline]
 pub unsafe fn make_reverse_list(env: NIF_ENV, list: NIF_TERM) -> Option<NIF_TERM> {
     let mut list_out = MaybeUninit::uninit();
     let success = enif_make_reverse_list(env, list, list_out.as_mut_ptr());

--- a/rustler/src/wrapper/map.rs
+++ b/rustler/src/wrapper/map.rs
@@ -122,6 +122,7 @@ pub unsafe fn map_iterator_get_pair(
     }
 }
 
+#[inline]
 pub unsafe fn map_iterator_next(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
     enif_map_iterator_next(env, iter);
 }
@@ -130,6 +131,7 @@ pub unsafe fn map_iterator_prev(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
     enif_map_iterator_prev(env, iter);
 }
 
+#[inline]
 pub unsafe fn make_map_from_arrays(
     env: NIF_ENV,
     keys: &[NIF_TERM],


### PR DESCRIPTION
I've gone through and added inline to some commonly used functions.

If everyone is happy, we could also add these to others.

We should judge **what** should be inlined. See https://nnethercote.github.io/perf-book/inlining.html

`None. The compiler will decide itself if the function should be inlined. This will depend on the optimization level, the size of the function, etc. If you are not using link-time optimization, functions will never be inlined across crates.`
`#[inline]. This suggests that the function should be inlined, including across crate boundaries.`

Amazingly I saw great wins with just this, as I have to call some of these functions a lot when encoding a lot of data.

This is using lto:
before
```
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.13.4
Erlang 25.0.2

Benchmarking encode column ...

Name                    ips        average  deviation         median         99th %
encode columns         13.86       72.17 ms    ±21.40%       74.47 ms      114.95 ms
```

after:
```
Name                    ips        average  deviation         median         99th %
encode columns         15.12       66.13 ms    ±23.48%       68.36 ms      108.11 ms
```