### PR TITLE
Allow lists to be built from iterators

### DIFF
--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -2,7 +2,7 @@
 //!
 //! Right now the only supported way to read lists are through the ListIterator.
 
-use crate::wrapper::{list, NIF_TERM};
+use crate::wrapper::list;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 
 /// Enables iteration over the items in the list.
@@ -86,13 +86,6 @@ impl<'a> Decoder<'a> for ListIterator<'a> {
     }
 }
 
-//impl<'a, T> Encoder for Iterator<Item = T> where T: Encoder {
-//    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-//        let term_arr: Vec<NIF_TERM> =
-//            self.map(|x| x.encode(env).as_c_arg()).collect();
-//    }
-//}
-
 impl<T> Encoder for Vec<T>
 where
     T: Encoder,
@@ -118,8 +111,8 @@ where
     T: Encoder,
 {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
-        unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
+        let mut iter = self.iter().map(|x| x.encode(env).as_c_arg());
+        unsafe { Term::new(env, list::make_list_from_end(env.as_c_arg(), &mut iter)) }
     }
 }
 impl<'a, T> Encoder for &'a [T]
@@ -127,8 +120,8 @@ where
     T: Encoder,
 {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
-        unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
+        let mut iter = self.iter().map(|x| x.encode(env).as_c_arg());
+        unsafe { Term::new(env, list::make_list_from_end(env.as_c_arg(), &mut iter)) }
     }
 }
 

--- a/rustler/src/wrapper/list.rs
+++ b/rustler/src/wrapper/list.rs
@@ -35,7 +35,12 @@ pub unsafe fn make_list_from_end(
 }
 
 /// Builds a list from an iterator.
