### PR TITLE
Add unsafe dyncall support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ versions.
 - The resource type name can now be overridden with
   `#[register_impl(name = "...")]` (#638)
 - Floats can be decoded from integers (#641, fixes #603)
+- Resource types can now implement and use dynamic calls on NIF version 2.16
+  (#635)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "rustler_tests/native/rustler_serde_test",
   "rustler_tests/native/dynamic_load",
   "rustler_tests/native/rustler_compile_tests",
+  "rustler_tests/native/resource_dyncall",
   "rustler_benchmarks/native/benchmark",
 ]
 default-members = [

--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -81,3 +81,7 @@ pub mod serde;
 
 #[cfg(feature = "serde")]
 pub use crate::serde::SerdeTerm;
+
+pub mod sys {
+    pub use rustler_sys::*;
+}

--- a/rustler/src/resource/arc.rs
+++ b/rustler/src/resource/arc.rs
@@ -172,6 +172,29 @@ impl<'a> Env<'a> {
     pub fn demonitor<T: Resource>(&self, resource: &ResourceArc<T>, mon: &Monitor) -> bool {
         resource.demonitor(Some(*self), mon)
     }
+
+    #[cfg(feature = "nif_version_2_16")]
+    pub unsafe fn dynamic_resource_call(
+        self,
+        module: crate::Atom,
+        name: crate::Atom,
+        resource: Term<'a>,
+        call_data: *mut rustler_sys::c_void,
+    ) -> Result<(), super::DynamicResourceCallError> {
+        let res = rustler_sys::enif_dynamic_resource_call(
+            self.as_c_arg(),
+            module.as_c_arg(),
+            name.as_c_arg(),
+            resource.as_c_arg(),
+            call_data,
+        );
+
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(super::DynamicResourceCallError)
+        }
+    }
 }
 
 impl<T> Deref for ResourceArc<T>

--- a/rustler/src/resource/error.rs
+++ b/rustler/src/resource/error.rs
@@ -1,3 +1,8 @@
 /// Indicates that a resource has not been registered successfully
 #[derive(Clone, Copy, Debug)]
 pub struct ResourceInitError;
+
+/// Indicates that a dynamic resource call failed
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug)]
+pub struct DynamicResourceCallError;

--- a/rustler/src/resource/mod.rs
+++ b/rustler/src/resource/mod.rs
@@ -13,7 +13,7 @@ mod traits;
 mod util;
 
 pub use arc::ResourceArc;
-pub use error::ResourceInitError;
+pub use error::*;
 pub use monitor::Monitor;
 pub use registration::Registration;
 pub use traits::Resource;

--- a/rustler/src/resource/traits.rs
+++ b/rustler/src/resource/traits.rs
@@ -35,6 +35,9 @@ pub trait Resource: Sized + Send + Sync + 'static {
     const IMPLEMENTS_DESTRUCTOR: bool = false;
     const IMPLEMENTS_DOWN: bool = false;
 
+    #[cfg(feature = "nif_version_2_16")]
+    const IMPLEMENTS_DYNCALL: bool = false;
+
     /// Callback function that is executed right before dropping a resource object.
     ///
     /// This callback does not have to be implemented to release associated resources or run
@@ -51,6 +54,10 @@ pub trait Resource: Sized + Send + Sync + 'static {
     /// by `ResourceArc<T>::monitor`.
     #[allow(unused)]
     fn down<'a>(&'a self, env: Env<'a>, pid: LocalPid, monitor: Monitor) {}
+
+    #[cfg(feature = "nif_version_2_16")]
+    #[allow(unused)]
+    unsafe fn dyncall<'a>(&'a self, env: Env<'a>, call_data: *mut rustler_sys::c_void) {}
 }
 
 #[doc(hidden)]

--- a/rustler_tests/lib/resource_dyncall.ex
+++ b/rustler_tests/lib/resource_dyncall.ex
@@ -1,0 +1,11 @@
+if RustlerTest.Helper.has_nif_version("2.16") do
+  defmodule ResourceDyncall do
+    use Rustler,
+      otp_app: :rustler_test,
+      crate: :resource_dyncall
+
+    def new(_), do: err()
+
+    defp err(), do: :erlang.nif_error(:nif_not_loaded)
+  end
+end

--- a/rustler_tests/native/resource_dyncall/Cargo.toml
+++ b/rustler_tests/native/resource_dyncall/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "resource_dyncall"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "resource_dyncall"
+crate-type = ["cdylib"]
+
+[dependencies]
+rustler = { path = "../../../rustler", features = ["allocator", "nif_version_2_16"] }

