### PR TITLE
Fix error messages

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -187,7 +187,7 @@ impl<'a> Context<'a> {
                 }
             }
         }
-        panic!("Cannot parse module")
+        panic!("Cannot parse tag")
     }
 
     fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
@@ -201,6 +201,6 @@ impl<'a> Context<'a> {
                 }
             }
         }
-        panic!("Cannot parse tag")
+        panic!("Cannot parse module")
     }
 }


### PR DESCRIPTION
While hacking on the codebase we noticed that the error messages when creating an incorrect `tag` or `module` are wrong.