### PR TITLE
Add OTP-29 enif functions

### DIFF
--- a/rustler/build.rs
+++ b/rustler/build.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::{env, fs};
 
 pub const MIN_SUPPORTED_VERSION: (u32, u32) = (2, 14);
-pub const MAX_SUPPORTED_VERSION: (u32, u32) = (2, 17);
+pub const MAX_SUPPORTED_VERSION: (u32, u32) = (2, 18);
 
 const SNIPPET_NAME: &str = "nif_api.snippet.rs";
 
@@ -830,6 +830,16 @@ fn build_api(b: &mut dyn ApiBuilder, opts: &GenerateOptions) {
             "enif_set_option",
             "env: *mut ErlNifEnv, opt: ErlNifOption",
         );
+    }
+
+    if opts.nif_version >= (2, 18) {
+        b.func("usize", "enif_term_size", "term: ERL_NIF_TERM");
+        b.func(
+            "c_int",
+            "enif_get_atom_cache_index",
+            "env: *mut ErlNifEnv, term: ERL_NIF_TERM, index: *mut c_uint",
+        );
+        b.func("c_uint", "enif_max_atom_cache_index", "");
     }
 
     // If new functions are added for a new OTP version, ensure that *all* functions are added in

--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -125,6 +125,11 @@ impl<'a> Term<'a> {
     pub fn get_erl_type(&self) -> ErlNifTermType {
         unsafe { enif_term_type(self.env.as_c_arg(), self.as_c_arg()) }
     }
+
+    #[cfg(feature = "nif_version_2_18")]
+    pub fn size(&self) -> usize {
+        unsafe { enif_term_size(self.as_c_arg()) }
+    }
 }
 
 impl PartialEq for Term<'_> {

--- a/rustler_mix/lib/rustler/compiler.ex
+++ b/rustler_mix/lib/rustler/compiler.ex
@@ -64,7 +64,7 @@ defmodule Rustler.Compiler do
     artifacts =
       case compile_result do
         {build_results, 0} -> build_results.artifacts
-        {_, code} -> raise "Rust NIF compile error (rustc exit code #{code})"
+        {_, code} -> raise "Failed to compile #{config.crate} (rustc exit code #{code})"
       end
 
     handle_artifacts(artifacts, config)

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -158,4 +158,8 @@ defmodule RustlerTest do
   if Helper.has_nif_version("2.16") do
     def perform_dyncall(_res, _a, _b, _c), do: err()
   end
+
+  if Helper.has_nif_version("2.18") do
+    def term_size(_term), do: err()
+  end
 end

--- a/rustler_tests/native/rustler_test/src/test_term.rs
+++ b/rustler_tests/native/rustler_test/src/test_term.rs
@@ -71,3 +71,9 @@ pub fn term_type(term: Term) -> Atom {
         rustler::TermType::Unknown => atoms::unknown(),
     }
 }
+
+#[cfg(feature = "nif_version_2_18")]
+#[rustler::nif]
+pub fn term_size(term: Term) -> usize {
+    term.size()
+}

--- a/rustler_tests/test/term_test.exs
+++ b/rustler_tests/test/term_test.exs
@@ -80,4 +80,11 @@ defmodule RustlerTest.TermTest do
     assert RustlerTest.term_type(& &1) == :fun
     assert RustlerTest.term_type(make_ref()) == :reference
   end
+
+  if RustlerTest.Helper.has_nif_version("2.18") do
+    test "term size" do
+      assert RustlerTest.term_size(%{}) > 0
+      assert RustlerTest.term_size(%{a: 1, c: 2}) > RustlerTest.term_size(%{})
+    end
+  end
 end


### PR DESCRIPTION
The two atom cache functions are not yet documented, as far as I can see. We add them here anyways to not later trip up the Windows build as the API stubs struct has to be complete.