### PR TITLE
Unconditionally enable `derive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ versions.
 
 - NIF implementations are now discovered automatically and the respective
   argument of `rustler::init!` is ignored (#613)
+- The `derive` feature flag is now ignored and its functionality unconditionally
+  enabled (#621)
 
 ### Removed
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -7,6 +7,9 @@ This document is intended to simplify upgrading to newer versions by extending t
 1. NIF implementations are now discovered automatically, the respective argument
    in the `rustler::init!` macro should be removed. If a NIF implementation
    should not be exported, it must be disabled with a `#[cfg]` marker.
+2. The functionality related to the `derive` feature is now unconditionally
+   active. The feature flag is kept for compatibility for now but will be
+   removed in the future.
 
 ## 0.32 -> 0.33
 

--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -11,8 +11,8 @@ rust-version = "1.70"
 
 [features]
 big_integer = ["dep:num-bigint"]
-default = ["derive", "nif_version_2_15"]
-derive = ["rustler_codegen"]
+default = ["nif_version_2_15"]
+derive = []
 alternative_nif_init_name = []
 allocator = []
 nif_version_2_14 = ["rustler_sys/nif_version_2_14"]
@@ -23,7 +23,7 @@ serde = ["dep:serde"]
 
 [dependencies]
 inventory = "0.3"
-rustler_codegen = { path = "../rustler_codegen", version = "0.33.0", optional = true}
+rustler_codegen = { path = "../rustler_codegen", version = "0.33.0" }
 rustler_sys = { path = "../rustler_sys", version = "~2.4.1" }
 num-bigint = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }

--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -71,7 +71,6 @@ pub use nif::Nif;
 
 pub type NifResult<T> = Result<T, Error>;
 
-#[cfg(feature = "derive")]
 pub use rustler_codegen::{
     init, nif, NifException, NifMap, NifRecord, NifStruct, NifTaggedEnum, NifTuple, NifUnitEnum,
     NifUntaggedEnum,


### PR DESCRIPTION
I see no need to support this right now and from experience, it's enabled pretty much everywhere anyhow. If people ask for it, we can look into providing nicer non-derive interfaces.