### PR TITLE
nif_filler: fix Android NIF init panic from dlopen(NULL) lookup

### DIFF
--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -2,7 +2,7 @@ pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(target_os = "android")))]
 mod internal {
     use std::ffi::OsStr;
 
@@ -26,6 +26,136 @@ mod internal {
         fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
             let symbol = unsafe { self.lib.get::<T>(name.as_bytes()).unwrap() };
             *field = Some(*symbol);
+        }
+    }
+
+    pub(crate) fn new() -> impl DynNifFiller {
+        DlsymNifFiller::new()
+    }
+}
+
+// Android: on Bionic, neither `dlopen(NULL, ...)` nor the `RTLD_DEFAULT`
+// pseudo-handle traverses RTLD_GLOBAL-promoted application libraries.
+// `dlopen(NULL)` returns a handle to the main executable namespace
+// (typically `app_process` for JVM-hosted apps); `RTLD_DEFAULT` walks
+// the loader's default search order but does not include siblings that
+// were loaded RTLD_LOCAL by `System.loadLibrary` and only later
+// upgraded via a host-side `dlopen(self, RTLD_GLOBAL)` trick (which
+// Bionic doesn't honour for symbol resolution).
+//
+// The path that *does* work: find the .so file containing this rustler
+// code (via `dladdr` of one of our own functions), then dlopen that
+// path with RTLD_NOLOAD so we get an explicit handle to it. dlsym on
+// that handle DOES find the statically-linked-in BEAM exports.
+#[cfg(target_os = "android")]
+mod internal {
+    
+    use std::os::raw::{c_char, c_int, c_void};
+
+    use super::DynNifFiller;
+
+    const RTLD_NOW: c_int = 0x00002;
+    const RTLD_NOLOAD: c_int = 0x00004;
+
+    #[repr(C)]
+    struct DlInfo {
+        dli_fname: *const c_char,
+        dli_fbase: *mut c_void,
+        dli_sname: *const c_char,
+        dli_saddr: *mut c_void,
+    }
+
+    extern "C" {
+        fn dladdr(addr: *const c_void, info: *mut DlInfo) -> c_int;
+        fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+        fn dlerror() -> *mut c_char;
+    }
+
+    pub(crate) struct DlsymNifFiller {
+        handle: *mut c_void,
+    }
+
+    // Safe to share — the handle is opened once and only used for dlsym
+    // reads, which are thread-safe per POSIX.
+    unsafe impl Send for DlsymNifFiller {}
+    unsafe impl Sync for DlsymNifFiller {}
+
+    impl DlsymNifFiller {
+        pub(crate) fn new() -> Self {
+            // Get the file path of the shared object we're inside. `Self::new`
+            // is statically linked into the same .so as the rest of rustler
+            // (and as libbeam.a's enif_* exports — that's why this works).
+            let mut info = DlInfo {
+                dli_fname: std::ptr::null(),
+                dli_fbase: std::ptr::null_mut(),
+                dli_sname: std::ptr::null(),
+                dli_saddr: std::ptr::null_mut(),
+            };
+            let probe_addr = Self::new as *const c_void;
+            let rc = unsafe { dladdr(probe_addr, &mut info) };
+            if rc == 0 || info.dli_fname.is_null() {
+                panic!(
+                    "rustler: dladdr() failed to identify the calling .so on \
+                     Android. Cannot open a self-handle for enif_* lookups."
+                );
+            }
+
+            // dlopen with RTLD_NOLOAD: don't reload the library (we're
+            // already running in it), just return a handle to the existing
+            // load. The handle's dlsym() scope is *this specific library*,
+            // which is exactly what we want for enif_* lookups.
+            let handle = unsafe { dlopen(info.dli_fname, RTLD_NOW | RTLD_NOLOAD) };
+            if handle.is_null() {
+                let err = unsafe { dlerror() };
+                let err_str = if err.is_null() {
+                    String::from("unknown")
+                } else {
+                    unsafe {
+                        std::ffi::CStr::from_ptr(err)
+                            .to_string_lossy()
+                            .into_owned()
+                    }
+                };
+                let fname = unsafe {
+                    std::ffi::CStr::from_ptr(info.dli_fname)
+                        .to_string_lossy()
+                        .into_owned()
+                };
+                panic!(
+                    "rustler: dlopen({:?}, RTLD_NOW | RTLD_NOLOAD) failed: {}",
+                    fname, err_str
+                );
+            }
+
+            DlsymNifFiller { handle }
+        }
+    }
+
+    impl DynNifFiller for DlsymNifFiller {
+        fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
+            // rustler's caller passes `name` with a trailing NUL byte
+            // already in it (so the same string can be handed to dlsym
+            // without a copy). `CString::new` would reject that as
+            // "interior nul" — convert as already-C-string instead.
+            let bytes = name.as_bytes();
+            debug_assert!(
+                bytes.ends_with(b"\0"),
+                "rustler: expected name with trailing NUL; got {:?}",
+                name
+            );
+            let raw = unsafe { dlsym(self.handle, bytes.as_ptr() as *const c_char) };
+            if raw.is_null() {
+                panic!(
+                    "rustler: dlsym({:?}) on self-handle returned null. \
+                     The BEAM's enif_* exports are not visible inside the \
+                     calling .so. Has the host process linked libbeam.a \
+                     into the .so containing rustler?",
+                    name
+                );
+            }
+            let sym: T = unsafe { *(&raw as *const _ as *const T) };
+            *field = Some(sym);
         }
     }
 

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -49,7 +49,7 @@ mod internal {
 // that handle DOES find the statically-linked-in BEAM exports.
 #[cfg(target_os = "android")]
 mod internal {
-    
+
     use std::os::raw::{c_char, c_int, c_void};
 
     use super::DynNifFiller;
@@ -111,11 +111,7 @@ mod internal {
                 let err_str = if err.is_null() {
                     String::from("unknown")
                 } else {
-                    unsafe {
-                        std::ffi::CStr::from_ptr(err)
-                            .to_string_lossy()
-                            .into_owned()
-                    }
+                    unsafe { std::ffi::CStr::from_ptr(err).to_string_lossy().into_owned() }
                 };
                 let fname = unsafe {
                     std::ffi::CStr::from_ptr(info.dli_fname)

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -83,9 +83,41 @@ mod internal {
 
     impl DlsymNifFiller {
         pub(crate) fn new() -> Self {
-            // Get the file path of the shared object we're inside. `Self::new`
-            // is statically linked into the same .so as the rest of rustler
-            // (and as libbeam.a's enif_* exports — that's why this works).
+            // RUSTLER_NIF_LIB_PATH lets the host process explicitly tell us
+            // the path of the .so containing the BEAM's enif_* exports. This
+            // generalises the fix: setups where rustler is statically linked
+            // alongside the BEAM (e.g. Mob) hit the same Bionic dlopen(NULL)
+            // blind spot, but setups where rustler and the BEAM live in
+            // different .so files would not be helped by the dladdr-self
+            // fallback below. When the env var is set we use it; otherwise
+            // we self-resolve, which is the right default for any single-.so
+            // deployment. See rusterlium/rustler#726.
+            if let Ok(path) = std::env::var("RUSTLER_NIF_LIB_PATH") {
+                if !path.is_empty() {
+                    let c_path = std::ffi::CString::new(path.clone()).expect(
+                        "rustler: RUSTLER_NIF_LIB_PATH must not contain interior NUL bytes",
+                    );
+                    let handle = unsafe { dlopen(c_path.as_ptr(), RTLD_NOW | RTLD_NOLOAD) };
+                    if handle.is_null() {
+                        let err = unsafe { dlerror() };
+                        let err_str = if err.is_null() {
+                            String::from("unknown")
+                        } else {
+                            unsafe { std::ffi::CStr::from_ptr(err).to_string_lossy().into_owned() }
+                        };
+                        panic!(
+                            "rustler: dlopen({:?}, RTLD_NOW | RTLD_NOLOAD) failed for \
+                             RUSTLER_NIF_LIB_PATH: {}",
+                            path, err_str
+                        );
+                    }
+                    return DlsymNifFiller { handle };
+                }
+            }
+
+            // Fallback: identify our own .so via dladdr, then dlopen it with
+            // RTLD_NOLOAD to get an explicit handle. Works for single-.so
+            // static-link deployments without any host setup.
             let mut info = DlInfo {
                 dli_fname: std::ptr::null(),
                 dli_fbase: std::ptr::null_mut(),


### PR DESCRIPTION
## Bug

When BEAM is statically linked into an Android app and a rustler NIF is loaded, NIF init panics with:

```
thread '<unnamed>' panicked: 'DlSym { source: "undefined symbol: enif_priv_data" }'
```

The panic comes from `sys::nif_filler` calling `Library::open(None, ...)` (i.e. `dlopen(NULL)`) to find `enif_*` symbols, then `dlsym`-ing each one off the resulting handle.

## Root cause

Bionic's `dlopen(NULL)` returns a handle to the main executable's link namespace — on a JVM-hosted Android app, that's `app_process`. That namespace does not resolve symbols from sibling `.so` libraries loaded via `System.loadLibrary`, even when the consumer has subsequently re-`dlopen`'d the app's own `.so` with `RTLD_NOW | RTLD_GLOBAL` from JNI/host code.

I tried `RTLD_DEFAULT` first under the assumption that it would traverse the global symbol scope; it has the same blind spot on Bionic. Empirically, the only way to get `dlsym` to resolve the statically-linked-in `enif_*` exports on Android is to open an **explicit handle to the `.so` that contains rustler itself**.

## Fix

Identify the `.so` containing rustler via `dladdr` of one of our own functions, then `dlopen(self_path, RTLD_NOW | RTLD_NOLOAD)` for an explicit handle (`NOLOAD` so we don't reload the library, just return a handle to the existing load). `dlsym` against that handle resolves the `enif_*` symbols correctly.

The change is gated behind `#[cfg(target_os = "android")]`. Linux, macOS, iOS, and Windows code paths are untouched.

Additional small fix: rustler's caller passes symbol names with a trailing NUL byte already (e.g. `b\"enif_priv_data\\0\"`), so we pass `bytes.as_ptr() as *const c_char` to `dlsym` directly instead of going through `CString::new(name).unwrap()` (which rejects the trailing NUL as "interior NUL"). A `debug_assert!` confirms the trailing NUL is present.

## Where this is in production

We use this in [Mob](https://github.com/GenericJam/mob), a framework for shipping BEAM apps on iOS and Android. Mob statically links BEAM + rustler into the main Android `.so`. Verified end-to-end on an Android emulator and a physical Pixel — three concurrent NIFs (C, Rust, Zig) statically linked into a single app, all initialise and respond to Erlang RPC.

Tracker on our side: [GenericJam/mob#7](https://github.com/GenericJam/mob/issues/7).

## Notes

- The new Android module panics with a descriptive message on `dladdr` / `dlopen` failure (path + dlerror). Those cases shouldn't occur in practice (we're identifying our own `.so`), but a loud panic seems better than silent symbol-table corruption.
- Happy to iterate on the shape — e.g. if you'd prefer a single-module implementation with `cfg(target_os = "android")` branches rather than a separate Android `internal` module, or want a different panic message style.

Edit by human: This is generated by AI (Claude Opus 4.6).
I understand if you don't accept AI PRs but this is what Mob needs for Rust / Rustler to work.
Feel free to pick from this what is genuinely useful as I would prefer to refer to the main repo than my fork.

How it's being used in Mob: https://hexdocs.pm/mob_dev/nifs.html#rust-via-rustler