-/// Prefer to use make_list_from_end if the iterator is double ended.
+///
+/// This collects the iterator as a vector and then builds a list from it.
+///
+/// You may also use make_list_from_end if the iterator is double ended,
+/// which avoids the intermediate vector allocation but it is slightly slower
+/// as it allocates cons cells one at a time instead of upfront.
 pub unsafe fn make_list_from_iter(
     env: NIF_ENV,
     iter: &mut dyn std::iter::Iterator<Item = NIF_TERM>,

--- a/rustler/src/wrapper/list.rs
+++ b/rustler/src/wrapper/list.rs
@@ -26,14 +26,20 @@ pub unsafe fn make_list(env: NIF_ENV, arr: &[NIF_TERM]) -> NIF_TERM {
     rustler_sys::enif_make_list_from_array(env, arr.as_ptr(), arr.len() as u32)
 }
 
-pub unsafe fn make_list_from_end(env: NIF_ENV, iter: &mut dyn std::iter::DoubleEndedIterator<Item=NIF_TERM>) -> NIF_TERM {
+pub unsafe fn make_list_from_end(
+    env: NIF_ENV,
+    iter: &mut dyn std::iter::DoubleEndedIterator<Item = NIF_TERM>,
+) -> NIF_TERM {
     let acc = make_list(env, &[]);
     iter.rfold(acc, |acc, term| make_list_cell(env, term, acc))
 }
 
 /// Builds a list from an iterator.
 /// Prefer to use make_list_from_end if the iterator is double ended.
-pub unsafe fn make_list_from_iter(env: NIF_ENV, iter: &mut dyn std::iter::Iterator<Item=NIF_TERM>) -> NIF_TERM {
+pub unsafe fn make_list_from_iter(
+    env: NIF_ENV,
+    iter: &mut dyn std::iter::Iterator<Item = NIF_TERM>,
+) -> NIF_TERM {
     make_list(env, iter.collect::<Vec<NIF_TERM>>().as_slice())
 }
 

--- a/rustler/src/wrapper/list.rs
+++ b/rustler/src/wrapper/list.rs
@@ -26,6 +26,17 @@ pub unsafe fn make_list(env: NIF_ENV, arr: &[NIF_TERM]) -> NIF_TERM {
     rustler_sys::enif_make_list_from_array(env, arr.as_ptr(), arr.len() as u32)
 }
 
+pub unsafe fn make_list_from_end(env: NIF_ENV, iter: &mut dyn std::iter::DoubleEndedIterator<Item=NIF_TERM>) -> NIF_TERM {
+    let acc = make_list(env, &[]);
+    iter.rfold(acc, |acc, term| make_list_cell(env, term, acc))
+}
+
+/// Builds a list from an iterator.
+/// Prefer to use make_list_from_end if the iterator is double ended.
+pub unsafe fn make_list_from_iter(env: NIF_ENV, iter: &mut dyn std::iter::Iterator<Item=NIF_TERM>) -> NIF_TERM {
+    make_list(env, iter.collect::<Vec<NIF_TERM>>().as_slice())
+}
+
 pub unsafe fn make_list_cell(env: NIF_ENV, head: NIF_TERM, tail: NIF_TERM) -> NIF_TERM {
     rustler_sys::enif_make_list_cell(env, head, tail)
 }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -19,6 +19,8 @@ defmodule RustlerTest do
 
   def sum_list(_), do: err()
   def make_list(), do: err()
+  def make_list_from_end(), do: err()
+  def make_list_from_iter(), do: err()
 
   def term_debug(_), do: err()
   def term_eq(_, _), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -23,6 +23,8 @@ rustler::init!(
         test_primitives::result_to_int,
         test_list::sum_list,
         test_list::make_list,
+        test_list::make_list_from_end,
+        test_list::make_list_from_iter,
         test_term::term_debug,
         test_term::term_eq,
         test_term::term_cmp,

--- a/rustler_tests/native/rustler_test/src/test_list.rs
+++ b/rustler_tests/native/rustler_test/src/test_list.rs
@@ -1,5 +1,5 @@
-use rustler::{Encoder, Env, Error, ListIterator, NifResult, Term};
 use rustler::wrapper::list;
+use rustler::{Encoder, Env, Error, ListIterator, NifResult, Term};
 
 #[rustler::nif]
 pub fn sum_list(iter: ListIterator) -> NifResult<i64> {
@@ -16,15 +16,14 @@ pub fn make_list() -> Vec<usize> {
     vec![1, 2, 3]
 }
 
-
 #[rustler::nif]
 pub fn make_list_from_iter(env: Env) -> Term {
-  let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
-  unsafe { Term::new(env, list::make_list_from_iter(env.as_c_arg(), &mut iter)) }
+    let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
+    unsafe { Term::new(env, list::make_list_from_iter(env.as_c_arg(), &mut iter)) }
 }
 
 #[rustler::nif]
 pub fn make_list_from_end(env: Env) -> Term {
-  let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
-  unsafe { Term::new(env, list::make_list_from_end(env.as_c_arg(), &mut iter)) }
+    let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
+    unsafe { Term::new(env, list::make_list_from_end(env.as_c_arg(), &mut iter)) }
 }

--- a/rustler_tests/native/rustler_test/src/test_list.rs
+++ b/rustler_tests/native/rustler_test/src/test_list.rs
@@ -1,4 +1,5 @@
-use rustler::{Error, ListIterator, NifResult};
+use rustler::{Encoder, Env, Error, ListIterator, NifResult, Term};
+use rustler::wrapper::list;
 
 #[rustler::nif]
 pub fn sum_list(iter: ListIterator) -> NifResult<i64> {
@@ -13,4 +14,17 @@ pub fn sum_list(iter: ListIterator) -> NifResult<i64> {
 #[rustler::nif]
 pub fn make_list() -> Vec<usize> {
     vec![1, 2, 3]
+}
+
+
+#[rustler::nif]
+pub fn make_list_from_iter(env: Env) -> Term {
+  let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
+  unsafe { Term::new(env, list::make_list_from_iter(env.as_c_arg(), &mut iter)) }
+}
+
+#[rustler::nif]
+pub fn make_list_from_end(env: Env) -> Term {
+  let mut iter = [1, 2, 3].iter().map(|i| (i + 1).encode(env).as_c_arg());
+  unsafe { Term::new(env, list::make_list_from_end(env.as_c_arg(), &mut iter)) }
 }

--- a/rustler_tests/test/list_test.exs
+++ b/rustler_tests/test/list_test.exs
@@ -20,4 +20,12 @@ defmodule RustlerTest.ListTest do
   test "simple list construction with sum" do
     assert RustlerTest.sum_list(RustlerTest.make_list()) == 6
   end
+
+  test "simple list from iterator" do
+    assert RustlerTest.make_list_from_iter() == [2, 3, 4]
+  end
+
+  test "simple list from end" do
+    assert RustlerTest.make_list_from_end() == [2, 3, 4]
+  end
 end


### PR DESCRIPTION
In particular, allow lists to be built from
double ended iterators, which avoids allocating
intermediate vectors.