### PR TITLE
Simplify CI workflow and update versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,29 +10,11 @@ on:
     - cron: '0 0 * * 3'
 
 jobs:
-  clippy:
-    name: Clippy ${{matrix.os}}
-    runs-on: ${{matrix.os}}-latest
-    strategy:
-      matrix:
-        os: [ubuntu, windows, macos]
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            components: clippy
-            override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features -- -D warnings
-
   format:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: stable
@@ -43,7 +25,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: "25"
-          elixir-version: "1.13"
+          elixir-version: "1.14"
 
       - name: Check cargo fmt
         uses: actions-rs/cargo@v1
@@ -59,58 +41,63 @@ jobs:
         working-directory: rustler_tests
         run: mix format --check-formatted
 
-  rustler_mix_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Install Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Install Erlang/Elixir
-        uses: erlef/setup-beam@v1
-        with:
-          otp-version: "24"
-          elixir-version: 1.13
-
-      - name: Test rustler_mix
-        working-directory: rustler_mix
-        run: ./test.sh
-
-  test:
-    name: OTP ${{matrix.pair.erlang}} / Elixir ${{matrix.pair.elixir}} / Rust ${{matrix.rust}} / OS ${{matrix.os}}
+  clippy:
+    name: Clippy ${{matrix.os}}
     runs-on: ${{matrix.os}}-latest
     strategy:
       matrix:
+        os: [ubuntu, windows, macos]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --all-features -- -D warnings
+
+  test:
+    name: OTP ${{matrix.pair.erlang}} / Elixir ${{matrix.pair.elixir}} / Rust ${{matrix.rust}} / OS ${{matrix.os}}
+    needs: [format, clippy]
+    strategy:
+      matrix:
         pair:
-          - { erlang: "25", elixir: "1.14" }
+          - { erlang: "25", elixir: "1.14", latest: true }
           - { erlang: "25", elixir: "1.13" }
           - { erlang: "24", elixir: "1.13" }
           - { erlang: "24", elixir: "1.12" }
-          - { erlang: "24", elixir: "1.11" }
-          - { erlang: "23", elixir: "1.11" }
+          - { erlang: "23", elixir: "1.12" }
         rust:
           - stable
-          - beta
           - nightly
         os:
-          - windows
-          # TODO change this to ubuntu after OTP 23 is deprecated, see
+          - macos-11
+          - windows-latest
+          # TODO change this to ubuntu-latest after OTP 23 is deprecated, see
           # https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp
           # for compatibility
           - ubuntu-20.04
+    runs-on: ${{matrix.os}}
+
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Install Erlang/Elixir
         uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}
+        if: "!startsWith(matrix.os, 'macos')"
+
+      - name: Install Erlang/Elixir with Brew
+        run: |
+          brew install elixir
+          mix local.hex --force
+        if: "startsWith(matrix.os, 'macos')"
 
       - name: Install Rust ${{matrix.rust}} toolchain
         uses: actions-rs/toolchain@v1
@@ -132,34 +119,7 @@ jobs:
           mix deps.get
           mix test
 
-  test_macos:
-    name: macos-11 test
-    runs-on: macos-11
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v1
-
-      - name: Install Erlang/Elixir
-        run: |
-          brew install elixir
-          mix local.hex --force
-
-      - name: Install Rust ${{matrix.rust}} toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - run: cargo test
-
-      - name: Test rustler_mix
+      - name: Test mix project with example created from template
         working-directory: rustler_mix
-        run: |
-          mix deps.get
-          mix test
-
-      - name: Test rustler_tests
-        working-directory: rustler_tests
-        run: |
-          mix deps.get
-          mix test
+        run: ./test.sh
+        if: "startsWith(matrix.os, 'ubuntu') && matrix.pair.latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            components: rustfmt
-            override: true
+          components: rustfmt
 
       - name: Install Erlang/Elixir
         uses: erlef/setup-beam@v1
@@ -28,10 +27,7 @@ jobs:
           elixir-version: "1.14"
 
       - name: Check cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Check mix format (rustler_mix)
         working-directory: rustler_mix
@@ -49,15 +45,12 @@ jobs:
         os: [ubuntu, windows, macos]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            components: clippy
-            override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-targets --all-features -- -D warnings
+          components: clippy
+
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: OTP ${{matrix.pair.erlang}} / Elixir ${{matrix.pair.elixir}} / Rust ${{matrix.rust}} / OS ${{matrix.os}}
@@ -100,10 +93,9 @@ jobs:
         if: "startsWith(matrix.os, 'macos')"
 
       - name: Install Rust ${{matrix.rust}} toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
-          override: true
 
       - run: cargo test
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,7 @@ jobs:
       matrix:
         pair:
           - { erlang: "25", elixir: "1.14", latest: true }
-          - { erlang: "25", elixir: "1.13" }
           - { erlang: "24", elixir: "1.13" }
-          - { erlang: "24", elixir: "1.12" }
           - { erlang: "23", elixir: "1.12" }
         rust:
           - stable

