### PR TITLE
Ignore MIX_ENV for build profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer versions.
 
+## [unreleased]
+
+### BREAKING
+
+* `MIX_ENV` is no longer considered for determining the build profile. Now, the
+  profile defaults to `:release`. Use the `:mode` option to pick another profile explicitly.
+
 ## [0.26.0] - 2022-09-02
 
 ### Highlight

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -51,10 +51,7 @@ defmodule Rustler do
       `{:my_app, "priv/native/<artifact>"}`. Due to the way `:erlang.load_nif/2`
       works, the artifact should not include the file extension (i.e. `.so`, `.dll`).
 
-    * `:mode` - Specify which mode to compile the crate with. If you do not specify
-      this option, a default will be provide based on the `Mix.env()`:
-      - When `Mix.env()` is `:dev` or `:test`, the crate will be compiled in `:debug` mode.
-      - When `Mix.env()` is `:prod` or `:bench`, the crate will be compiled in `:release` mode.
+    * `:mode` - Specify which mode to compile the crate with (default: `:release`)
 
     * `:path` - By default, rustler expects the crate to be found in `native/<crate>` in the
       root of the project. Use this option to override this.

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -43,7 +43,7 @@ defmodule Rustler.Compiler.Config do
     defaults = %Config{
       crate: crate,
       load_from: {otp_app, "priv/native/lib#{crate}"},
-      mode: build_mode(Mix.env()),
+      mode: :release,
       otp_app: otp_app,
       path: "native/#{crate}",
       target_dir: Application.app_dir(otp_app, "native/#{crate}")
@@ -138,9 +138,6 @@ defmodule Rustler.Compiler.Config do
     |> Enum.filter(&(&1["name"] == name))
     |> List.first()
   end
-
-  defp build_mode(env) when env in [:prod, :bench], do: :release
-  defp build_mode(_), do: :debug
 
   defp to_atom(name) when is_binary(name),
     do: String.to_atom(name)


### PR DESCRIPTION
Using `MIX_ENV` to determine the build profile profile does not work well as a change to `MIX_ENV` does not necessarily result in a module recompilation. With that, a shared lib built with the wrong profile might be used. To avoid that, `MIX_ENV` support is dropped altogether in favour of defaulting to `:release` if the user does not pick a profile explicitly.

Close #479 