### PR TITLE
Make rustler_sys forward compatible

### DIFF
--- a/rustler_sys/src/rustler_sys_api.rs
+++ b/rustler_sys/src/rustler_sys_api.rs
@@ -187,6 +187,7 @@ pub enum ErlNifResourceFlags {
 #[repr(C)]
 pub enum ErlNifCharEncoding {
     ERL_NIF_LATIN1 = 1,
+    #[cfg(nif_2_17)]
     ERL_NIF_UTF8 = 2,
 }
 
@@ -330,6 +331,7 @@ pub enum ErlNifTermType {
 }
 
 /// See [ErlNifOption](http://www.erlang.org/doc/man/erl_nif.html#ErlNifOption) in the Erlang docs.
+#[cfg(nif_2_17)]
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum ErlNifOption {


### PR DESCRIPTION
Makes `rustler_sys` forward compatible by falling back to the highest available version as long as the NIF major version matches.