### PR TITLE
Add term_map macro

### DIFF
--- a/rustler/src/lib.rs
+++ b/rustler/src/lib.rs
@@ -72,6 +72,18 @@ pub use nif::Nif;
 
 pub type NifResult<T> = Result<T, Error>;
 
+#[macro_export]
+macro_rules! term_map {
+    ($env:expr, { $($key:expr => $value:expr),* $(,)? }) => {{
+        $crate::Term::map_from_term_arrays(
+            $env,
+            &[$($crate::Encoder::encode(&$key, $env)),*],
+            &[$($crate::Encoder::encode(&$value, $env)),*],
+        )
+        .expect("failed to create map")
+    }};
+}
+
 pub use rustler_codegen::{
     init, nif, resource_impl, NifException, NifMap, NifRecord, NifStruct, NifTaggedEnum, NifTuple,
     NifUnitEnum, NifUntaggedEnum,

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -63,6 +63,7 @@ defmodule RustlerTest do
   def map_entries_reversed(_), do: err()
   def map_from_arrays(_keys, _values), do: err()
   def map_from_pairs(_pairs), do: err()
+  def map_from_macro(), do: err()
   def map_generic(_), do: err()
   def map_atom_keys(_), do: err()
 

--- a/rustler_tests/native/rustler_test/src/test_map.rs
+++ b/rustler_tests/native/rustler_test/src/test_map.rs
@@ -2,6 +2,12 @@ use rustler::types::map::MapIterator;
 use rustler::types::tuple::make_tuple;
 use rustler::{Atom, Encoder, Env, Error, ListIterator, NifResult, Term};
 
+rustler::atoms! {
+    code,
+    css,
+    errors,
+}
+
 #[rustler::nif]
 pub fn sum_map_values(iter: MapIterator) -> NifResult<i64> {
     let res: NifResult<Vec<i64>> = iter.map(|(_key, value)| value.decode::<i64>()).collect();
@@ -54,6 +60,15 @@ pub fn map_from_pairs<'a>(env: Env<'a>, pairs: ListIterator<'a>) -> NifResult<Te
     let res: Result<Vec<(Term, Term)>, Error> = pairs.map(|x| x.decode()).collect();
 
     res.and_then(|v| Term::map_from_pairs(env, &v))
+}
+
+#[rustler::nif]
+pub fn map_from_macro<'a>(env: Env<'a>) -> Term<'a> {
+    rustler::term_map!(env, {
+        code() => "console.log(1)",
+        css() => Option::<String>::None,
+        errors() => Vec::<String>::new(),
+    })
 }
 
 #[rustler::nif]

--- a/rustler_tests/test/map_test.exs
+++ b/rustler_tests/test/map_test.exs
@@ -54,6 +54,10 @@ defmodule RustlerTest.MapTest do
              RustlerTest.map_from_pairs(pairs)
   end
 
+  test "map from macro" do
+    assert %{code: "console.log(1)", css: nil, errors: []} == RustlerTest.map_from_macro()
+  end
+
   test "map from pairs with incorrect type" do
     pairs = [{"a", 1}, {"b", 7}, {"c", 6}, {"d", 0}, nil]
 


### PR DESCRIPTION
Adds a small `term_map!` macro for constructing Erlang maps without manually maintaining parallel key/value arrays.

Example:

```rust
rustler::term_map!(env, {
    atoms::code() => "console.log(1)",
    atoms::css() => Option::<String>::None,
    atoms::errors() => Vec::<String>::new(),
})
```

This expands through Rustler’s existing map construction APIs and keeps each map key next to its encoded value.

Refs #727.

Tests run:

- `cargo test -q`
- `cd rustler_tests && mix test test/map_test.exs`