### PR TITLE
Implement direct `Result` serialization

### DIFF
--- a/rustler/src/serde/atoms.rs
+++ b/rustler/src/serde/atoms.rs
@@ -3,9 +3,6 @@
 use crate::serde::Error;
 use crate::{types::atom::Atom, Encoder, Env, Term};
 
-pub static OK: &str = "Ok";
-pub static ERROR: &str = "Err";
-
 atoms! {
     nil,
     ok,
@@ -23,16 +20,10 @@ atoms! {
  * Attempts to create an atom term from the provided string (if the atom already exists in the atom table). If not, returns a string term.
  */
 pub fn str_to_term<'a>(env: &Env<'a>, string: &str) -> Result<Term<'a>, Error> {
-    if string == "Ok" {
-        Ok(ok().encode(*env))
-    } else if string == "Err" {
-        Ok(error().encode(*env))
-    } else {
-        match Atom::try_from_bytes(*env, string.as_bytes()) {
-            Ok(Some(term)) => Ok(term.encode(*env)),
-            Ok(None) => Err(Error::InvalidStringable),
-            _ => Err(Error::InvalidStringable),
-        }
+    match Atom::try_from_bytes(*env, string.as_bytes()) {
+        Ok(Some(term)) => Ok(term.encode(*env)),
+        Ok(None) => Err(Error::InvalidStringable),
+        _ => Err(Error::InvalidStringable),
     }
 }
 
@@ -40,11 +31,7 @@ pub fn str_to_term<'a>(env: &Env<'a>, string: &str) -> Result<Term<'a>, Error> {
  * Attempts to create a `String` from the term.
  */
 pub fn term_to_string(term: &Term) -> Result<String, Error> {
-    if ok().eq(term) {
-        Ok(OK.to_string())
-    } else if error().eq(term) {
-        Ok(ERROR.to_string())
-    } else if term.is_atom() {
+    if term.is_atom() {
         term.atom_to_string().or(Err(Error::InvalidAtom))
     } else {
         Err(Error::InvalidStringable)


### PR DESCRIPTION
`serde_rustler` decided to map Rust's `Result<Value, Error>` type to `{ok, Value} | {error, Error}`. While we should keep this functionality, the current implementation is flawed by handling this through actually mapping `ok <-> "Ok"` and `error <-> "Err"`. We can instead detect (de)serialization of a `Result` object by looking at the `name` and `variants` in a variant handler.