### PR TITLE
Exclude directories from external resources to be compatible with Elixir 1.15

### DIFF
--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -105,7 +105,7 @@ defmodule Rustler.Compiler.Config do
     path
     |> Path.join("**/*")
     |> Path.wildcard()
-    |> Enum.reject(&String.starts_with?(&1, "#{path}/target/"))
+    |> Enum.reject(&(String.starts_with?(&1, "#{path}/target/") or File.dir?(&1)))
   end
 
   defp local_crate?(package) do


### PR DESCRIPTION
Elixir 1.15 handles external resources differently:

https://github.com/elixir-lang/elixir/blob/v1.15.0/CHANGELOG.md#mix

`[mix compile] Track digests of @external_resources`

It will try to read the file content and compute a digest to know if the file should be recompiled. https://github.com/elixir-lang/elixir/blob/96996cef7dbdbb5daa8c8009d1e51582d4c4023e/lib/mix/lib/mix/compilers/elixir.ex#L445C1-L445C1

Because rustler includes directories in the `@external_resources` module attribute, trying to recompile after a first compilation will fail with this error:

```
** (File.Error) could not read file "native/name_of_project/src": illegal operation on a directory
    (elixir 1.15.0) lib/file.ex:358: File.read!/1
    (mix 1.15.0) lib/mix/compilers/elixir.ex:441: Mix.Compilers.Elixir.digest_file!/1
    (mix 1.15.0) lib/mix/compilers/elixir.ex:426: Mix.Compilers.Elixir.stale_external?/3
    (elixir 1.15.0) lib/enum.ex:4190: Enum.predicate_list/3
    (mix 1.15.0) lib/mix/compilers/elixir.ex:394: anonymous fn/6 in Mix.Compilers.Elixir.compiler_info_from_updated/9
    (elixir 1.15.0) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3
    (mix 1.15.0) lib/mix/compilers/elixir.ex:385: Mix.Compilers.Elixir.compiler_info_from_updated/9
    (mix 1.15.0) lib/mix/compilers/elixir.ex:134: Mix.Compilers.Elixir.compile/7
``` 