### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Erlang/Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@main
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install Erlang/Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: "26"
-          elixir-version: "1.15"
+          otp-version: "27"
+          elixir-version: "1.18"
 
       - name: Check cargo fmt
         run: cargo fmt --all -- --check
@@ -85,6 +85,8 @@ jobs:
     strategy:
       matrix:
         pair:
+          - { erlang: "28.0", elixir: "1.19.0-rc.0", strict: true }
+          - { erlang: "27.3.4", elixir: "1.19.0-rc.0", strict: true }
           - { erlang: "27", elixir: "1.18", latest: true }
           - { erlang: "26", elixir: "1.18" }
           - { erlang: "27", elixir: "1.17" }
@@ -111,13 +113,7 @@ jobs:
         with:
           otp-version: ${{matrix.pair.erlang}}
           elixir-version: ${{matrix.pair.elixir}}
-        if: "!startsWith(matrix.os, 'macos')"
-
-      - name: Install Erlang/Elixir with Brew
-        run: |
-          brew install elixir
-          mix local.hex --force
-        if: "startsWith(matrix.os, 'macos')"
+          version-type: ${{ matrix.pair.strict && 'strict' || 'loose' }}
 
       - name: Install Rust ${{matrix.rust}} toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,6 @@ jobs:
           - { erlang: "26", elixir: "1.16" }
           - { erlang: "26", elixir: "1.15" }
           - { erlang: "25", elixir: "1.15" }
-          - { erlang: "24", elixir: "1.14" }
         rust:
           - stable
           - nightly


### PR DESCRIPTION
- Add Elixir 1.19-rc and OTP28 to CI
- Drop OTP24 from CI
- Remove `brew` installation on macOS in favour of `setup-beam`'s new direct support (use `main` until there is a release)