### PR TITLE
Remove superfluous `module` argument

### DIFF
--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -97,7 +97,7 @@ defmodule Rustler do
     quote bind_quoted: [opts: opts] do
       otp_app = Keyword.fetch!(opts, :otp_app)
       env = Application.compile_env(otp_app, __MODULE__, [])
-      config = Rustler.Compiler.compile_crate(otp_app, __MODULE__, env, opts)
+      config = Rustler.Compiler.compile_crate(otp_app, env, opts)
 
       for resource <- config.external_resources do
         @external_resource resource

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -4,8 +4,8 @@ defmodule Rustler.Compiler do
   alias Rustler.Compiler.{Config, Messages, Rustup}
 
   @doc false
-  def compile_crate(otp_app, module, config, opts) do
-    config = Config.from(otp_app, module, config, opts)
+  def compile_crate(otp_app, config, opts) do
+    config = Config.from(otp_app, config, opts)
 
     unless config.skip_compilation? do
       crate_full_path = Path.expand(config.path, File.cwd!())

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -32,7 +32,7 @@ defmodule Rustler.Compiler.Config do
 
   alias Rustler.Compiler.Config
 
-  def from(otp_app, module, config, opts) do
+  def from(otp_app, config, opts) do
     crate = config[:crate] || opts[:crate] || otp_app
 
     # TODO: Remove in 1.0


### PR DESCRIPTION
This PR removes this warning:

```
warning: variable "module" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/rustler/compiler/config.ex:35
```