### PR TITLE
Fix atoms module name generated by the `NifStruct` derive macro

### DIFF
--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -86,7 +86,10 @@ impl<'a> Context<'a> {
     }
 
     pub fn atoms_module_name(&self, span: Span) -> Ident {
-        Ident::new(&format!("RUSTLER_ATOMS_{}", self.ident), span)
+        Ident::new(
+            &format!("rustler_atoms_{}", self.ident).to_snake_case(),
+            span,
+        )
     }
 
     pub fn encode(&self) -> bool {

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -53,7 +53,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput, add_exception: bool) -> Toke
     };
 
     let gen = quote! {
-        #[allow(non_snake_case)]
         mod #atoms_module_name {
             #atom_defs
         }


### PR DESCRIPTION
This is related to https://github.com/rusterlium/rustler/pull/573, but now the macro is given a warning even with the annotation to ignore.

![image](https://github.com/rusterlium/rustler/assets/381213/33e37c7f-ca00-458c-8726-88bdb3f03cbe)


So this is a fix that turns the atoms module name generated by the macro in a snake case name.