### PR TITLE
Fix warnings

### DIFF
--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -14,7 +14,7 @@ defmodule RustlerTest.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    []
   end
 
   defp deps do

--- a/rustler_tests/test/resource_test.exs
+++ b/rustler_tests/test/resource_test.exs
@@ -1,6 +1,6 @@
 defmodule RustlerTest.ResourceTest do
   use ExUnit.Case, async: true
-  use Bitwise
+  import Bitwise
 
   test "resource creation and interaction" do
     resource = RustlerTest.resource_make()


### PR DESCRIPTION
This PR fixes two warnings:

* `use Bitwise` is deprecated. import Bitwise instead
* `warning: Rustler.Compiler.compile_crate/2 defined in application :rustler is used by the current application`