### PR TITLE
Fix lifetime handling in rustler_codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ members = [
   "rustler_tests/native/rustler_test",
   "rustler_tests/native/rustler_bigint_test",
   "rustler_tests/native/deprecated_macros",
+  "rustler_tests/native/rustler_compile_tests",
 ]

--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -102,7 +102,7 @@ use std::{
 /// See [module-level doc](index.html) for more information.
 pub struct OwnedBinary(ErlNifBinary);
 
-impl<'a> OwnedBinary {
+impl OwnedBinary {
     pub unsafe fn from_raw(inner: ErlNifBinary) -> OwnedBinary {
         OwnedBinary(inner)
     }

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -93,7 +93,7 @@ impl<'a> Decoder<'a> for ListIterator<'a> {
 //    }
 //}
 
-impl<'a, T> Encoder for Vec<T>
+impl<T> Encoder for Vec<T>
 where
     T: Encoder,
 {
@@ -113,7 +113,7 @@ where
     }
 }
 
-impl<'a, T> Encoder for [T]
+impl<T> Encoder for [T]
 where
     T: Encoder,
 {

--- a/rustler/src/wrapper/binary.rs
+++ b/rustler/src/wrapper/binary.rs
@@ -1,5 +1,5 @@
 use crate::{wrapper::size_t, Env, Term};
-pub(in crate) use rustler_sys::ErlNifBinary;
+pub(crate) use rustler_sys::ErlNifBinary;
 use std::mem::MaybeUninit;
 
 pub unsafe fn alloc(size: size_t) -> Option<ErlNifBinary> {

--- a/rustler_bigint/src/big_int.rs
+++ b/rustler_bigint/src/big_int.rs
@@ -59,7 +59,7 @@ rustler::atoms! {
 /// }
 /// ```
 ///
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Eq)]
 pub struct BigInt(num_bigint::BigInt);
 
 impl std::convert::From<num_bigint::BigInt> for BigInt {
@@ -89,7 +89,7 @@ impl std::ops::DerefMut for BigInt {
 }
 
 fn decode_big_integer(input: &[u8]) -> NifResult<num_bigint::BigInt> {
-    if Some(&EXTERNAL_TERM_FORMAT_VERSION) != input.get(0) {
+    if Some(&EXTERNAL_TERM_FORMAT_VERSION) != input.first() {
         return Err(Error::BadArg);
     }
 

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -16,7 +16,7 @@ use super::RustlerAttr;
 pub(crate) struct Context<'a> {
     pub attrs: Vec<RustlerAttr>,
     pub ident: &'a proc_macro2::Ident,
-    pub ident_with_lifetime: proc_macro2::TokenStream,
+    pub generics: &'a syn::Generics,
     pub variants: Option<Vec<&'a Variant>>,
     pub struct_fields: Option<Vec<&'a Field>>,
     pub is_tuple_struct: bool,
@@ -38,19 +38,6 @@ impl<'a> Context<'a> {
             attrs.push(RustlerAttr::Decode);
         }
 
-        let has_lifetime = match ast.generics.lifetimes().count() {
-            0 => false,
-            1 => true,
-            _ => panic!("Struct can only have one lifetime argument"),
-        };
-
-        let ident = &ast.ident;
-        let ident_with_lifetime = if has_lifetime {
-            quote! { #ident <'a> }
-        } else {
-            quote! { #ident }
-        };
-
         let variants = match ast.data {
             Data::Enum(ref data_enum) => Some(data_enum.variants.iter().collect()),
             _ => None,
@@ -71,8 +58,8 @@ impl<'a> Context<'a> {
 
         Self {
             attrs,
-            ident,
-            ident_with_lifetime,
+            ident: &ast.ident,
+            generics: &ast.generics,
             variants,
             struct_fields,
             is_tuple_struct,

--- a/rustler_codegen/src/encode_decode_templates.rs
+++ b/rustler_codegen/src/encode_decode_templates.rs
@@ -1,0 +1,81 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+
+use super::context::Context;
+
+pub(crate) fn decoder(ctx: &Context, inner: TokenStream) -> TokenStream {
+    let ident = ctx.ident;
+    let generics = ctx.generics;
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+
+    // The Decoder uses a special lifetime '__rustler_decode_lifetime. We need to ensure that all
+    // other lifetimes are bound to this lifetime: As we decode from a term (which has a lifetime),
+    // references to that term may not outlive the term itself.
+    let lifetimes: Vec<_> = generics
+        .params
+        .iter()
+        .filter_map(|g| match g {
+            syn::GenericParam::Lifetime(l) => Some(l.lifetime.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let mut impl_generics = generics.clone();
+    let decode_lifetime = syn::Lifetime::new("'__rustler_decode_lifetime", Span::call_site());
+    let lifetime_def = syn::LifetimeDef::new(decode_lifetime.clone());
+    impl_generics
+        .params
+        .push(syn::GenericParam::Lifetime(lifetime_def));
+
+    if !lifetimes.is_empty() {
+        let where_clause = impl_generics.make_where_clause();
+
+        for lifetime in lifetimes {
+            let mut puncated = syn::punctuated::Punctuated::new();
+            puncated.push(lifetime.clone());
+            let predicate = syn::PredicateLifetime {
+                lifetime: decode_lifetime.clone(),
+                colon_token: syn::token::Colon {
+                    spans: [Span::call_site()],
+                },
+                bounds: puncated,
+            };
+            where_clause.predicates.push(predicate.into());
+
+            let mut puncated = syn::punctuated::Punctuated::new();
+            puncated.push(decode_lifetime.clone());
+            let predicate = syn::PredicateLifetime {
+                lifetime: lifetime.clone(),
+                colon_token: syn::token::Colon {
+                    spans: [Span::call_site()],
+                },
+                bounds: puncated,
+            };
+            where_clause.predicates.push(predicate.into());
+        }
+    }
+
+    let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::rustler::Decoder<'__rustler_decode_lifetime> for #ident #ty_generics #where_clause {
+            fn decode(term: ::rustler::Term<'__rustler_decode_lifetime>) -> ::rustler::NifResult<Self> {
+                #inner
+            }
+        }
+    }
+}
+
+pub(crate) fn encoder(ctx: &Context, inner: TokenStream) -> TokenStream {
+    let ident = ctx.ident;
+    let generics = ctx.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::rustler::Encoder for #ident #ty_generics #where_clause {
+            fn encode<'__rustler__encode_lifetime>(&self, env: ::rustler::Env<'__rustler__encode_lifetime>) -> ::rustler::Term<'__rustler__encode_lifetime> {
+                #inner
+            }
+        }
+    }
+}

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -3,6 +3,7 @@
 use proc_macro::TokenStream;
 
 mod context;
+mod encode_decode_templates;
 mod ex_struct;
 mod init;
 mod map;

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -49,7 +49,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 }
 
 fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
-    let struct_type = &ctx.ident_with_lifetime;
     let struct_name = ctx.ident;
 
     // Make a decoder for each of the fields in the struct.
@@ -97,49 +96,45 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
             Ok(#struct_name { #(#field_defs),* })
         }
     };
-    let gen = quote! {
-        impl<'a> ::rustler::Decoder<'a> for #struct_type {
-            fn decode(term: ::rustler::Term<'a>) -> ::rustler::NifResult<Self> {
-                use #atoms_module_name::*;
 
-                let terms = match ::rustler::types::tuple::get_tuple(term) {
-                    Err(_) => return Err(::rustler::Error::RaiseTerm(
-                            Box::new(format!("Invalid Record structure for {}", #struct_name_str)))),
-                    Ok(value) => value,
-                };
+    super::encode_decode_templates::decoder(
+        ctx,
+        quote! {
+            use #atoms_module_name::*;
 
-                if terms.len() != #field_num + 1 {
-                    return Err(::rustler::Error::RaiseAtom("invalid_record"));
-                }
+            let terms = match ::rustler::types::tuple::get_tuple(term) {
+                Err(_) => return Err(::rustler::Error::RaiseTerm(
+                        Box::new(format!("Invalid Record structure for {}", #struct_name_str)))),
+                Ok(value) => value,
+            };
 
-                let tag : ::rustler::types::atom::Atom = terms[0].decode()?;
-
-                if tag != atom_tag() {
-                    return Err(::rustler::Error::RaiseAtom("invalid_record"));
-                }
-
-                fn try_decode_index<'a, T>(terms: &[::rustler::Term<'a>], pos_in_struct: &str, index: usize) -> ::rustler::NifResult<T>
-                    where
-                        T: rustler::Decoder<'a>,
-                {
-                    match ::rustler::Decoder::decode(terms[index]) {
-                        Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(
-                                    format!("Could not decode field {} on Record {}", pos_in_struct, #struct_name_str)))),
-                        Ok(value) => Ok(value)
-                    }
-                }
-
-                #construct
+            if terms.len() != #field_num + 1 {
+                return Err(::rustler::Error::RaiseAtom("invalid_record"));
             }
-        }
-    };
 
-    gen
+            let tag : ::rustler::types::atom::Atom = terms[0].decode()?;
+
+            if tag != atom_tag() {
+                return Err(::rustler::Error::RaiseAtom("invalid_record"));
+            }
+
+            fn try_decode_index<'a, T>(terms: &[::rustler::Term<'a>], pos_in_struct: &str, index: usize) -> ::rustler::NifResult<T>
+                where
+                    T: rustler::Decoder<'a>,
+            {
+                match ::rustler::Decoder::decode(terms[index]) {
+                    Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(
+                                format!("Could not decode field {} on Record {}", pos_in_struct, #struct_name_str)))),
+                    Ok(value) => Ok(value)
+                }
+            }
+
+            #construct
+        },
+    )
 }
 
 fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
-    let struct_type = &ctx.ident_with_lifetime;
-
     // Make a field encoder expression for each of the items in the struct.
     let field_encoders: Vec<TokenStream> = fields
         .iter()
@@ -163,20 +158,16 @@ fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         [#tag_encoder, #(#field_encoders),*]
     };
 
-    // The implementation itself
-    let gen = quote! {
-        impl<'b> ::rustler::Encoder for #struct_type {
-            fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
-                use #atoms_module_name::*;
+    super::encode_decode_templates::encoder(
+        ctx,
+        quote! {
+            use #atoms_module_name::*;
 
-                use ::rustler::Encoder;
-                let arr = #field_list_ast;
-                ::rustler::types::tuple::make_tuple(env, &arr)
-            }
-        }
-    };
-
-    gen
+            use ::rustler::Encoder;
+            let arr = #field_list_ast;
+            ::rustler::types::tuple::make_tuple(env, &arr)
+        },
+    )
 }
 
 fn get_tag(ctx: &Context) -> String {

--- a/rustler_codegen/src/unit_enum.rs
+++ b/rustler_codegen/src/unit_enum.rs
@@ -67,7 +67,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 }
 
 fn gen_decoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) -> TokenStream {
-    let enum_type = &ctx.ident_with_lifetime;
     let enum_name = ctx.ident;
 
     let variant_defs: Vec<TokenStream> = variants
@@ -85,25 +84,21 @@ fn gen_decoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
         })
         .collect();
 
-    let gen = quote! {
-        impl<'a> ::rustler::Decoder<'a> for #enum_type {
-            fn decode(term: ::rustler::Term<'a>) -> ::rustler::NifResult<Self> {
-                use #atoms_module_name::*;
+    super::encode_decode_templates::decoder(
+        ctx,
+        quote! {
+            use #atoms_module_name::*;
 
-                let value = ::rustler::types::atom::Atom::from_term(term)?;
+            let value = ::rustler::types::atom::Atom::from_term(term)?;
 
-                #(#variant_defs)*
+            #(#variant_defs)*
 
-                Err(::rustler::Error::RaiseAtom("invalid_variant"))
-            }
-        }
-    };
-
-    gen
+            Err(::rustler::Error::RaiseAtom("invalid_variant"))
+        },
+    )
 }
 
 fn gen_encoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) -> TokenStream {
-    let enum_type = &ctx.ident_with_lifetime;
     let enum_name = ctx.ident;
 
     let variant_defs: Vec<TokenStream> = variants
@@ -119,17 +114,14 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant], atoms_module_name: &Ident) 
         })
         .collect();
 
