### PR TITLE
feat: allow users to set a custom resource destructor

### DIFF
--- a/rustler/src/resource.rs
+++ b/rustler/src/resource.rs
@@ -109,7 +109,7 @@ fn get_alloc_size_struct<T>() -> usize {
 /// Given a pointer `ptr` to an allocation of `get_alloc_size_struct::<T>()` bytes, return the
 /// first aligned pointer within the allocation where a `T` may be stored.
 /// Unsafe: `ptr` must point to a large enough allocation and not be null.
-unsafe fn align_alloced_mem_for_struct<T>(ptr: *const c_void) -> *const c_void {
+pub unsafe fn align_alloced_mem_for_struct<T>(ptr: *const c_void) -> *const c_void {
     let offset = mem::align_of::<T>() - ((ptr as usize) % mem::align_of::<T>());
     ptr.add(offset)
 }


### PR DESCRIPTION
Hi this PR adds an arm to the `rustler::resource!` macro which users to set a custom resource destructor, and also makes `rustler::resource::align_alloced_mem_for_struct` public so that user can use it in these customised resource destructors. 

This should make things easier when a custom resource destructor is needed.