### PR TITLE
Allow deserialize_seq to deserialize binaries.

### DIFF
--- a/rustler/src/serde/de.rs
+++ b/rustler/src/serde/de.rs
@@ -324,7 +324,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        if self.term.is_list() | self.term.is_empty_list() {
+        if self.term.is_list() || self.term.is_empty_list() {
             let iter: ListIterator = self.term.decode().or(Err(Error::ExpectedList))?;
             visitor.visit_seq(SequenceDeserializer::new(iter))
         } else if self.term.is_binary() {

--- a/rustler/src/serde/de.rs
+++ b/rustler/src/serde/de.rs
@@ -1,6 +1,6 @@
 use crate::serde::{atoms, error::Error, util};
 use crate::{
-    types::{ListIterator, MapIterator},
+    types::{Encoder, ListIterator, MapIterator},
     Term, TermType,
 };
 use serde::{
@@ -324,12 +324,22 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
     where
         V: Visitor<'de>,
     {
-        if !(self.term.is_list() | self.term.is_empty_list()) {
+        if self.term.is_list() | self.term.is_empty_list() {
+            let iter: ListIterator = self.term.decode().or(Err(Error::ExpectedList))?;
+            visitor.visit_seq(SequenceDeserializer::new(iter))
+        } else if self.term.is_binary() {
+            let binary = self
+                .term
+                .decode_as_binary()
+                .or(Err(Error::ExpectedBinary))?;
+            let iter = binary
+                .as_slice()
+                .iter()
+                .map(|x| x.encode(self.term.get_env()));
+            visitor.visit_seq(SequenceDeserializer::new(iter))
+        } else {
             return Err(Error::ExpectedList);
         }
-
-        let iter: ListIterator = self.term.decode().or(Err(Error::ExpectedList))?;
-        visitor.visit_seq(SequenceDeserializer::new(iter))
     }
 
     #[inline]

--- a/rustler/src/serde/de.rs
+++ b/rustler/src/serde/de.rs
@@ -338,7 +338,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
                 .map(|x| x.encode(self.term.get_env()));
             visitor.visit_seq(SequenceDeserializer::new(iter))
         } else {
-            return Err(Error::ExpectedList);
+            Err(Error::ExpectedList)
         }
     }
 

--- a/rustler_tests/native/rustler_serde_test/src/test.rs
+++ b/rustler_tests/native/rustler_serde_test/src/test.rs
@@ -113,6 +113,7 @@ pub fn test<'a>(
         // Sequences
         "sequences (empty)" => run_test!(Vec::new() as Vec<u8>),
         "sequences (primitive)" => run_test!(vec!["hello", "world"]),
+        "sequences (byte)" => run_test!(vec![2, 3, 5, 7, 11, 13]),
         "sequences (complex)" => {
             let a = NewtypeStruct(u8::min_value());
             let b = NewtypeStruct(u8::max_value());

--- a/rustler_tests/test/serde_rustler_tests_test.exs
+++ b/rustler_tests/test/serde_rustler_tests_test.exs
@@ -275,6 +275,16 @@ defmodule SerdeRustlerTests.NifTest do
       run_tests("sequences (primitive)", ["hello", "world"], ctx)
     end
 
+    test "sequences (byte)", ctx do
+      test_name = "sequences (byte)"
+      expected_term = <<2, 3, 5, 7, 11, 13>>
+      Helpers.run_de(test_name, expected_term)
+
+      if ctx[:skip] != :transcode do
+        Helpers.run_transcode(test_name, expected_term)
+      end
+    end
+
     test "sequences (complex)", ctx do
       test_case = [NewtypeStruct.record(num: 0), NewtypeStruct.record(num: 255)]
       transcoded = [[~s"#{NewtypeStruct}", 0], [~s"#{NewtypeStruct}", 255]]


### PR DESCRIPTION
I came across the bug `** (ErlangError) Erlang error: :nif_panicked` when trying to do the following NIF call in Elixir: `AnomaSDK.Arm.encrypt_cipher(<<96, 109, 146, 170, 18, 27, 248, 118, 203, 31, 65, 72, 51, 153, 179, 35, 168, 62, 88, 150, 244, 119, 198, 51, 20, 106, 74, 8, 143, 32, 45, 168>>)`. The NIF is defined as follows:
```
#[nif]
fn encrypt_cipher(SerdeTerm(cipher): SerdeTerm<Vec<u8>>) -> SerdeTerm<Ciphertext> { ... }
```

Tracking down this error led me to the `Deserializer::deserialize_seq` implementation. It seems that the function does not have the ability to treat Elixir binary terms as sequences. This PR enables Elixir binaries to be treated as sequences (in addition to lists and empty lists) which fixes the NIF panic described above.

And thanks for maintaining Rustler, this crate is extremely useful!