### PR TITLE
rustler_codegen: Fix stale doc example for init

### DIFF
--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -46,7 +46,11 @@ enum RustlerAttr {
 ///     a / b
 /// }
 ///
-/// rustler::init!("Elixir.Math", [add, sub, mul, div], Some(load));
+/// fn load(env: Env, _term: Term) -> bool {
+///     true
+/// }
+///
+/// rustler::init!("Elixir.Math", [add, sub, mul, div], load = load);
 /// ```
 #[proc_macro]
 pub fn init(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
`Some(load)` has been replaced with `load = load`.

Also add a stub for showing how `load` should look like.