### PR TITLE
POC PGO configuration

### DIFF
--- a/rustler_benchmarks/lib/benchmark.ex
+++ b/rustler_benchmarks/lib/benchmark.ex
@@ -1,5 +1,11 @@
 defmodule Benchmark do
-  use Rustler, otp_app: :rustler_benchmarks, crate: "benchmark", mode: :release
+  use Rustler,
+      otp_app: :rustler_benchmarks,
+      crate: "benchmark",
+      mode: :release,
+      pgo_commands: [
+          ["mix", "run", "-e", "Benchmark.NifStruct.run"]
+      ]
 
   def nifstruct_benchmark(_input, _operation), do: error()
   def nifrecord_benchmark(_input, _operation), do: error()

--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -10,6 +10,7 @@ defmodule Rustler.Compiler.Config do
   @type mode :: :debug | :release
   @type load_data :: term()
   @type path :: Path.t()
+  @type pgo_commands :: list(list(String.t())) | nil
 
   defstruct cargo: :system,
             crate: nil,
@@ -24,6 +25,7 @@ defmodule Rustler.Compiler.Config do
             mode: :release,
             otp_app: nil,
             path: "",
+            pgo_commands: nil,
             priv_dir: "",
             skip_compilation?: false,
             target: nil,


### PR DESCRIPTION
This PR adds a POC implementation to enable rustler projects to configure scripts that will be used to optimize the rust code using PGO following: https://doc.rust-lang.org/rustc/profile-guided-optimization.html#a-complete-cargo-workflow

I've only tested it on the Struct benchmark, it seems to give small but consistent (I only tried running a few times manually) improvement especially for the bigger "decode & encode" benchmark:
```
Benchmarking decode ...
Benchmarking decode and encode ...
# With PGO
Name                        ips        average  deviation         median         99th %
decode                   1.06 M        0.94 μs    ±49.74%        0.92 μs        1.30 μs
decode and encode        0.80 M        1.26 μs  ±1450.35%        1.20 μs        1.46 μs

Comparison: 
decode                   1.06 M
decode and encode        0.80 M - 1.33x slower +0.31 μs


# Without PGO
Name                        ips        average  deviation         median         99th %
decode                   1.04 M        0.96 μs    ±18.04%        0.95 μs        1.28 μs
decode and encode        0.76 M        1.32 μs  ±1367.14%        1.23 μs        2.17 μs

Comparison: 
decode                   1.04 M
decode and encode        0.76 M - 1.38x slower +0.36 μs
```

Maybe there is a bigger rustler project we could try it on.

This was first discussed in #565 