### PR TITLE
Tagged enum usability & performance improvements

### DIFF
--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -92,6 +92,7 @@ pub enum TaggedEnum1 {
     String1(String),
     String2(String),
     Untagged,
+    Samefields {x: i32, y: i32},
 }
 
 #[rustler::nif]

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -92,7 +92,7 @@ pub enum TaggedEnum1 {
     String1(String),
     String2(String),
     Untagged,
-    Samefields {x: i32, y: i32},
+    Samefields { x: i32, y: i32 },
 }
 
 #[rustler::nif]

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -154,7 +154,7 @@ defmodule RustlerTest.CodegenTest do
                RustlerTest.tagged_enum_1_echo({:named, "not a map"})
              end)
 
-    assert %ErlangError{original: "The first element of the tuple must be an atom"} ==
+    assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->
                RustlerTest.tagged_enum_1_echo({"named", %{x: 1, y: 2}})
              end)


### PR DESCRIPTION
1. Support multiple units with same field names
2. Move atom / tuple decode outside the type check if, to remove duplicate decode calls

Enum with 22 cases:
before:
tagged_enum_decode          1.56 M      642.48 ns  ±1292.75%         634 ns         675 ns
after:
tagged_enum_decode          3.17 M      314.98 ns  ±2092.02%         311 ns         343 ns

(~300ns is also the tagged_enum_encode latency on my machine)