### PR TITLE
Implement Hash for atoms

### DIFF
--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -153,7 +153,7 @@ impl Hash for Term<'_> {
         // As far as I can see, there is really no way
         // to get a seed from the hasher. This is definitely
         // not optimal, but it's the best we can do for now.
-        state.write_u32(self.hash_phash2());
+        state.write_u32(self.hash_internal(0));
     }
 }
 

--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -153,7 +153,7 @@ impl Hash for Term<'_> {
         // As far as I can see, there is really no way
         // to get a seed from the hasher. This is definitely
         // not optimal, but it's the best we can do for now.
-        state.write_u32(self.hash_internal(0));
+        state.write_u32(self.hash_phash2());
     }
 }
 

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -141,7 +141,8 @@ pub(in crate::types) fn decode_bool(term: Term) -> NifResult<bool> {
 impl Hash for Atom {
     fn hash<H: Hasher>(&self, state: &mut H) {
         use crate::sys::{enif_hash, ErlNifHash};
-        let hash = unsafe { enif_hash(ErlNifHash::ERL_NIF_PHASH2, self.as_c_arg(), 0) as u32 };
+        let hash =
+            unsafe { enif_hash(ErlNifHash::ERL_NIF_INTERNAL_HASH, self.as_c_arg(), 0) as u32 };
         state.write_u32(hash);
     }
 }

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -1,6 +1,7 @@
 use crate::wrapper::atom;
 use crate::wrapper::NIF_TERM;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
+use std::hash::{Hash, Hasher};
 
 // Atoms are a special case of a term. They can be stored and used on all envs regardless of where
 // it lives and when it is created.
@@ -96,6 +97,12 @@ impl Encoder for Atom {
 impl<'a> Decoder<'a> for Atom {
     fn decode(term: Term<'a>) -> NifResult<Atom> {
         Atom::from_term(term)
+    }
+}
+
+impl Hash for Atom {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_c_arg().hash(state);
     }
 }
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -64,6 +64,7 @@ defmodule RustlerTest do
   def map_from_arrays(_keys, _values), do: err()
   def map_from_pairs(_pairs), do: err()
   def map_generic(_), do: err()
+  def map_atom_keys(_), do: err()
 
   def resource_make(), do: err()
   def resource_set_integer_field(_, _), do: err()

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -1,6 +1,6 @@
 use rustler::types::map::MapIterator;
 use rustler::types::tuple::make_tuple;
-use rustler::{Encoder, Env, Error, ListIterator, NifResult, Term};
+use rustler::{Atom, Encoder, Env, Error, ListIterator, NifResult, Term};
 
 #[rustler::nif]
 pub fn sum_map_values(iter: MapIterator) -> NifResult<i64> {
@@ -60,5 +60,12 @@ pub fn map_from_pairs<'a>(env: Env<'a>, pairs: ListIterator<'a>) -> NifResult<Te
 pub fn map_generic(
     map: std::collections::HashMap<i64, String>,
 ) -> std::collections::HashMap<i64, String> {
+    map
+}
+
+#[rustler::nif]
+pub fn map_atom_keys(
+    map: std::collections::HashMap<Atom, String>,
+) -> std::collections::HashMap<Atom, String> {
     map
 }


### PR DESCRIPTION
Alternative to #694. Fixes #693 and #474.

Uses the same has function for `Atom` and `Term`.

The other approach has the significant shortcoming that an atom has a different hash when represented as a `Term` and that it relies on the implementation detail that atom pointers are completely stable.

/edit: Previously also switched to phash2, but given how `std::hash::Hash` is used and documented (not even guaranteed to be stable across Rust versions), it doesn't really help us to pass more "portable" values in.