### PR TITLE
Elixir 1.18 tweaks and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,8 @@ jobs:
     strategy:
       matrix:
         pair:
+          - { erlang: "27", elixir: "1.18.0-rc.0" }
+          - { erlang: "26", elixir: "1.18.0-rc.0" }
           - { erlang: "27", elixir: "1.17", latest: true }
           - { erlang: "26", elixir: "1.17" }
           - { erlang: "26", elixir: "1.16" }

--- a/rustler_mix/lib/mix/tasks/rustler.new.ex
+++ b/rustler_mix/lib/mix/tasks/rustler.new.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Rustler.New do
   root = Path.join(:code.priv_dir(:rustler), "templates/")
 
   for {format, source, _} <- @basic do
-    unless format == :keep do
+    if format != :keep do
       @external_resource Path.join(root, source)
       defp render(unquote(source)), do: unquote(File.read!(Path.join(root, source)))
     end
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Rustler.New do
   end
 
   defp check_module_name_validity!(name) do
-    unless name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/ do
+    if !(name =~ ~r/^[A-Z]\w*(\.[A-Z]\w*)*$/) do
       Mix.raise(
         "Module name must be a valid Elixir alias (for example: Foo.Bar), got: #{inspect(name)}"
       )

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -7,7 +7,7 @@ defmodule Rustler.Compiler do
   def compile_crate(otp_app, config, opts) do
     config = Config.from(otp_app, config, opts)
 
-    unless config.skip_compilation? do
+    if !config.skip_compilation? do
       crate_full_path = Path.expand(config.path, File.cwd!())
 
       File.mkdir_p!(priv_dir())
@@ -54,7 +54,7 @@ defmodule Rustler.Compiler do
       throw_error(:rustup_not_installed)
     end
 
-    unless Rustup.version_installed?(version) do
+    if !Rustup.version_installed?(version) do
       throw_error({:rust_version_not_installed, version})
     end
 
@@ -176,7 +176,7 @@ defmodule Rustler.Compiler do
   end
 
   defp toml_data(path) do
-    unless File.dir?(path) do
+    if !File.dir?(path) do
       throw_error({:nonexistent_crate_directory, path})
     end
 

--- a/rustler_tests/test/serde_rustler_tests_test.exs
+++ b/rustler_tests/test/serde_rustler_tests_test.exs
@@ -69,7 +69,7 @@ defmodule SerdeRustlerTests.NifTest do
     Helpers.run_ser(test_name, expected_term)
     Helpers.run_de(test_name, expected_term)
 
-    unless ctx[:skip] == :transcode do
+    if ctx[:skip] != :transcode do
       Helpers.run_transcode(test_name, expected_term)
     end
   end


### PR DESCRIPTION
- **Run mix format --migrate to drop usage of 'unless'**
- **Flatten __before_compile__ macro to make the new type check happy** (fixes #669)
- **Add Elixir 1.18 release candidate to CI**
