### PR TITLE
Replace unsupported definition list syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,17 @@ is favored as of now.
 
 #### Features
 
-Safety
-: The code you write in a Rust NIF should never be able to crash the BEAM.
+**Safety**
+The code you write in a Rust NIF should never be able to crash the BEAM.
 
-Interop
-: Decoding and encoding rust values into Erlang terms is as easy as a function
-: call.
+**Interop**
+Decoding and encoding rust values into Erlang terms is as easy as a function call.
 
-Type composition
-: Making a Rust struct encodable and decodable to Erlang or Elixir can be done
-: with a single attribute.
+**Type composition**
+Making a Rust struct encodable and decodable to Erlang or Elixir can be done with a single attribute.
 
-Resource objects
-: Enables you to safely pass a reference to a Rust struct into Erlang code. The
-: struct will be automatically dropped when it's no longer referenced.
+**Resource objects**
+Enables you to safely pass a reference to a Rust struct into Erlang code. The struct will be automatically dropped when it's no longer referenced.
 
 #### Getting started
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,19 @@ is favored as of now.
 #### Features
 
 **Safety**
+
 The code you write in a Rust NIF should never be able to crash the BEAM.
 
 **Interop**
+
 Decoding and encoding rust values into Erlang terms is as easy as a function call.
 
 **Type composition**
+
 Making a Rust struct encodable and decodable to Erlang or Elixir can be done with a single attribute.
 
 **Resource objects**
+
 Enables you to safely pass a reference to a Rust struct into Erlang code. The struct will be automatically dropped when it's no longer referenced.
 
 #### Getting started

--- a/README.md
+++ b/README.md
@@ -18,20 +18,16 @@ is favored as of now.
 
 #### Features
 
-**Safety**
-
+**Safety**  
 The code you write in a Rust NIF should never be able to crash the BEAM.
 
-**Interop**
-
+**Interop**  
 Decoding and encoding rust values into Erlang terms is as easy as a function call.
 
-**Type composition**
-
+**Type composition**  
 Making a Rust struct encodable and decodable to Erlang or Elixir can be done with a single attribute.
 
-**Resource objects**
-
+**Resource objects**  
 Enables you to safely pass a reference to a Rust struct into Erlang code. The struct will be automatically dropped when it's no longer referenced.
 
 #### Getting started


### PR DESCRIPTION
**problem**: GitHub Flavored Markdown (GFM) does not support Markdown's definition lists natively.
the current Readme file is rendering the definition list as:

`Type composition : Making a Rust struct encodable and decodable to Erlang or Elixir can be done : with a single attribute.`

**fix**: simulate a definition list using bold terms and line breaks