### PR TITLE
Add support for path dependencies

### DIFF
--- a/rustler_mix/lib/rustler/compiler/config.ex
+++ b/rustler_mix/lib/rustler/compiler/config.ex
@@ -132,7 +132,10 @@ defmodule Rustler.Compiler.Config do
 
     paths = Enum.map(local_deps, & &1["path"]) ++ paths_acc
 
-    as_specs = Enum.map(local_deps, &get_spec(packages, &1["name"]))
+    as_specs =
+      local_deps
+      |> Enum.map(&get_spec(packages, &1["name"]))
+      |> Enum.reject(&is_nil/1)
 
     visited =
       local_deps


### PR DESCRIPTION
# What changes

Fix a bug when adding a path dependency to a rustler Cargo.toml that gives this cryptic error:
```
  == Compilation error in file lib/multiplayer_backend/project_mutator.ex ==
  ** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom
      (elixir 1.16.1) lib/enum.ex:1: Enumerable.impl_for!/1
      (elixir 1.16.1) lib/enum.ex:166: Enumerable.reduce/3
      (elixir 1.16.1) lib/enum.ex:4399: Enum.filter/2
      (rustler 0.32.1) lib/rustler/compiler/config.ex:130: Rustler.Compiler.Config.gather_local_crates/4
      (rustler 0.32.1) lib/rustler/compiler/config.ex:108: Rustler.Compiler.Config.external_resources/3
      (rustler 0.32.1) lib/rustler/compiler/config.ex:79: Rustler.Compiler.Config.build/1
      (rustler 0.32.1) lib/rustler/compiler.ex:8: Rustler.Compiler.compile_crate/3
      lib/multiplayer_backend/project_mutator.ex:2: (module)
```
Somehow this dependency slips nil's in the specs, so we just filter them out.

# How to test

Clone [this repository](https://github.com/Photoroom/rustler_path_dependency_example) and try to build it to reproduce the error. Uncomment the `rustler` dependency pointing to this PR to fix.