### PR TITLE
Remove cfg! directives in build.rs causing cross-compilation to fail

### DIFF
--- a/rustler_sys/build.rs
+++ b/rustler_sys/build.rs
@@ -895,8 +895,10 @@ fn get_nif_version_from_features() -> (u32, u32) {
 
 fn main() {
     let nif_version = get_nif_version_from_features();
+    let target_family_or_current =
+        env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_else(|_| env::consts::FAMILY.to_string());
 
-    let target_family = if cfg!(target_family = "windows") {
+    let target_family = if target_family_or_current == "windows" {
         OsFamily::Win
     } else if cfg!(target_family = "unix") {
         OsFamily::Unix
@@ -904,12 +906,20 @@ fn main() {
         panic!("Unsupported Operational System Family")
     };
 
+    let target_pointer_width = match env::var("CARGO_CFG_TARGET_POINTER_WIDTH") {
+       Ok(target_pointer_width) => target_pointer_width,
+         Err(err) => panic!(
+            "An error occurred while determining the pointer width to compile `rustler_sys` for:\n\n{:?}\n\nPlease report a bug.",
+            err
+        )
+    };
+
     let ulong_size = match target_family {
         OsFamily::Win => 4,
         OsFamily::Unix => {
-            if cfg!(target_pointer_width = "32") {
+            if target_pointer_width == "32" {
                 4
-            } else if cfg!(target_pointer_width = "64") {
+            } else if target_pointer_width == "64" {
                 8
             } else {
                 panic!("Unsupported target pointer width")


### PR DESCRIPTION
By bumping `rustler` to `0.29.0` in a project using `rustler_precompiled`, I realized that the cross-compilation of some targets fails.
For instance,  when compiling rustler with `cargo build --target=arm-unknown-linux-gnueabihf`, the ulong_size is not picked up correctly.
This is because the build.rs is compiled by the host prior to being executed, so the `cfg!` macro refers to the host configuration.
This PR reverts the usage of the `cfg!` macro in favor of the `CARGO_*` env variables.