### PR TITLE
Apply current NIF version for tests and raise default

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../README.md"
 edition = "2018"
 
 [features]
-default = ["derive", "nif_version_2_14"]
+default = ["derive", "nif_version_2_15"]
 derive = ["rustler_codegen"]
 alternative_nif_init_name = []
 nif_version_2_14 = ["rustler_sys/nif_version_2_14"]

--- a/rustler_sys/Cargo.toml
+++ b/rustler_sys/Cargo.toml
@@ -35,8 +35,7 @@ build = "build.rs"
 categories = ["external-ffi-bindings"]
 
 [features]
-# Default version: 2.14
-default = ["nif_version_2_14"]
+default = ["nif_version_2_15"]
 nif_version_2_14 = []
 nif_version_2_15 = ["nif_version_2_14"]
 nif_version_2_16 = ["nif_version_2_15"]

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -2,10 +2,22 @@ defmodule NifNotLoadedError do
   defexception message: "nif not loaded"
 end
 
+defmodule RustlerTest.Helper do
+  def nif_feature_from_running_version() do
+    [major, minor | _] =
+      :erlang.system_info(:nif_version)
+      |> to_string
+      |> String.split(".")
+
+    "nif_version_#{major}_#{minor}"
+  end
+end
+
 defmodule RustlerTest do
   use Rustler,
     otp_app: :rustler_test,
-    crate: :rustler_test
+    crate: :rustler_test,
+    features: [RustlerTest.Helper.nif_feature_from_running_version()]
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 

--- a/rustler_tests/native/rustler_test/Cargo.toml
+++ b/rustler_tests/native/rustler_test/Cargo.toml
@@ -13,6 +13,12 @@ crate-type = ["cdylib"]
 name = "hello_rust"
 path = "src/main.rs"
 
+[features]
+nif_version_2_14 = ["rustler/nif_version_2_14"]
+nif_version_2_15 = ["nif_version_2_14", "rustler/nif_version_2_15"]
+nif_version_2_16 = ["nif_version_2_15", "rustler/nif_version_2_16"]
+nif_version_2_17 = ["nif_version_2_16", "rustler/nif_version_2_17"]
+
 [dependencies]
 lazy_static = "1.4"
 rustler = { path = "../../../rustler" }


### PR DESCRIPTION
- Activate matching version feature on the test projects
- Raise default NIF version to 2.15
