### PR TITLE
Improve nif macro error messages for invalid attributes

### DIFF
--- a/rustler_codegen/Cargo.toml
+++ b/rustler_codegen/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.27.0" # rustler_codegen version
 authors = ["Hansihe <hansihe@hansihe.com>"]
 license = "MIT/Apache-2.0"
 readme = "../README.md"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "rustler_codegen"
@@ -17,3 +17,6 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 heck = "0.4"
 proc-macro2 = "1.0"
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/rustler_codegen/tests/test.rs
+++ b/rustler_codegen/tests/test.rs
@@ -1,0 +1,5 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/rustler_codegen/tests/ui/nif-macro-unrecognized-attribute.rs
+++ b/rustler_codegen/tests/ui/nif-macro-unrecognized-attribute.rs
@@ -1,0 +1,8 @@
+use rustler_codegen::nif;
+
+#[nif(scheduler = "DirtyCpu")]
+fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+fn main() {}

--- a/rustler_codegen/tests/ui/nif-macro-unrecognized-attribute.stderr
+++ b/rustler_codegen/tests/ui/nif-macro-unrecognized-attribute.stderr
@@ -1,0 +1,5 @@
+error: Unsupported nif macro attribute. Expecting schedule or name.
+ --> tests/ui/nif-macro-unrecognized-attribute.rs:3:7
+  |
+3 | #[nif(scheduler = "DirtyCpu")]
+  |       ^^^^^^^^^

--- a/rustler_codegen/tests/ui/nif-macro-wrong-schedule-attribute-value.rs
+++ b/rustler_codegen/tests/ui/nif-macro-wrong-schedule-attribute-value.rs
@@ -1,0 +1,8 @@
+use rustler_codegen::nif;
+
+#[nif(schedule = "DirtyGPU")]
+fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+
+fn main() {}

--- a/rustler_codegen/tests/ui/nif-macro-wrong-schedule-attribute-value.stderr
+++ b/rustler_codegen/tests/ui/nif-macro-wrong-schedule-attribute-value.stderr
@@ -1,0 +1,5 @@
+error: The schedule option is expecting one of the values: ["Normal", "DirtyCpu", "DirtyIo"]
+ --> tests/ui/nif-macro-wrong-schedule-attribute-value.rs:3:7
+  |
+3 | #[nif(schedule = "DirtyGPU")]
+  |       ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The idea is to provide more contextual messages when an invalid "schedule" option is used.

This also includes a new dev dependency - [trybuild](https://github.com/dtolnay/trybuild) - that helps with the testing of compile error messages.