### PR TITLE
Make `OwnedEnv` `Sync`-compatible

### DIFF
--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -206,6 +206,7 @@ pub struct OwnedEnv {
 }
 
 unsafe impl Send for OwnedEnv {}
+unsafe impl Sync for OwnedEnv {}
 
 impl OwnedEnv {
     /// Allocates a new process-independent environment.


### PR DESCRIPTION
It should be perfectly fine to do, in the same way #469 makes
`OwnedBinary` `Sync`-compatible.

I require it to make `OwnedEnv` part of the structure that is storing
`Term`s within its body, just like it happens with ETS.
