### PR TITLE
Add support for generic types

### DIFF
--- a/rustler_codegen/src/encode_decode_templates.rs
+++ b/rustler_codegen/src/encode_decode_templates.rs
@@ -31,25 +31,25 @@ pub(crate) fn decoder(ctx: &Context, inner: TokenStream) -> TokenStream {
         let where_clause = impl_generics.make_where_clause();
 
         for lifetime in lifetimes {
-            let mut puncated = syn::punctuated::Punctuated::new();
-            puncated.push(lifetime.clone());
+            let mut punctuated = syn::punctuated::Punctuated::new();
+            punctuated.push(lifetime.clone());
             let predicate = syn::PredicateLifetime {
                 lifetime: decode_lifetime.clone(),
                 colon_token: syn::token::Colon {
                     spans: [Span::call_site()],
                 },
-                bounds: puncated,
+                bounds: punctuated,
             };
             where_clause.predicates.push(predicate.into());
 
-            let mut puncated = syn::punctuated::Punctuated::new();
-            puncated.push(decode_lifetime.clone());
+            let mut punctuated = syn::punctuated::Punctuated::new();
+            punctuated.push(decode_lifetime.clone());
             let predicate = syn::PredicateLifetime {
                 lifetime: lifetime.clone(),
                 colon_token: syn::token::Colon {
                     spans: [Span::call_site()],
                 },
-                bounds: puncated,
+                bounds: punctuated,
             };
             where_clause.predicates.push(predicate.into());
         }

--- a/rustler_codegen/src/encode_decode_templates.rs
+++ b/rustler_codegen/src/encode_decode_templates.rs
@@ -12,15 +12,6 @@ pub(crate) fn decoder(ctx: &Context, inner: TokenStream) -> TokenStream {
     // The Decoder uses a special lifetime '__rustler_decode_lifetime. We need to ensure that all
     // other lifetimes are bound to this lifetime: As we decode from a term (which has a lifetime),
     // references to that term may not outlive the term itself.
-    let lifetimes: Vec<_> = generics
-        .params
-        .iter()
-        .filter_map(|g| match g {
-            syn::GenericParam::Lifetime(l) => Some(l.lifetime.clone()),
-            _ => None,
-        })
-        .collect();
-
     let mut impl_generics = generics.clone();
     let decode_lifetime = syn::Lifetime::new("'__rustler_decode_lifetime", Span::call_site());
     let lifetime_def = syn::LifetimeParam::new(decode_lifetime.clone());
@@ -28,93 +19,78 @@ pub(crate) fn decoder(ctx: &Context, inner: TokenStream) -> TokenStream {
         .params
         .push(syn::GenericParam::Lifetime(lifetime_def));
 
-    if !lifetimes.is_empty() {
-        let where_clause = impl_generics.make_where_clause();
+    let where_clause = impl_generics.make_where_clause();
 
-        for lifetime in lifetimes {
-            let mut punctuated = syn::punctuated::Punctuated::new();
-            punctuated.push(lifetime.clone());
-            let predicate = syn::PredicateLifetime {
-                lifetime: decode_lifetime.clone(),
-                colon_token: syn::token::Colon {
-                    spans: [Span::call_site()],
-                },
-                bounds: punctuated,
-            };
-            where_clause.predicates.push(predicate.into());
+    for lifetime in ctx.lifetimes.iter() {
+        let mut punctuated = syn::punctuated::Punctuated::new();
+        punctuated.push(lifetime.clone());
+        let predicate = syn::PredicateLifetime {
+            lifetime: decode_lifetime.clone(),
+            colon_token: syn::token::Colon {
+                spans: [Span::call_site()],
+            },
+            bounds: punctuated,
+        };
+        where_clause.predicates.push(predicate.into());
 
-            let mut punctuated = syn::punctuated::Punctuated::new();
-            punctuated.push(decode_lifetime.clone());
-            let predicate = syn::PredicateLifetime {
-                lifetime: lifetime.clone(),
-                colon_token: syn::token::Colon {
-                    spans: [Span::call_site()],
-                },
-                bounds: punctuated,
-            };
-            where_clause.predicates.push(predicate.into());
-        }
+        let mut punctuated = syn::punctuated::Punctuated::new();
+        punctuated.push(decode_lifetime.clone());
+        let predicate = syn::PredicateLifetime {
+            lifetime: lifetime.clone(),
+            colon_token: syn::token::Colon {
+                spans: [Span::call_site()],
+            },
+            bounds: punctuated,
+        };
+        where_clause.predicates.push(predicate.into());
     }
 
-    let type_parameters: Vec<_> = generics
-        .params
-        .iter()
-        .filter_map(|g| match g {
-            syn::GenericParam::Type(t) => Some(t.clone()),
-            _ => None,
-        })
-        .collect();
-
-    if !type_parameters.is_empty() {
-        let where_clause = impl_generics.make_where_clause();
-
-        for type_parameter in type_parameters {
-            let mut punctuated = syn::punctuated::Punctuated::new();
-            punctuated.push(decode_lifetime.clone().into());
-            punctuated.push(syn::TypeParamBound::Trait(TraitBound {
-                paren_token: None,
-                modifier: syn::TraitBoundModifier::None,
-                lifetimes: None,
-                path: syn::Path {
-                    leading_colon: Some(syn::token::PathSep::default()),
-                    segments: [
-                        PathSegment {
-                            ident: syn::Ident::new("rustler", Span::call_site()),
-                            arguments: syn::PathArguments::None,
-                        },
-                        PathSegment {
-                            ident: syn::Ident::new("Decoder", Span::call_site()),
-                            arguments: syn::PathArguments::AngleBracketed(
-                                syn::AngleBracketedGenericArguments {
-                                    colon2_token: None,
-                                    lt_token: Default::default(),
-                                    args: std::iter::once(GenericArgument::Lifetime(
-                                        decode_lifetime.clone(),
-                                    ))
-                                    .collect(),
-                                    gt_token: Default::default(),
-                                },
-                            ),
-                        },
-                    ]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                },
-            }));
-            let predicate = syn::PredicateType {
-                lifetimes: None,
-                bounded_ty: syn::Type::Path(syn::TypePath {
-                    qself: None,
-                    path: type_parameter.ident.into(),
-                }),
-                colon_token: syn::token::Colon {
-                    spans: [Span::call_site()],
-                },
-                bounds: punctuated,
-            };
-            where_clause.predicates.push(predicate.into());
-        }
+    for type_parameter in ctx.type_parameters.iter() {
+        let mut punctuated = syn::punctuated::Punctuated::new();
+        punctuated.push(decode_lifetime.clone().into());
+        punctuated.push(syn::TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: syn::TraitBoundModifier::None,
+            lifetimes: None,
+            path: syn::Path {
+                leading_colon: Some(syn::token::PathSep::default()),
+                segments: [
+                    PathSegment {
+                        ident: syn::Ident::new("rustler", Span::call_site()),
+                        arguments: syn::PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: syn::Ident::new("Decoder", Span::call_site()),
+                        arguments: syn::PathArguments::AngleBracketed(
+                            syn::AngleBracketedGenericArguments {
+                                colon2_token: None,
+                                lt_token: Default::default(),
+                                args: std::iter::once(GenericArgument::Lifetime(
+                                    decode_lifetime.clone(),
+                                ))
+                                .collect(),
+                                gt_token: Default::default(),
+                            },
+                        ),
+                    },
+                ]
+                .iter()
+                .cloned()
+                .collect(),
+            },
+        }));
+        let predicate = syn::PredicateType {
+            lifetimes: None,
+            bounded_ty: syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: type_parameter.clone().ident.into(),
+            }),
+            colon_token: syn::token::Colon {
+                spans: [Span::call_site()],
+            },
+            bounds: punctuated,
+        };
+        where_clause.predicates.push(predicate.into());
     }
 
     let (impl_generics, _, where_clause) = impl_generics.split_for_impl();
@@ -132,54 +108,44 @@ pub(crate) fn decoder(ctx: &Context, inner: TokenStream) -> TokenStream {
 pub(crate) fn encoder(ctx: &Context, inner: TokenStream) -> TokenStream {
     let ident = ctx.ident;
     let mut generics = ctx.generics.clone();
-    let type_parameters: Vec<_> = generics
-        .params
-        .iter()
-        .filter_map(|g| match g {
-            syn::GenericParam::Type(t) => Some(t.clone()),
-            _ => None,
-        })
-        .collect();
 
-    if !type_parameters.is_empty() {
-        let where_clause = generics.make_where_clause();
+    let where_clause = generics.make_where_clause();
 
-        for type_parameter in type_parameters {
-            let mut punctuated = syn::punctuated::Punctuated::new();
-            punctuated.push(syn::TypeParamBound::Trait(TraitBound {
-                paren_token: None,
-                modifier: syn::TraitBoundModifier::None,
-                lifetimes: None,
-                path: syn::Path {
-                    leading_colon: Some(syn::token::PathSep::default()),
-                    segments: [
-                        PathSegment {
-                            ident: syn::Ident::new("rustler", Span::call_site()),
-                            arguments: syn::PathArguments::None,
-                        },
-                        PathSegment {
-                            ident: syn::Ident::new("Encoder", Span::call_site()),
-                            arguments: syn::PathArguments::None,
-                        },
-                    ]
-                    .iter()
-                    .cloned()
-                    .collect(),
-                },
-            }));
-            let predicate = syn::PredicateType {
-                lifetimes: None,
-                bounded_ty: syn::Type::Path(syn::TypePath {
-                    qself: None,
-                    path: type_parameter.ident.into(),
-                }),
-                colon_token: syn::token::Colon {
-                    spans: [Span::call_site()],
-                },
-                bounds: punctuated,
-            };
-            where_clause.predicates.push(predicate.into());
-        }
+    for type_parameter in ctx.type_parameters.iter() {
+        let mut punctuated = syn::punctuated::Punctuated::new();
+        punctuated.push(syn::TypeParamBound::Trait(TraitBound {
+            paren_token: None,
+            modifier: syn::TraitBoundModifier::None,
+            lifetimes: None,
+            path: syn::Path {
+                leading_colon: Some(syn::token::PathSep::default()),
+                segments: [
+                    PathSegment {
+                        ident: syn::Ident::new("rustler", Span::call_site()),
+                        arguments: syn::PathArguments::None,
+                    },
+                    PathSegment {
+                        ident: syn::Ident::new("Encoder", Span::call_site()),
+                        arguments: syn::PathArguments::None,
+                    },
+                ]
+                .iter()
+                .cloned()
+                .collect(),
+            },
+        }));
+        let predicate = syn::PredicateType {
+            lifetimes: None,
+            bounded_ty: syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: type_parameter.ident.clone().into(),
+            }),
+            colon_token: syn::token::Colon {
+                spans: [Span::call_site()],
+            },
+            bounds: punctuated,
+        };
+        where_clause.predicates.push(predicate.into());
     }
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -105,6 +105,8 @@ defmodule RustlerTest do
   def newtype_record_echo(_), do: err()
   def tuplestruct_record_echo(_), do: err()
   def reserved_keywords_type_echo(_), do: err()
+  def generic_struct_echo(_), do: err()
+  def mk_generic_map(_), do: err()
 
   def dirty_io(), do: err()
   def dirty_cpu(), do: err()

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -95,7 +95,9 @@ rustler::init!(
         test_tuple::maybe_add_one_to_tuple,
         test_tuple::add_i32_from_tuple,
         test_tuple::greeting_person_from_tuple,
-        test_codegen::reserved_keywords::reserved_keywords_type_echo
+        test_codegen::reserved_keywords::reserved_keywords_type_echo,
+        test_codegen::generic_types::generic_struct_echo,
+        test_codegen::generic_types::mk_generic_map,
     ],
     load = load
 );

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -262,3 +262,28 @@ pub mod reserved_keywords {
         reserved
     }
 }