--- a/rustler_tests/mix.exs
+++ b/rustler_tests/mix.exs
@@ -5,8 +5,7 @@ defmodule RustlerTest.Mixfile do
     [
       app: :rustler_test,
       version: "0.0.1",
-      elixir: "~> 1.11",
-      compilers: [:rustler] ++ Mix.compilers(),
+      elixir: "~> 1.12",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -13,10 +13,6 @@ crate-type = ["cdylib"]
 name = "hello_rust"
 path = "src/main.rs"
 
-[[bin]]
-name = "hello_rust2"
-path = "src/main.rs"
-
 [dependencies]
 lazy_static = "1.4"
 rustler = { path = "../../../rustler" }

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::panic;
 
 use rustler::types::binary::{Binary, NewBinary, OwnedBinary};
 use rustler::{Env, Error, NifResult, Term};
@@ -37,6 +38,9 @@ pub fn new_binary_new(env: Env) -> Binary {
 
 #[rustler::nif]
 pub fn unowned_to_owned<'a>(env: Env<'a>, binary: Binary<'a>) -> NifResult<Binary<'a>> {
+    // Do nothing and suppress panic message. From https://stackoverflow.com/a/35559417
+    panic::set_hook(Box::new(|_info| {}));
+
     let mut copied = binary.to_owned().unwrap();
     copied.as_mut_slice()[0] = 1;
     Ok(copied.release(env))

--- a/rustler_tests/native/rustler_test/src/test_list.rs
+++ b/rustler_tests/native/rustler_test/src/test_list.rs
@@ -1,7 +1,11 @@
 use rustler::{Error, ListIterator, NifResult};
+use std::panic;
 
 #[rustler::nif]
 pub fn sum_list(iter: ListIterator) -> NifResult<i64> {
+    // Do nothing and suppress panic message. From https://stackoverflow.com/a/35559417
+    panic::set_hook(Box::new(|_info| {}));
+
     let res: Result<Vec<i64>, Error> = iter.map(|x| x.decode::<i64>()).collect();
 
     match res {

--- a/rustler_tests/native/rustler_test/src/test_thread.rs
+++ b/rustler_tests/native/rustler_test/src/test_thread.rs
@@ -2,6 +2,8 @@ use rustler::thread;
 use rustler::types::atom;
 use rustler::{Atom, Encoder, Env};
 
+use std::panic;
+
 #[rustler::nif]
 pub fn threaded_fac(env: Env, n: u64) -> Atom {
     // Multiply two numbers; panic on overflow. In Rust, the `*` operator wraps (rather than
@@ -10,6 +12,9 @@ pub fn threaded_fac(env: Env, n: u64) -> Atom {
     fn mul(a: u64, b: u64) -> u64 {
         a.checked_mul(b).expect("threaded_fac: integer overflow")
     }
+
+    // Do nothing and suppress panic message. From https://stackoverflow.com/a/35559417
+    panic::set_hook(Box::new(|_info| {}));
 
     thread::spawn::<thread::ThreadSpawner, _>(env, move |thread_env| {
         let result = (1..=n).fold(1, mul);

--- a/rustler_tests/test/binary_example_test.exs
+++ b/rustler_tests/test/binary_example_test.exs
@@ -2,7 +2,7 @@ defmodule BinaryExampleTest do
   use ExUnit.Case
 
   test "binary is compiled" do
-    bins = ~w(binary_example hello_rust hello_rust2)
+    bins = ~w(binary_example hello_rust)
 
     for bin <- bins do
       assert_exists(bin)

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -28,6 +28,8 @@ defmodule RustlerTest.BinaryTest do
   test "unowned binary to owned" do
     assert RustlerTest.unowned_to_owned("test") == <<1, "est">>
     assert RustlerTest.unowned_to_owned("whatisgoingon") == <<1, "hatisgoingon">>
+    # Notice that this also panic, but we are suppressing the message
+    # at the function implementation.
     assert_raise ErlangError, fn -> RustlerTest.unowned_to_owned("") end
   end
 

--- a/rustler_tests/test/list_test.exs
+++ b/rustler_tests/test/list_test.exs
@@ -6,6 +6,8 @@ defmodule RustlerTest.ListTest do
   end
 
   test "list iteration fails on improper lists" do
+    # Note that this also panic, but we are suppressing
+    # the panic message at the function implementation.
     assert_raise ErlangError, fn -> RustlerTest.sum_list([1, 4, 2 | :invalid]) end
   end
 

--- a/rustler_tests/test/thread_test.exs
+++ b/rustler_tests/test/thread_test.exs
@@ -49,7 +49,10 @@ defmodule RustlerTest.ThreadTest do
   end
 
   test "thread panic" do
-    # overflows u64 and panics
+    # Overflows u64 and panics.
+    #
+    # Note that we are suppressing the panic message inside the
+    # function implementation.
     RustlerTest.threaded_fac(100)
 
     receive do


### PR DESCRIPTION
It removes Elixir 1.11 that is not supported anymore.

It updates the version of Actions in the workflow, and also simplifies by merging parts that are common and can work together.