### PR TITLE
1.19 typing_violation_error

### DIFF
--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -95,10 +95,7 @@ defmodule Rustler.Compiler do
     if os_type do
       os_type.os_type
     else
-      throw_error(
-        {:unknown_target,
-         "#{target} is not in the support list yet. Please report it on https://github.com/rusterlium/rustler/issues."}
-      )
+      throw_error({:unknown_target, target})
     end
   end
 

--- a/rustler_mix/lib/rustler/compiler/messages.ex
+++ b/rustler_mix/lib/rustler/compiler/messages.ex
@@ -53,4 +53,10 @@ defmodule Rustler.Compiler.Messages do
     Note: You should already have this if you made your project with the project generator.
     """
   end
+
+  def message({:unknown_target, target}) do
+    """
+    #{target} is not in the support list yet. Please report it on https://github.com/rusterlium/rustler/issues."
+    """
+  end
 end


### PR DESCRIPTION
Rustler fails to compile on 1.19-dev
```
==> rustler                                                                                                                                                                       
    warning: incompatible types given to throw_error/1:                                                                                                                           
                                                                                                                                                                                  
        throw_error(                                                                                                                                                              
          {:unknown_target,                                                                                                                                                       
           <<to_string(target)::binary,                                                                                                                                           
             " is not in the support list yet. Please report it on https://github.com/rusterlium/rustler/issues.">>}                                                              
        )                                                                                                                                                                         
                                                                                                                                                                                  
    given types:                                                                                                                                                                  
                                                                                                                                                                                  
        {:unknown_target, binary()}                                                                                                                                               
                                                                                                                                                                                  
    but expected one of:                                                                                                                                                          
                                                                                                                                                                                  
        dynamic(                                                                                                                                                                  
          :rustup_not_installed or {:no_rustler_deps, term(), term()} or                                                                                                          
            {:unsupported_rustler_version, term(), term(), term()} or                                                                                                             
            {:cargo_toml_not_found or :nonexistent_crate_directory or :rust_version_not_installed, term()}                                                                        
        )                                                                                                                                                                         
                                                                                                                                                                                  
    where "target" was given the type:                                                                                                                                            
                                                                                                                                                                                  
        # type: dynamic()                                                                                                                                                         
        # from: lib/rustler/compiler.ex:82:27                                                                                                                                     
        target       
```
There are also some warnings for single quotes and map update syntax but it compiles, just this one is causing compilation problems