### PR TITLE
Expose wrapper::binary::make_subbinary

### DIFF
--- a/rustler/src/wrapper/binary.rs
+++ b/rustler/src/wrapper/binary.rs
@@ -2,6 +2,8 @@ use crate::{wrapper::size_t, Env, Term};
 pub(crate) use rustler_sys::ErlNifBinary;
 use std::mem::MaybeUninit;
 
+pub use rustler_sys::enif_make_sub_binary as make_subbinary;
+
 pub unsafe fn alloc(size: size_t) -> Option<ErlNifBinary> {
     let mut binary = MaybeUninit::uninit();
     let success = rustler_sys::enif_alloc_binary(size, binary.as_mut_ptr());

--- a/rustler/src/wrapper/resource.rs
+++ b/rustler/src/wrapper/resource.rs
@@ -4,10 +4,8 @@ use crate::wrapper::{
 
 pub use rustler_sys::{
     enif_alloc_resource as alloc_resource, enif_keep_resource as keep_resource,
-    enif_make_resource as make_resource,
+    enif_make_resource as make_resource, enif_release_resource as release_resource,
 };
-
-pub use rustler_sys::enif_release_resource as release_resource;
 
 use std::mem::MaybeUninit;
 use std::ptr;


### PR DESCRIPTION
I have decided to use Rustler convention (subbinary) instead of OTP one (sub_binary).