### PR TITLE
Add from_iter to NewBinary

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -509,6 +509,14 @@ impl<'a> NewBinary<'a> {
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         unsafe { ::std::slice::from_raw_parts_mut(self.buf, self.size) }
     }
+
+    pub fn from_iter(env: Env<'a>, iter: impl ExactSizeIterator<Item = u8>) -> Self {
+        let mut bin = Self::new(env, iter.len());
+        for (src, dst) in ::std::iter::zip(iter, bin.iter_mut()) {
+            *dst = src;
+        }
+        bin
+    }
 }
 
 impl<'a> From<NewBinary<'a>> for Binary<'a> {

--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -498,6 +498,7 @@ impl<'a> NewBinary<'a> {
         let (buf, term) = unsafe { new_binary(env, size) };
         NewBinary { buf, term, size }
     }
+
     /// Extracts a slice containing the entire binary.
     #[inline]
     pub fn as_slice(&self) -> &[u8] {

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -85,6 +85,8 @@ defmodule RustlerTest do
   def binary_new(), do: err()
   def owned_binary_new(), do: err()
   def new_binary_new(), do: err()
+  def new_binary_from_iter(), do: err()
+  def owned_binary_from_iter(), do: err()
   def unowned_to_owned(_), do: err()
   def realloc_shrink(), do: err()
   def realloc_grow(), do: err()

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -37,6 +37,18 @@ pub fn new_binary_new(env: Env) -> Binary {
 }
 
 #[rustler::nif]
+pub fn new_binary_from_iter(env: Env) -> Binary {
+    let binary = NewBinary::from_iter(env, vec![1, 2, 3, 4].into_iter());
+    binary.into()
+}
+
+#[rustler::nif]
+pub fn owned_binary_from_iter(env: Env) -> Binary {
+    let binary = OwnedBinary::from_iter(vec![1, 2, 3, 4].into_iter());
+    binary.release(env)
+}
+
+#[rustler::nif]
 pub fn unowned_to_owned<'a>(env: Env<'a>, binary: Binary<'a>) -> NifResult<Binary<'a>> {
     // Do nothing and suppress panic message. From https://stackoverflow.com/a/35559417
     panic::set_hook(Box::new(|_info| {}));

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -25,6 +25,14 @@ defmodule RustlerTest.BinaryTest do
     assert RustlerTest.new_binary_new() == <<1, 2, 3, 4>>
   end
 
+  test "new binary from iter" do
+    assert RustlerTest.new_binary_from_iter() == <<1, 2, 3, 4>>
+  end
+
+  test "owned binary from iter" do
+    assert RustlerTest.owned_binary_from_iter() == <<1, 2, 3, 4>>
+  end
+
   test "unowned binary to owned" do
     assert RustlerTest.unowned_to_owned("test") == <<1, "est">>
     assert RustlerTest.unowned_to_owned("whatisgoingon") == <<1, "hatisgoingon">>


### PR DESCRIPTION
#702 added conformance to `FromIterator` to `OwnedBinary`, `NewBinary` can't do the same since it requires an `Env` and lacks realloc, however a function that does similarly, though with the added requirement of `ExactSizeIterator` would be useful.