### PR TITLE
Fix iolist inspect

### DIFF
--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -90,6 +90,7 @@ defmodule RustlerTest do
   def realloc_grow(), do: err()
   def encode_string(), do: err()
   def decode_iolist(_), do: err()
+  def first_four_bytes_of_iolist(_), do: err()
 
   def atom_to_string(_), do: err()
   def atom_equals_ok(_), do: err()

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -77,3 +77,10 @@ pub fn encode_string() -> (String, &'static str) {
 pub fn decode_iolist(binary: Term) -> NifResult<Binary> {
     binary.decode_as_binary()
 }
+
+#[rustler::nif]
+pub fn first_four_bytes_of_iolist<'a>(term: Term<'a>) -> Binary<'a> {
+    let bin = Binary::from_iolist(term).unwrap();
+    let sub = bin.make_subbinary(0, 4).unwrap();
+    sub
+}

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -46,6 +46,14 @@ defmodule RustlerTest.BinaryTest do
   end
 
   test "decode iolist as binary" do
-    assert RustlerTest.decode_iolist(["hi", " ", "there"]) == ["hi", " ", "there"]
+    assert RustlerTest.decode_iolist(["hi", " ", "there"]) == "hi there"
+    assert RustlerTest.decode_iolist([[?h, ?i], ~c" ", ["there"]]) == "hi there"
+  end
+
+  test "iolist decode returns binary" do
+    assert RustlerTest.first_four_bytes_of_iolist("hi there") == "hi t"
+    assert RustlerTest.first_four_bytes_of_iolist(["hi there"]) == "hi t"
+    assert RustlerTest.first_four_bytes_of_iolist(["hi", " ", "there"]) == "hi t"
+    assert RustlerTest.first_four_bytes_of_iolist([[?h, ?i], ~c" ", ["there"]]) == "hi t"
   end
 end


### PR DESCRIPTION
In `Binary::io_list`, we incorrectly attach the original `term` to the `Binary` object. This leads to subsequent calls failing or doing unexpected things.

Now, instead, we create a new `Term` for the `ErlNifBinary` and put it in `Binary`. Sadly, our test for this was also wrong :/. I fixed it and added additional tests.