--- a/rustler_tests/native/resource_dyncall/src/lib.rs
+++ b/rustler_tests/native/resource_dyncall/src/lib.rs
@@ -1,0 +1,32 @@
+use rustler::{Env, LocalPid, Resource, ResourceArc};
+
+#[repr(C)]
+struct Params {
+    a: i64,
+    b: i64,
+    c: i64,
+    sent_to: Option<LocalPid>,
+}
+
+struct ResourceWithDyncall {
+    pid: LocalPid,
+}
+
+#[rustler::resource_impl(name = "resource_with_dyncall")]
+impl Resource for ResourceWithDyncall {
+    unsafe fn dyncall<'a>(&'a self, env: Env<'a>, call_data: *mut rustler::sys::c_void) {
+        let p = &mut *(call_data as *mut Params);
+        if let Ok(()) = env.send(&self.pid, (p.a, p.b, p.c)) {
+            p.sent_to = Some(self.pid);
+        } else {
+            p.sent_to = None
+        }
+    }
+}
+
+#[rustler::nif]
+fn new(pid: LocalPid) -> ResourceArc<ResourceWithDyncall> {
+    ResourceWithDyncall { pid }.into()
+}
+
+rustler::init!("Elixir.ResourceDyncall");

--- a/rustler_tests/native/rustler_test/src/lib.rs
+++ b/rustler_tests/native/rustler_test/src/lib.rs
@@ -2,6 +2,8 @@ mod test_atom;
 mod test_binary;
 mod test_codegen;
 mod test_dirty;
+#[cfg(feature = "nif_version_2_16")]
+mod test_dyncall;
 mod test_env;
 mod test_error;
 mod test_list;

--- a/rustler_tests/native/rustler_test/src/test_dyncall.rs
+++ b/rustler_tests/native/rustler_test/src/test_dyncall.rs
@@ -1,0 +1,37 @@
+use rustler::{Env, LocalPid, Term};
+
+rustler::atoms! {
+    module = "Elixir.ResourceDyncall",
+    resource_name = "resource_with_dyncall",
+}
+
+#[repr(C)]
+struct Params {
+    a: i64,
+    b: i64,
+    c: i64,
+    sent_to: Option<LocalPid>,
+}
+
+#[rustler::nif]
+pub fn perform_dyncall<'a>(
+    env: Env<'a>,
+    resource: Term<'a>,
+    a: i64,
+    b: i64,
+    c: i64,
+) -> Option<LocalPid> {
+    let mut params = Params {
+        a,
+        b,
+        c,
+        sent_to: None,
+    };
+
+    unsafe {
+        let params_ptr = std::ptr::addr_of_mut!(params) as *mut rustler::sys::c_void;
+        let _ = env.dynamic_resource_call(module(), resource_name(), resource, params_ptr);
+    }
+
+    params.sent_to
+}

--- a/rustler_tests/test/resource_dyncall_test.exs
+++ b/rustler_tests/test/resource_dyncall_test.exs
@@ -1,0 +1,22 @@
+if RustlerTest.Helper.has_nif_version("2.16") do
+  defmodule RustlerTest.ResourceDyncallTest do
+    use ExUnit.Case, async: true
+
+    test "perform dyncall" do
+      pid = self()
+
+      res = ResourceDyncall.new(pid)
+
+      call_res = RustlerTest.perform_dyncall(res, 1, 2, 3)
+
+      assert call_res == pid
+
+      receive do
+        {1, 2, 3} -> true
+      after
+        50 ->
+          raise "fail"
+      end
+    end
+  end
+end

--- a/rustler_tests/test/test_helper.exs
+++ b/rustler_tests/test/test_helper.exs
@@ -1,3 +1,6 @@
+# Raise an error if RustlerTest can't be loaded
+Code.ensure_loaded!(RustlerTest)
+
 ExUnit.start()
 
 defmodule SerdeRustlerTests.Helpers do


### PR DESCRIPTION
This adds support for dynamic resource calls (https://www.erlang.org/doc/apps/erts/erl_nif#enif_dynamic_resource_call). The feature is inherently unsafe (exchanging pointers to mutable data between different dynamic libraries), though we might be able to eventually provide a stable API on top of it.

Changes to other parts:

- Exposes all of `rustler_sys` under `rustler::sys` s.t. it doesn't have to be explicitly referenced
- Adds helper function to compile tests and nif stubs only for particular NIF versions
- Ensures that `RustlerTest` can be loaded at startup