### PR TITLE
Fix Nif* macros requiring an encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 See [`UPGRADE.md`](./UPGRADE.md) for additional help when upgrading to newer
 versions.
 
+## unreleased
+
+### Fixed
+
+- Some derive macros failed when only `decode` was requested (#676)
+
 ## [0.35.1] - 2024-12-18
 
 ### Fixed

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -59,7 +59,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput, add_exception: bool) -> Toke
 
         #decoder
 
-        #[allow(clippy::needless_borrow)]
         #encoder
     };
 

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -44,7 +44,6 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 
         #decoder
 
-        #[allow(clippy::needless_borrow)]
         #encoder
     };
 

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -225,6 +225,39 @@ pub fn tuplestruct_record_echo(tuplestruct: TupleStructRecord) -> TupleStructRec
     tuplestruct
 }
 
+mod check_if_only_decode_is_enough {
+    // Regression test, failed to compile
+    // TODO: Move this test to the trybuild tests in rustler_codegen
+
+    use rustler::{NifMap, NifRecord, NifStruct, NifTaggedEnum, NifTuple, NifUnitEnum};
+
+    #[derive(NifMap)]
+    #[rustler(decode)]
+    struct TestMap {}
+
+    #[derive(NifRecord)]
+    #[tag = "test_rec"]
+    #[rustler(decode)]
+    struct TestRec {}
+
+    #[derive(NifTuple)]
+    #[rustler(decode)]
+    struct TestTuple {}
+
+    #[derive(NifStruct)]
+    #[module = "TestStruct"]
+    #[rustler(decode)]
+    struct TestStruct {}
+
+    #[derive(NifUnitEnum)]
+    #[rustler(decode)]
+    enum TestUnitEnum {}
+
+    #[derive(NifTaggedEnum)]
+    #[rustler(decode)]
+    enum TestTaggedEnum {}
+}
+
 pub mod reserved_keywords {
     use rustler::{NifMap, NifRecord, NifStruct, NifTuple, NifUntaggedEnum};
 

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -29,6 +29,7 @@ pub fn tuple_echo(tuple: AddTuple) -> AddTuple {
 
 #[derive(NifRecord)]
 #[rustler(encode, decode)] // Added to check encode/decode attribute, #180
+// The case of only `decode` is checked below
 #[must_use] // Added to check attribute order (see similar issue #152)
 #[tag = "record"]
 pub struct AddRecord {


### PR DESCRIPTION
This was probably a left-over from a refactoring. If the encoder was not requested, the macros compiled to code with a dangling `#[allow(...)]` which leads to a parser error.

Fixes #675.