### PR TITLE
Fix NifTaggedEnum derived Encoder impl for named-field variants

### DIFF
--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -48,7 +48,7 @@ impl<'a> Term<'a> {
     }
 
     /// Construct a new map from two vectors of terms.
-    /// 
+    ///
     /// It is identical to map_from_arrays, but requires the keys and values to
     /// be encoded already - this is useful for constructing maps whose values
     /// or keys are different Rust types, with the same performance as map_from_arrays.

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -65,7 +65,11 @@ impl<'a> Term<'a> {
         values: impl EncoderIterable<'a>,
     ) -> NifResult<Term<'a>> {
         let keys: Vec<_> = keys.terms(env).into_iter().map(|t| t.as_c_arg()).collect();
-        let values: Vec<_> = values.terms(env).into_iter().map(|t| t.as_c_arg()).collect();
+        let values: Vec<_> = values
+            .terms(env)
+            .into_iter()
+            .map(|t| t.as_c_arg())
+            .collect();
 
         if keys.len() == values.len() {
             unsafe {
@@ -300,10 +304,10 @@ macro_rules! impl_encoder_args {
     );
 }
 
-impl <'a, A:Encoder> EncoderIterable<'a> for (A,) {
+impl<'a, A: Encoder> EncoderIterable<'a> for (A,) {
     type IntoIter = [Term<'a>; 1];
 
-    fn terms(&self,env:Env<'a>) -> Self::IntoIter {
+    fn terms(&self, env: Env<'a>) -> Self::IntoIter {
         [Encoder::encode(&self.0, env)]
     }
 }

--- a/rustler/src/types/map.rs
+++ b/rustler/src/types/map.rs
@@ -47,31 +47,20 @@ impl<'a> Term<'a> {
         }
     }
 
-    /// Construct a new map from two iterables
-    ///
-    /// It is identical to map_from_arrays, but accepts tuples
-    /// instead of arrays to allow differing types within the
-    /// keys and values.
-    ///
-    /// ### Elixir equivalent
-    /// ```elixir
-    /// keys = ["foo", "bar"]
-    /// values = [1, true]
-    /// Enum.zip(values) |> Map.new()
-    /// ```
-    pub fn map_from_iterables(
+    /// Construct a new map from two vectors of terms.
+    /// 
+    /// It is identical to map_from_arrays, but requires the keys and values to
+    /// be encoded already - this is useful for constructing maps whose values
+    /// or keys are different Rust types, with the same performance as map_from_arrays.
+    pub fn map_from_term_arrays(
         env: Env<'a>,
-        keys: impl EncoderIterable<'a>,
-        values: impl EncoderIterable<'a>,
+        keys: &[Term<'a>],
+        values: &[Term<'a>],
     ) -> NifResult<Term<'a>> {
-        let keys: Vec<_> = keys.terms(env).into_iter().map(|t| t.as_c_arg()).collect();
-        let values: Vec<_> = values
-            .terms(env)
-            .into_iter()
-            .map(|t| t.as_c_arg())
-            .collect();
-
         if keys.len() == values.len() {
+            let keys: Vec<_> = keys.iter().map(|k| k.as_c_arg()).collect();
+            let values: Vec<_> = values.iter().map(|v| v.as_c_arg()).collect();
+
             unsafe {
                 map::make_map_from_arrays(env.as_c_arg(), &keys, &values)
                     .map_or_else(|| Err(Error::BadArg), |map| Ok(Term::new(env, map)))
@@ -271,49 +260,3 @@ where
         Ok(first..=last)
     }
 }
-
-/// A trait for types that can be converted to an iterable of terms
-/// using an `Env`.
-///
-/// Used by Term::map_from_iterables
-pub trait EncoderIterable<'a> {
-    type IntoIter: IntoIterator<Item = Term<'a>>;
-
-    fn terms(&self, env: Env<'a>) -> Self::IntoIter;
-}
-
-/// Helper macro that returns the number of comma-separated expressions passed to it.
-/// For example, `count!(a + b, c)` evaluates to `2`.
-macro_rules! count {
-    ( ) => ( 0 );
-    ( $blah:expr ) => ( 1 );
-    ( $blah:expr, $( $others:expr ),* ) => ( 1 + count!( $( $others ),* ) )
-}
-
-macro_rules! impl_encoder_args {
-    ( $($index:tt : $tyvar:ident),* ) => (
-        impl<'a, $( $tyvar: Encoder ),*>
-            EncoderIterable<'a> for ( $( $tyvar ),* ) {
-
-            type IntoIter = [Term<'a>; count!( $( $tyvar ),* )];
-
-            fn terms(&self, env: Env<'a>) -> Self::IntoIter {
-                [ $( Encoder::encode(&self.$index, env) ),* ]
-            }
-        }
-    );
-}
-
-impl<'a, A: Encoder> EncoderIterable<'a> for (A,) {
-    type IntoIter = [Term<'a>; 1];
-
-    fn terms(&self, env: Env<'a>) -> Self::IntoIter {
-        [Encoder::encode(&self.0, env)]
-    }
-}
-impl_encoder_args!(0: A, 1: B);
-impl_encoder_args!(0: A, 1: B, 2: C);
-impl_encoder_args!(0: A, 1: B, 2: C, 3: D);
-impl_encoder_args!(0: A, 1: B, 2: C, 3: D, 4: E);
-impl_encoder_args!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F);
-impl_encoder_args!(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G);

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -332,12 +332,12 @@ fn gen_named_encoder(
         let key_tuple = match &keys[..] {
             [] => panic!("{}", "Named fields can not be empty"),
             [fn0] => quote! { (#fn0(),) },
-            _ => quote! { (#(#keys()),*) }
+            _ => quote! { (#(#keys()),*) },
         };
         let value_tuple = match &values[..] {
             [] => panic!("{}", "Named fields can not be empty"),
             [v0] => quote! { (#v0,) },
-            _ => quote! { (#(#values),*) }
+            _ => quote! { (#(#values),*) },
         };
         quote! {
             #enum_name :: #variant_ident{

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -312,7 +312,7 @@ fn gen_named_encoder(
             }
         })
         .collect::<Vec<_>>();
-    let (pairs, field_defs): (Vec<_>, Vec<_>) = fields
+    let (keys, values): (Vec<_>, Vec<_>) = fields
         .named
         .iter()
         .map(|field| {
@@ -321,42 +321,19 @@ fn gen_named_encoder(
                 .as_ref()
                 .expect("Named fields must have an ident.");
             let atom_fun = Context::field_to_atom_fun(field);
-            let field_put = quote_spanned! { field.span() =>
-                map = map.map_put(#atom_fun(), &#field_ident).unwrap();
-            };
-            ((atom_fun, field_ident), field_put)
+            (
+                quote! { ::rustler::Encoder::encode(&#atom_fun(), env) },
+                quote! { ::rustler::Encoder::encode(&#field_ident, env) },
+            )
         })
         .unzip();
-    let (keys, values): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
-    if keys.len() < 8 {
-        let key_tuple = match &keys[..] {
-            [] => panic!("{}", "Named fields can not be empty"),
-            [fn0] => quote! { (#fn0(),) },
-            _ => quote! { (#(#keys()),*) },
-        };
-        let value_tuple = match &values[..] {
-            [] => panic!("{}", "Named fields can not be empty"),
-            [v0] => quote! { (#v0,) },
-            _ => quote! { (#(#values),*) },
-        };
-        quote! {
-            #enum_name :: #variant_ident{
-                #(#field_decls)*
-            } => {
-                let map = ::rustler::Term::map_from_iterables(env, #key_tuple, #value_tuple)
-                    .expect("Failed to create map");
-                ::rustler::types::tuple::make_tuple(env, &[::rustler::Encoder::encode(&#atom_fn(), env), map])
-            }
-        }
-    } else {
-        quote! {
-            #enum_name :: #variant_ident{
-                #(#field_decls)*
-            } => {
-                let mut map = ::rustler::types::map::map_new(env);
-                #(#field_defs)*
-                ::rustler::types::tuple::make_tuple(env, &[::rustler::Encoder::encode(&#atom_fn(), env), map])
-            }
+    quote! {
+        #enum_name :: #variant_ident{
+            #(#field_decls)*
+        } => {
+            let map = ::rustler::Term::map_from_term_arrays(env, &[#(#keys),*], &[#(#values),*])
+                .expect("Failed to create map");
+            ::rustler::types::tuple::make_tuple(env, &[::rustler::Encoder::encode(&#atom_fn(), env), map])
         }
     }
 }

--- a/rustler_codegen/src/tagged_enum.rs
+++ b/rustler_codegen/src/tagged_enum.rs
@@ -312,7 +312,7 @@ fn gen_named_encoder(
             }
         })
         .collect::<Vec<_>>();
-    let field_defs: Vec<_> = fields
+    let (keys, values): (Vec<_>, Vec<_>) = fields
         .named
         .iter()
         .map(|field| {
@@ -321,17 +321,15 @@ fn gen_named_encoder(
                 .as_ref()
                 .expect("Named fields must have an ident.");
             let atom_fun = Context::field_to_atom_fun(field);
-            quote_spanned! { field.span() =>
-                map = map.map_put(#atom_fun(), &#field_ident).unwrap();
-            }
+            (atom_fun, field_ident)
         })
-        .collect();
+        .unzip();
     quote! {
         #enum_name :: #variant_ident{
             #(#field_decls)*
         } => {
-            let mut map = ::rustler::types::map::map_new(env);
-            #(#field_defs)*
+            let map = ::rustler::Term::map_from_arrays(env, &[#(#keys()),*], &[#(#values),*])
+                .expect("Failed to create map");
             ::rustler::types::tuple::make_tuple(env, &[::rustler::Encoder::encode(&#atom_fn(), env), map])
         }
     }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -95,6 +95,7 @@ defmodule RustlerTest do
   def tagged_enum_1_echo(_), do: err()
   def tagged_enum_2_echo(_), do: err()
   def tagged_enum_3_echo(_), do: err()
+  def tagged_enum_4_echo(_), do: err()
   def untagged_enum_echo(_), do: err()
   def untagged_enum_with_truthy(_), do: err()
   def untagged_enum_for_issue_370(_), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -70,6 +70,7 @@ rustler::init!(
         test_codegen::tagged_enum_1_echo,
         test_codegen::tagged_enum_2_echo,
         test_codegen::tagged_enum_3_echo,
+        test_codegen::tagged_enum_4_echo,
         test_codegen::untagged_enum_echo,
         test_codegen::untagged_enum_with_truthy,
         test_codegen::untagged_enum_for_issue_370,

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -44,6 +44,7 @@ pub fn record_echo(record: AddRecord) -> AddRecord {
 pub struct AddMap {
     lhs: i32,
     rhs: i32,
+    loc: (u32, u32),
 }
 
 #[rustler::nif]
@@ -57,12 +58,14 @@ pub fn map_echo(map: AddMap) -> AddMap {
 pub struct AddStruct {
     lhs: i32,
     rhs: i32,
+    loc: (u32, u32),
 }
 
 #[derive(Debug, NifException)]
 #[module = "AddException"]
 pub struct AddException {
     message: String,
+    loc: (u32, u32),
 }
 
 #[rustler::nif]

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -125,6 +125,18 @@ pub fn tagged_enum_3_echo(tagged_enum: TaggedEnum3) -> TaggedEnum3 {
     tagged_enum
 }
 
+#[derive(NifTaggedEnum)]
+pub enum TaggedEnum4 {
+    Unit,
+    Unnamed(u64, bool),
+    Named { size: u64, filename: String },
+}
+
+#[rustler::nif]
+pub fn tagged_enum_4_echo(tagged_enum: TaggedEnum4) -> TaggedEnum4 {
+    tagged_enum
+}
+
 #[derive(NifUntaggedEnum)]
 pub enum UntaggedEnum {
     Foo(u32),

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -132,7 +132,10 @@ pub fn tagged_enum_3_echo(tagged_enum: TaggedEnum3) -> TaggedEnum3 {
 pub enum TaggedEnum4 {
     Unit,
     Unnamed(u64, bool),
-    Named { size: u64, filename: String },
+    Named {
+        size: u64,
+        filename: String,
+    },
     Long {
         f0: bool,
         f1: u8,
@@ -143,7 +146,7 @@ pub enum TaggedEnum4 {
         f6: Option<i32>,
         f7: Option<i32>,
         f8: Option<i32>,
-    }
+    },
 }
 
 #[rustler::nif]

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -130,6 +130,17 @@ pub enum TaggedEnum4 {
     Unit,
     Unnamed(u64, bool),
     Named { size: u64, filename: String },
+    Long {
+        f0: bool,
+        f1: u8,
+        f2: u8,
+        f3: u8,
+        f4: u8,
+        f5: Option<i32>,
+        f6: Option<i32>,
+        f7: Option<i32>,
+        f8: Option<i32>,
+    }
 }
 
 #[rustler::nif]

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -279,6 +279,31 @@ defmodule RustlerTest.CodegenTest do
              end)
   end
 
+  test "tagged enum transcoder 4" do
+    assert :unit == RustlerTest.tagged_enum_4_echo(:unit)
+
+    assert {:unnamed, 10_000_000_000, true} ==
+             RustlerTest.tagged_enum_4_echo({:unnamed, 10_000_000_000, true})
+
+    assert {:named, %{filename: "\u2200", size: 123}} ==
+             RustlerTest.tagged_enum_4_echo({:named, %{filename: "\u2200", size: 123}})
+
+    assert %ErlangError{original: :invalid_variant} ==
+             assert_raise(ErlangError, fn ->
+               RustlerTest.tagged_enum_4_echo({})
+             end)
+
+    assert %ErlangError{original: :invalid_variant} ==
+             assert_raise(ErlangError, fn ->
+               RustlerTest.tagged_enum_4_echo(%{})
+             end)
+
+    assert %ErlangError{original: :invalid_variant} ==
+             assert_raise(ErlangError, fn ->
+               RustlerTest.tagged_enum_4_echo({nil})
+             end)
+  end
+
   test "untagged enum transcoder" do
     assert 123 == RustlerTest.untagged_enum_echo(123)
     assert "Hello" == RustlerTest.untagged_enum_echo("Hello")

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -288,6 +288,11 @@ defmodule RustlerTest.CodegenTest do
     assert {:named, %{filename: "\u2200", size: 123}} ==
              RustlerTest.tagged_enum_4_echo({:named, %{filename: "\u2200", size: 123}})
 
+    long_map = %{f0: true, f1: 8, f2: 5, f3: 12, f4: 12, f5: 15,
+                 f6: nil, f7: nil, f8: nil}
+    assert {:long, long_map} ==
+              RustlerTest.tagged_enum_4_echo({:long, long_map})
+
     assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->
                RustlerTest.tagged_enum_4_echo(:unnamed)

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -47,6 +47,7 @@ defmodule RustlerTest.CodegenTest do
 
     test "with invalid map" do
       value = %{lhs: "invalid", rhs: 2, loc: {57, 15}}
+
       assert_raise ErlangError, "Erlang error: \"Could not decode field :lhs on %{}\"", fn ->
         assert value == RustlerTest.map_echo(value)
       end
@@ -76,10 +77,10 @@ defmodule RustlerTest.CodegenTest do
       value = %AddStruct{lhs: 45, rhs: 123, loc: {-76, -15}}
 
       assert_raise ErlangError,
-                  "Erlang error: \"Could not decode field :loc on %AddStruct{}\"",
-                  fn ->
-                    RustlerTest.struct_echo(value)
-                  end
+                   "Erlang error: \"Could not decode field :loc on %AddStruct{}\"",
+                   fn ->
+                     RustlerTest.struct_echo(value)
+                   end
     end
   end
 
@@ -106,10 +107,10 @@ defmodule RustlerTest.CodegenTest do
       value = %AddException{message: "testing", loc: %{line: 114, col: 15}}
 
       assert_raise ErlangError,
-                  "Erlang error: \"Could not decode field :loc on %AddException{}\"",
-                  fn ->
-                    RustlerTest.exception_echo(value)
-                  end
+                   "Erlang error: \"Could not decode field :loc on %AddException{}\"",
+                   fn ->
+                     RustlerTest.exception_echo(value)
+                   end
     end
   end
 
@@ -303,10 +304,10 @@ defmodule RustlerTest.CodegenTest do
     assert {:named, %{filename: "\u2200", size: 123}} ==
              RustlerTest.tagged_enum_4_echo({:named, %{filename: "\u2200", size: 123}})
 
-    long_map = %{f0: true, f1: 8, f2: 5, f3: 12, f4: 12, f5: 15,
-                 f6: nil, f7: nil, f8: nil}
+    long_map = %{f0: true, f1: 8, f2: 5, f3: 12, f4: 12, f5: 15, f6: nil, f7: nil, f8: nil}
+
     assert {:long, long_map} ==
-              RustlerTest.tagged_enum_4_echo({:long, long_map})
+             RustlerTest.tagged_enum_4_echo({:long, long_map})
 
     assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -290,17 +290,22 @@ defmodule RustlerTest.CodegenTest do
 
     assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->
-               RustlerTest.tagged_enum_4_echo({})
+               RustlerTest.tagged_enum_4_echo(:unnamed)
              end)
 
     assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->
-               RustlerTest.tagged_enum_4_echo(%{})
+               RustlerTest.tagged_enum_4_echo({:unit, 2, false})
              end)
 
     assert %ErlangError{original: :invalid_variant} ==
              assert_raise(ErlangError, fn ->
-               RustlerTest.tagged_enum_4_echo({nil})
+               RustlerTest.tagged_enum_4_echo({:named, "@", 45})
+             end)
+
+    assert %ErlangError{original: :invalid_variant} ==
+             assert_raise(ErlangError, fn ->
+               RustlerTest.tagged_enum_4_echo(nil)
              end)
   end
 


### PR DESCRIPTION
Hi :wave:,

On rustler 0.28.0, I get an error in the generated code from enums like this:

```rust
#[derive(NifTaggedEnum)]
enum TaggedEnum {
    Numbers { unit: Option<String>, values: Vec<f64> }
}
/*
error[E0308]: mismatched types
  --> src/types.rs:85:29
   |
85 |                     &[unit, values],
   |                             ^^^^^^ expected `&Option<String>`, found `&Vec<f64>`
   |
   = note: expected reference `&std::option::Option<std::string::String>`
              found reference `&Vec<f64>`
*/
```

The slice was being passed to `map_from_arrays`. I looked at NifMap's equivalent `gen_named_encoder` and copied the `map_put` strategy, which worked.

If performance is a concern, I think a set of `map_from(env, k1, v1, ...)` functions for small map sizes could accomplish the same thing but still use `enif_make_map_from_arrays`.
