### PR TITLE
Cache Mix.env() to trigger recompilation

### DIFF
--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -20,6 +20,17 @@ def deps do
 end
 ```
 
+In order to also allow picking the build profile with `MIX_ENV`, add the `:rustler` compiler to your `project/0` in `mix.exs`:
+
+```elixir
+def project do
+  [
+  #...
+  compilers: [:rustler | Mix.compilers()]
+  ]
+end
+```
+
 ## Usage
 
 1.  Fetch all necessary dependencies:

--- a/rustler_mix/lib/mix/tasks/compile.rustler.ex
+++ b/rustler_mix/lib/mix/tasks/compile.rustler.ex
@@ -4,16 +4,32 @@ defmodule Mix.Tasks.Compile.Rustler do
   use Mix.Task
 
   def run(_args) do
-    IO.puts([
-      IO.ANSI.yellow(),
-      """
+    cache_mix_env()
+  end
 
-      The `:rustler` compiler has been deprecated since v0.22.0 and will be
-      removed in v1.0.
+  defp cache_mix_env() do
+    File.mkdir(cache_target_path())
+    mix_cache_path = mix_cache_path()
+    current_mix_env = inspect(Mix.env())
 
-      To remove this warning, please consult the CHANGELOG for v0.22.0.
-      """,
-      IO.ANSI.default_color()
-    ])
+    case File.read(mix_cache_path) do
+      {:ok, ^current_mix_env} ->
+        :ok
+
+      _ ->
+        File.write!(mix_cache_path, current_mix_env)
+    end
+  end
+
+  defp cache_target_path do
+    # We need to cache directly under `_build`, as the cache needs to be
+    # overwritten if the build environment changes
+    Mix.Project.build_path()
+    |> Path.join("..")
+    |> Path.join("rustler_cache")
+  end
+
+  def mix_cache_path do
+    Path.join(cache_target_path(), "mix_env.cache")
   end
 end

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -86,6 +86,8 @@ defmodule Rustler do
         @external_resource resource
       end
 
+      @external_resource Mix.Tasks.Compile.Rustler.mix_cache_path()
+
       if config.lib do
         @load_from config.load_from
         @load_data config.load_data

--- a/rustler_mix/priv/templates/basic/README.md
+++ b/rustler_mix/priv/templates/basic/README.md
@@ -15,6 +15,17 @@ defmodule <%= module %> do
 end
 ```
 
+Also add `:rustler` to the `:compilers` key in `mix.exs`:
+
+```
+def project do
+  [
+  # ...
+  compilers: [:rustler | Mix.compilers()]
+  ]
+end
+```
+
 ## Examples
 
 [This](https://github.com/rusterlium/NifIo) is a complete example of a NIF written in Rust.


### PR DESCRIPTION
When using MIX_ENV to configure the build profile, changing `MIX_ENV` in a subsequent run needs to trigger the mechanism for recompilation to determine if that mode was build. For this, we need to cache value of `Mix.env()` and detect when that changes. If it changes, we write the cache, `@external_resource` can pick that up.

Close #479