### PR TITLE
Static NIFs

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.70"
 big_integer = ["dep:num-bigint"]
 default = ["nif_version_2_15"]
 derive = []
-alternative_nif_init_name = []
 allocator = []
 nif_version_2_14 = []
 nif_version_2_15 = ["nif_version_2_14"]


### PR DESCRIPTION
- Still lacks documentation
- The necessary mechanism was released with Erlang 28 (https://www.erlang.org/doc/apps/erts/erl_nif.html#initialization)
- Relevant discussion is https://github.com/rusterlium/rustler/discussions/687.

The general approach is to create a `staticlib` that depends on the relevant NIF libraries (all Rust-based ones have to be linked together) and then passing it into the `configure` script of OTP.