### PR TITLE
add support fro tuples in nif macro

### DIFF
--- a/rustler_codegen/src/nif.rs
+++ b/rustler_codegen/src/nif.rs
@@ -153,6 +153,16 @@ fn extract_inputs(inputs: Punctuated<syn::FnArg, Comma>) -> TokenStream {
                         }
                     }
                 }
+                syn::Type::Tuple(typ) => {
+                    let decoder = quote! {
+                        let #name: #typ = match args[#idx].decode() {
+                            Ok(value) => value,
+                            Err(err) => return Err(err)
+                        };
+                    };
+
+                    tokens.extend(decoder);
+                }
                 other => {
                     panic!("unsupported input given: {:?}", other);
                 }


### PR DESCRIPTION
This commit adds support for tuples in a nif function by expanding the nif macro to decode tuple types with the `Decode` trait.

ISSUE: #519 