### PR TITLE
Use non-captured identifier in format string

### DIFF
--- a/rustler_tests/native/rustler_test/src/test_tuple.rs
+++ b/rustler_tests/native/rustler_test/src/test_tuple.rs
@@ -34,8 +34,11 @@ pub fn greeting_person_from_tuple(age_and_name: (u8, &str)) -> String {
     let (age, name) = age_and_name;
 
     if age > 18 {
-        format!("Hello, {name}! You are allowed in the bar area.")
+        format!("Hello, {}! You are allowed in the bar area.", name)
     } else {
-        format!("Hi, {name}! I'm sorry, but you are not allowed in the bar area.")
+        format!(
+            "Hi, {}! I'm sorry, but you are not allowed in the bar area.",
+            name
+        )
     }
 }


### PR DESCRIPTION
To ensure that MSRV of 1.56.1 still holds, replace the captured identifier in format strings. Capturing identifierts for format strings was introduced with Rust 1.58.0.