+
+pub mod generic_types {
+    use rustler::{NifMap, NifStruct};
+    #[derive(NifStruct)]
+    #[module = "GenericStruct"]
+    pub struct GenericStruct<T> {
+        t: T,
+    }
+
+    #[rustler::nif]
+    pub fn generic_struct_echo(value: GenericStruct<i32>) -> GenericStruct<i32> {
+        value
+    }
+
+    #[derive(NifMap)]
+    pub struct GenericMap<T> {
+        a: T,
+        b: T,
+    }
+
+    #[rustler::nif]
+    pub fn mk_generic_map(value: &str) -> GenericMap<&str> {
+        GenericMap { a: value, b: value }
+    }
+}

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -434,4 +434,16 @@ defmodule RustlerTest.CodegenTest do
     assert {1} == RustlerTest.reserved_keywords_type_echo({1})
     assert {:record, 1} == RustlerTest.reserved_keywords_type_echo({:record, 1})
   end
+
+  describe "generic types" do
+    test "generic struct" do
+      assert %{__struct__: GenericStruct, t: 1} ==
+               RustlerTest.generic_struct_echo(%{__struct__: GenericStruct, t: 1})
+    end
+
+    test "generic map" do
+      assert %{a: "hello", b: "hello"} ==
+               RustlerTest.mk_generic_map("hello")
+    end
+  end
 end


### PR DESCRIPTION
Closes #424. Allows generic type parameters in the derive macros:

```rust
    #[derive(NifStruct)]
    #[module = "GenericStruct"]
    pub struct GenericStruct<T> {
        t: T
    }
```