### PR TITLE
Document to use runtime: false for rustler dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer ver
 * Dropped support for `RUSTLER_NIF_VERSION`
 * Deprecated `:rustler_crates` project configuration
 * Mark `use Rustler` module configuration as compile-time
+* Make `:rustler` a compile-time-only dependency (#516, #559)
 
 ## [0.29.1] - 2023-06-30
 

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -41,7 +41,7 @@ sed -i "s/^version = \"[^\"]*\" # rustler_codegen version$/version = \"$VERSION\
 sed -i "s/^rustler.*$/rustler = {path = \"..\/rustler\", version = \"$VERSION\"}/" rustler_bigint/Cargo.toml
 sed -i "s/def rustler_version, do: \"[^\"]*\"$/def rustler_version, do: \"$VERSION\"/" rustler_mix/mix.exs rustler_mix/lib/rustler.ex
 sed -i "s/@version .*$/@version \"$VERSION\"/" rustler_mix/mix.exs
-sed -i "s/{:rustler, \".*\"}/{:rustler, \"~> $VERSION\"}/" rustler_mix/README.md
+sed -i "s/{:rustler, \".*\"/{:rustler, \"~> $VERSION\"/" rustler_mix/README.md
 
 echo "Committing version.."
 git commit -m "(release) $VERSION" \

--- a/rustler_benchmarks/mix.exs
+++ b/rustler_benchmarks/mix.exs
@@ -22,7 +22,7 @@ defmodule RustlerBenchmarks.MixProject do
   defp deps do
     [
       {:benchee, "~> 1.0"},
-      {:rustler, path: "../rustler_mix"}
+      {:rustler, path: "../rustler_mix", runtime: false}
     ]
   end
 end

--- a/rustler_mix/README.md
+++ b/rustler_mix/README.md
@@ -15,7 +15,7 @@ This package is available on [Hex.pm](https://hex.pm/packages/rustler). To insta
 ```elixir
 def deps do
   [
-    {:rustler, "~> 0.29.1"}
+    {:rustler, "~> 0.29.1", runtime: false}
   ]
 end
 ```

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -90,5 +90,10 @@ EOF
 
 mix test
 
+# See https://github.com/rusterlium/rustler/issues/516, we also need to verify that everything
+# we need is part of a release.
+mix release
+_build/dev/rel/test_rustler_mix/bin/test_rustler_mix eval 'RustlerMixTest.add(1, 2)'
+
 echo "Done; cleaning up"
 rm -r $tmp

--- a/rustler_mix/test.sh
+++ b/rustler_mix/test.sh
@@ -47,7 +47,7 @@ defmodule TestRustlerMix.MixProject do
 
   def application, do: [ ]
 
-  defp deps, do: [ {:rustler, path: "$rustler_mix"} ]
+  defp deps, do: [ {:rustler, path: "$rustler_mix", runtime: false} ]
 end
 EOF
 


### PR DESCRIPTION
As noted by @hauleth in #516, the rustler dependency is only required at compile time. This PR makes that possible by expanding `Rustler.construct_load_data/2` into the target module. The PR changes the documentation (and a test of the toolchain) to instruct that `runtime: false` can be used with rustler as a dependency.

Fix #516