-    let gen = quote! {
-        impl<'b> ::rustler::Encoder for #enum_type {
-            fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
-                use #atoms_module_name::*;
+    super::encode_decode_templates::encoder(
+        ctx,
+        quote! {
+            use #atoms_module_name::*;
 
-                match *self {
-                    #(#variant_defs)*
-                }
+            match *self {
+                #(#variant_defs)*
             }
-        }
-    };
-
-    gen
+        },
+    )
 }

--- a/rustler_codegen/src/untagged_enum.rs
+++ b/rustler_codegen/src/untagged_enum.rs
@@ -48,7 +48,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 }
 
 fn gen_decoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
-    let enum_type = &ctx.ident_with_lifetime;
     let enum_name = ctx.ident;
 
     let variant_defs: Vec<_> = variants
@@ -65,21 +64,17 @@ fn gen_decoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
         })
         .collect();
 
-    let gen = quote! {
-        impl<'a> ::rustler::Decoder<'a> for #enum_type {
-            fn decode(term: ::rustler::Term<'a>) -> ::rustler::NifResult<Self> {
-                #(#variant_defs)*
+    super::encode_decode_templates::decoder(
+        ctx,
+        quote! {
+            #(#variant_defs)*
 
-                Err(::rustler::Error::RaiseAtom("invalid_variant"))
-            }
-        }
-    };
-
-    gen
+            Err(::rustler::Error::RaiseAtom("invalid_variant"))
+        },
+    )
 }
 
 fn gen_encoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
