### PR TITLE
Fix Rustler on upcoming Elixir v1.15

### DIFF
--- a/rustler_mix/mix.exs
+++ b/rustler_mix/mix.exs
@@ -24,9 +24,9 @@ defmodule Rustler.Mixfile do
 
   defp deps do
     [
-      {:toml, "~> 0.6", runtime: false},
+      {:toml, "~> 0.6"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:jason, "~> 1.0", runtime: false}
+      {:jason, "~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
Elixir v1.15 will only keep in the code path
dependencies that are explicitly listed as
applications.

"runtime: false" dependencies are not included
in the applications, which breaks Rustler.

Please let me know what you think. A new Rustler
release will be very appreciated so it gives people
time to migrate. Otherwise Rustler and Elixir v1.15
will be incompatible once they launch.
