### PR TITLE
feat: add result-returning `send` variants to `Env` and `OwnedEnv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer ver
 * Mark `use Rustler` module configuration as compile-time
 * Bump Rust edition to 2021
 * Make `:rustler` a compile-time-only dependency (#516, #559)
+* Return `Result<(), SendError>` from all `send` functions (#239, #563)
 
 ## [0.29.1] - 2023-06-30
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,6 +8,16 @@ This document is intended to simplify upgrading to newer versions by extending t
 options on `use Rustler` or configuring the module in your `config/*.exs`
 files.
 
+Additionally, `Env::send` and `OwnedEnv::send_and_clear` will now return a
+`Result`. Updating will thus introduce warnings about unused `Result`s. To
+remove the warnings without changing behaviour, the `Result`s can be "used" as
+```rust
+let _ = env.send(...)
+```
+Neither the `Ok` nor the `Err` case carry additional information so far. An
+error is returned if either the receiving or the sending process is dead. See
+also [enif\_send](https://www.erlang.org/doc/man/erl_nif.html#enif_send).
+
 ## 0.28 -> 0.29
 
 `RUSTLER_NIF_VERSION` is deprecated and will not be considered anymore for 0.30.

--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -30,6 +30,10 @@ impl<'a, 'b> PartialEq<Env<'b>> for Env<'a> {
     }
 }
 
+///
+#[derive(Clone, Copy, Debug)]
+pub struct SendError;
+
 impl<'a> Env<'a> {
     /// Create a new Env. For the `_lifetime_marker` argument, pass a
     /// reference to any local variable that has its own lifetime, different
@@ -71,12 +75,15 @@ impl<'a> Env<'a> {
     ///
     /// *   The current thread is *not* managed by the Erlang VM.
     ///
+    /// The result indicates whether the send was successful, see also
+    /// [enif\_send](https://www.erlang.org/doc/man/erl_nif.html#enif_send).
+    ///
     /// # Panics
     ///
     /// Panics if the above rules are broken (by trying to send a message from
     /// an `OwnedEnv` on a thread that's managed by the Erlang VM).
     ///
-    pub fn send(self, pid: &LocalPid, message: Term<'a>) {
+    pub fn send(self, pid: &LocalPid, message: Term<'a>) -> Result<(), SendError> {
         let thread_type = unsafe { rustler_sys::enif_thread_type() };
         let env = if thread_type == rustler_sys::ERL_NIF_THR_UNDEFINED {
             ptr::null_mut()
@@ -93,78 +100,15 @@ impl<'a> Env<'a> {
         };
 
         // Send the message.
-        unsafe {
-            rustler_sys::enif_send(env, pid.as_c_arg(), ptr::null_mut(), message.as_c_arg());
-        }
-    }
-
-    /// Send a message to a process, returning an `i32` result.
-    ///
-    /// ## See also
-    ///
-    /// - `send()`
-    /// - [OTP docs:
-    /// `enif_send`](https://www.erlang.org/doc/man/erl_nif#enif_send)
-    pub fn send_returning_i32(self, pid: &LocalPid, message: Term<'a>) -> i32 {
-        let thread_type = unsafe { rustler_sys::enif_thread_type() };
-        let env = if thread_type == rustler_sys::ERL_NIF_THR_UNDEFINED {
-            ptr::null_mut()
-        } else if thread_type == rustler_sys::ERL_NIF_THR_NORMAL_SCHEDULER
-            || thread_type == rustler_sys::ERL_NIF_THR_DIRTY_CPU_SCHEDULER
-            || thread_type == rustler_sys::ERL_NIF_THR_DIRTY_IO_SCHEDULER
-        {
-            // Panic if `self` is not the environment of the calling process.
-            self.pid();
-
-            self.as_c_arg()
-        } else {
-            panic!("Env::send(): unrecognized calling thread type");
+        let res = unsafe {
+            rustler_sys::enif_send(env, pid.as_c_arg(), ptr::null_mut(), message.as_c_arg())
         };
 
-        // Send the message.
-        unsafe { rustler_sys::enif_send(env, pid.as_c_arg(), ptr::null_mut(), message.as_c_arg()) }
-    }
-
-    /// Send a message to a process, returning a boolean result, `true` if the
-    /// send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_returning_i32()`
-    /// - `send()`
-    pub fn send_returning_i32_result(self, pid: &LocalPid, message: Term<'a>) -> Result<(), i32> {
-        let res = self.send_returning_i32(pid, message);
-        if 1 == res {
+        if res == 1 {
             Ok(())
         } else {
-            Err(res)
+            Err(SendError)
         }
-    }
-
-    /// Send a message to a process, returning a boolean result, `true` if the
-    /// send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_returning_i32()`
-    /// - `send()`
-    pub fn send_returning_result(self, pid: &LocalPid, message: Term<'a>) -> Result<(), ()> {
-        if 1 == self.send_returning_i32(pid, message) {
-            Ok(())
-        } else {
-            Err(())
-        }
-    }
-
-    /// Send a message to a process, returning a boolean result, `true` if the
-    /// send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_returning_i32()`
-    /// - `send()`
-    pub fn send_returning_bool(self, pid: &LocalPid, message: Term<'a>) -> bool {
-        1 == self.send_returning_i32(pid, message)
     }
 
     /// Attempts to find the PID of a process registered by `name_or_pid`
@@ -233,7 +177,7 @@ impl<'a> Env<'a> {
 ///
 ///     fn send_string_to_pid(data: &str, pid: &LocalPid) {
 ///         let mut msg_env = OwnedEnv::new();
-///         msg_env.send_and_clear(pid, |env| data.encode(env));
+///         let _ = msg_env.send_and_clear(pid, |env| data.encode(env));
 ///     }
 ///
 /// There's no way to run Erlang code in an `OwnedEnv`. It's not a process. It's just a workspace
@@ -267,38 +211,15 @@ impl OwnedEnv {
     /// The environment is cleared as though by calling the `.clear()` method.
     /// To avoid that, use `env.send(pid, term)` instead.
     ///
+    /// The result is the same as what `Env::send` would return.
+    ///
     /// # Panics
     ///
     /// Panics if called from a thread that is managed by the Erlang VM. You
     /// can only use this method on a thread that was created by other
     /// means. (This curious restriction is imposed by the Erlang VM.)
     ///
-    pub fn send_and_clear<F>(&mut self, recipient: &LocalPid, closure: F)
-    where
-        F: for<'a> FnOnce(Env<'a>) -> Term<'a>,
-    {
-        if unsafe { rustler_sys::enif_thread_type() } != rustler_sys::ERL_NIF_THR_UNDEFINED {
-            panic!("send_and_clear: current thread is managed");
-        }
-
-        let message = self.run(|env| closure(env).as_c_arg());
-
-        unsafe {
-            rustler_sys::enif_send(ptr::null_mut(), recipient.as_c_arg(), *self.env, message);
-        }
-
-        self.clear();
-    }
-
-    /// Send a message from a Rust thread to an Erlang process, returning an
-    /// `i32` result.
-    ///
-    /// ## See also
-    ///
-    /// - `send_and_clear()`
-    /// - [OTP docs:
-    /// `enif_send`](https://www.erlang.org/doc/man/erl_nif#enif_send)
-    pub fn send_and_clear_returning_i32<F>(&mut self, recipient: &LocalPid, closure: F) -> i32
+    pub fn send_and_clear<F>(&mut self, recipient: &LocalPid, closure: F) -> Result<(), SendError>
     where
         F: for<'a> FnOnce(Env<'a>) -> Term<'a>,
     {
@@ -314,66 +235,11 @@ impl OwnedEnv {
 
         self.clear();
 
-        res
-    }
-
-    /// Send a message from a Rust thread to an Erlang process, returning a
-    /// boolean result, `true` if the send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_and_clear_returning_i32()`
-    /// - `send()`
-    pub fn send_and_clear_returning_i32_result<F>(
-        &mut self,
-        recipient: &LocalPid,
-        closure: F,
-    ) -> Result<(), i32>
-    where
-        F: for<'a> FnOnce(Env<'a>) -> Term<'a>,
-    {
-        let res = self.send_and_clear_returning_i32(recipient, closure);
-        if 1 == res {
+        if res == 1 {
             Ok(())
         } else {
-            Err(res)
+            Err(SendError)
         }
-    }
-
-    /// Send a message from a Rust thread to an Erlang process, returning a
-    /// boolean result, `true` if the send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_and_clear_returning_i32()`
-    /// - `send()`
-    pub fn send_and_clear_returning_result<F>(
-        &mut self,
-        recipient: &LocalPid,
-        closure: F,
-    ) -> Result<(), ()>
-    where
-        F: for<'a> FnOnce(Env<'a>) -> Term<'a>,
-    {
-        if 1 == self.send_and_clear_returning_i32(recipient, closure) {
-            Ok(())
-        } else {
-            Err(())
-        }
-    }
-
-    /// Send a message from a Rust thread to an Erlang process, returning a
-    /// boolean result, `true` if the send succeeds, otherwise `false`.
-    ///
-    /// ## See also
-    ///
-    /// - `send_and_clear_returning_i32()`
-    /// - `send()`
-    pub fn send_and_clear_returning_bool<F>(&mut self, recipient: &LocalPid, closure: F) -> bool
-    where
-        F: for<'a> FnOnce(Env<'a>) -> Term<'a>,
-    {
-        1 == self.send_and_clear_returning_i32(recipient, closure)
     }
 
     /// Free all terms in this environment and clear it for reuse.

--- a/rustler/src/thread.rs
+++ b/rustler/src/thread.rs
@@ -41,7 +41,7 @@ where
 {
     let pid = env.pid();
     S::spawn(move || {
-        OwnedEnv::new().send_and_clear(&pid, |env| {
+        let _ = OwnedEnv::new().send_and_clear(&pid, |env| {
             match panic::catch_unwind(|| thread_fn(env)) {
                 Ok(term) => term,
                 Err(err) => {

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -83,6 +83,7 @@ defmodule RustlerTest do
   def threaded_sleep(_), do: err()
 
   def send_all(_, _), do: err()
+  def send(_, _), do: err()
   def whereis_pid(_), do: err()
   def sublists(_), do: err()
 

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -59,6 +59,7 @@ rustler::init!(
         test_thread::threaded_fac,
         test_thread::threaded_sleep,
         test_env::send_all,
+        test_env::send,
         test_env::whereis_pid,
         test_env::sublists,
         test_codegen::tuple_echo,

--- a/rustler_tests/test/env_test.exs
+++ b/rustler_tests/test/env_test.exs
@@ -67,4 +67,23 @@ defmodule RustlerTest.EnvTest do
     assert nil == RustlerTest.whereis_pid("not a PID")
     assert nil == RustlerTest.whereis_pid(:not_a_registered_name)
   end
+
+  test "send_error" do
+    task =
+      Task.async(fn ->
+        receive do
+          :exit -> :ok
+        end
+      end)
+
+    # A send to an alive process from an alive process should not return an
+    # error
+    assert :ok == RustlerTest.send(task.pid, :msg)
+    assert :ok == RustlerTest.send(task.pid, :exit)
+    Task.await(task)
+
+    # Once the target process is down, sends should error
+    assert :error == RustlerTest.send(task.pid, :msg)
+    assert :error == RustlerTest.send(task.pid, :msg)
+  end
 end


### PR DESCRIPTION
`Env::send()` and `OwnedEnv::send_and_clear()` should ideally not elide the return value of [`enif_send`](https://www.erlang.org/doc/man/erl_nif#enif_send).

Included are several variants, all of which provide exactly the same information, given the current NIF API.

My take is that the preferred solution would be to pick one and resignature `send()`, but we could also keep some/all of the variants provided instead.

In all cases, resignature would not a breaking API change, but will generate warnings for the `_result` variants. The `_i32` and `_bool` variants are less idiomatic, but do not suffer from this issue. Nonetheless, my thinking is that an unhandled `Result` warning is ideal in this case, as it makes users aware of the fact that they are currently discarding information without breaking the build.

The naming is intentionally clunky, and if we decide to keep one or more of the `send_*()` variants rather than resignature `send()`, I'm happy to redraft with nicer names. Additional/modified tests will also follow that decision.