-    let enum_type = &ctx.ident_with_lifetime;
     let enum_name = ctx.ident;
 
     let variant_defs: Vec<_> = variants
@@ -93,15 +88,12 @@ fn gen_encoder(ctx: &Context, variants: &[&Variant]) -> TokenStream {
         })
         .collect();
 
-    let gen = quote! {
-        impl<'b> ::rustler::Encoder for #enum_type {
-            fn encode<'a>(&self, env: ::rustler::Env<'a>) -> ::rustler::Term<'a> {
-                match *self {
-                    #(#variant_defs)*
-                }
+    super::encode_decode_templates::encoder(
+        ctx,
+        quote! {
+            match *self {
+                #(#variant_defs)*
             }
-        }
-    };
-
-    gen
+        },
+    )
 }

--- a/rustler_sys/build.rs
+++ b/rustler_sys/build.rs
@@ -22,7 +22,7 @@ trait ApiBuilder {
     fn dummy(&mut self, name: &str);
 }
 
-#[derive(PartialEq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum OsFamily {
     Unix,
     Win,

--- a/rustler_tests/native/rustler_compile_tests/Cargo.toml
+++ b/rustler_tests/native/rustler_compile_tests/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rustler_compile_tests"
+version = "0.1.0"
+authors = []
+edition = "2018"
+
+[lib]
+name = "rustler_test"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+lazy_static = "1.4"
+rustler = { path = "../../../rustler" }

