### PR TITLE
Use compile_env for compile-time configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer ver
 ### Changed
 
 * Dropped support for `RUSTLER_NIF_VERSION`
+* Deprecated `:rustler_crates` project configuration
+* Mark `use Rustler` module configuration as compile-time
 
 ## [0.29.0] - 2023-06-22
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,12 @@
 
 This document is intended to simplify upgrading to newer versions by extending the changelog.
 
+## 0.29 -> ...
+
+`rustler_crates` configuration is deprecated in favor of explicitly passing
+options on `use Rustler` or configuring the module in your `config/*.exs`
+files.
+
 ## 0.28 -> 0.29
 
 `RUSTLER_NIF_VERSION` is deprecated and will not be considered anymore for 0.30.

--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -51,15 +51,15 @@ defmodule Rustler do
 
       Example
 
-        defmodule NIF do
-          use Rustler, load_data_fun: {Deployment, :nif_data}
-        end
-
-        defmodule Deployment do
-          def nif_data do
-            :code.priv_dir(:otp_app) |> IO.iodata_to_binary()
+          defmodule NIF do
+            use Rustler, load_data_fun: {Deployment, :nif_data}
           end
-        end
+
+          defmodule Deployment do
+            def nif_data do
+              :code.priv_dir(:otp_app) |> IO.iodata_to_binary()
+            end
+          end
 
     * `:load_from` - This option allows control over where the final artifact should be
       loaded from at runtime. By default the compiled artifact is loaded from the
@@ -79,7 +79,7 @@ defmodule Rustler do
 
     * `:target` - Specify a compile [target] triple.
 
-    * `:target_dir`: Override the compiler output directory.
+    * `:target_dir` - Override the compiler output directory.
 
   Any of the above options can be passed directly into the `use` macro like so:
 
@@ -95,7 +95,9 @@ defmodule Rustler do
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
-      config = Rustler.Compiler.compile_crate(__MODULE__, opts)
+      otp_app = Keyword.fetch!(opts, :otp_app)
+      env = Application.compile_env(otp_app, __MODULE__, [])
+      config = Rustler.Compiler.compile_crate(otp_app, __MODULE__, env, opts)
 
       for resource <- config.external_resources do
         @external_resource resource
@@ -170,8 +172,8 @@ defmodule Rustler do
   """
   def nif_versions,
     do: [
-      '2.14',
-      '2.15',
-      '2.16'
+      ~c"2.14",
+      ~c"2.15",
+      ~c"2.16"
     ]
 end

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -4,9 +4,8 @@ defmodule Rustler.Compiler do
   alias Rustler.Compiler.{Config, Messages, Rustup}
 
   @doc false
-  def compile_crate(module, opts) do
-    otp_app = Keyword.fetch!(opts, :otp_app)
-    config = Config.from(otp_app, module, opts)
+  def compile_crate(otp_app, module, config, opts) do
+    config = Config.from(otp_app, module, config, opts)
 
     unless config.skip_compilation? do
       crate_full_path = Path.expand(config.path, File.cwd!())

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -32,13 +32,18 @@ defmodule Rustler.Compiler.Config do
 
   alias Rustler.Compiler.Config
 
-  def from(otp_app, module, opts) do
-    config = Application.get_env(otp_app, module, [])
-
+  def from(otp_app, module, config, opts) do
     crate = config[:crate] || opts[:crate] || otp_app
 
     # TODO: Remove in 1.0
-    rustler_crates = Mix.Project.config()[:rustler_crates] || []
+    rustler_crates =
+      if mix_config = Mix.Project.config()[:rustler_crates] do
+        mix_config
+      else
+        IO.warn(":rustler_crates in mix.exs is deprecated, please use config instead")
+        []
+      end
+
     legacy_config = rustler_crates[to_atom(crate)] || []
 
     defaults = %Config{

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -40,7 +40,10 @@ defmodule Rustler.Compiler.Config do
       if mix_config = Mix.Project.config()[:rustler_crates] do
         mix_config
       else
-        IO.warn(":rustler_crates in mix.exs is deprecated, please use config instead")
+        IO.warn(
+          ":rustler_crates in mix.exs is deprecated, please explicitly pass options on `use Rustler` or configure the module in your `config/*.exs` files"
+        )
+
         []
       end
 

--- a/rustler_mix/lib/rustler/compiler/messages.ex
+++ b/rustler_mix/lib/rustler/compiler/messages.ex
@@ -24,22 +24,6 @@ defmodule Rustler.Compiler.Messages do
     """
   end
 
-  def message(:no_crates_property) do
-    """
-    No NIF crates listed in project definition.
-    Add some crate directories under :rustler_crates in the mix.exs project definition to compile them.
-
-    Example:
-    rustler_crates: ["/native/my_nif_crate"]
-    """
-  end
-
-  def message(:no_config) do
-    """
-    Add your crate to the 'rustler_crates' attribute in the project function.
-    """
-  end
-
   def message({:differing_versions, crate, rustler_version, codegen_version}) do
     """
     The '#{crate}' crate should have the same rustler and rustler_codegen version in its Cargo.toml:
@@ -75,12 +59,6 @@ defmodule Rustler.Compiler.Messages do
     > rustler_codegen = #{version}
 
     Note: You should already have this if you made your project with the project generator.
-    """
-  end
-
-  def message({:cargo_no_name, crate}) do
-    """
-    No library or binary with name listed in Cargo.toml of crate '#{crate}'.
     """
   end
 


### PR DESCRIPTION
We also deprecate rustler_crates since that cannot be as efficiently tracked by the Elixir compiler.