--- a/rustler_tests/native/rustler_compile_tests/src/lib.rs
+++ b/rustler_tests/native/rustler_compile_tests/src/lib.rs
@@ -1,0 +1,41 @@
+pub mod lifetimes {
+    use rustler::{Binary, NifMap, NifRecord, NifStruct, NifTuple};
+
+    #[derive(NifMap)]
+    pub struct GenericMap<'a, 'b> {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+
+    #[derive(NifStruct)]
+    #[module = "GenericStruct"]
+    pub struct GenericStruct<'a, 'b> {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+
+    #[derive(NifRecord)]
+    #[tag = "generic_record"]
+    pub struct GenericRecord<'a, 'b> {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+
+    #[derive(NifTuple)]
+    pub struct GenericTuple<'a, 'b>(Binary<'a>, Binary<'b>);
+
+    #[derive(NifMap)]
+    pub struct WhereClause<'a, 'b>
+    where
+        'a: 'b,
+    {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+
+    #[derive(NifMap)]
+    pub struct LifetimeBounded<'a, 'b: 'a> {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+}


### PR DESCRIPTION
This PR builds on the previous work of @turion (https://github.com/rusterlium/rustler/pull/430), 
@SeokminHong (https://github.com/rusterlium/rustler/pull/430#issuecomment-1175816881) and @neosimsim (https://github.com/rusterlium/rustler/pull/471), so kudos to them, this PR only attempts to complete their prior work.

Handling lifetimes for encoders within `rustler_codegen` is obvious: we can directly use `split_for_impl()` from `syn` to split the generics in a way which allows us to use them for a generated `impl`. For decoders, handling lifetimes is more involved. First of all, we need to ensure that the special lifetime of the decoder (named `'__rustler_decode_lifetime` in the generated code) outlives the lifetimes of the type to which we want to decode. The reason for this is that references to parts of the term may not outlive the term itself. On the other hand, the lifetimes of the type need to be able to outlive the term's lifetime, as we return a new struct/enum from the decoder. To ensure this, we generate a `where` clause for a lifetime `'a` like this:

```rust
// .. here could be other predicates
'a: '__rustler_decode_lifetime,
'__rustler_decode_lifetime: 'a
```

With that, the lifetimes `'a` and `'__rustler_decode_lifetime` are practically the same.

Fix #428
Close #430
Close #471