### PR TITLE
Implement UTF8 atom support on NIF 2.17

### DIFF
--- a/rustler/src/serde/atoms.rs
+++ b/rustler/src/serde/atoms.rs
@@ -19,11 +19,10 @@ atoms! {
 /**
  * Attempts to create an atom term from the provided string (if the atom already exists in the atom table). If not, returns a string term.
  */
-pub fn str_to_term<'a>(env: &Env<'a>, string: &str) -> Result<Term<'a>, Error> {
-    match Atom::try_from_bytes(*env, string.as_bytes()) {
-        Ok(Some(term)) => Ok(term.encode(*env)),
-        Ok(None) => Ok(string.encode(*env)),
-        _ => Err(Error::InvalidStringable),
+pub fn str_to_term<'a>(env: Env<'a>, string: &str) -> Term<'a> {
+    match Atom::try_from_str(env, string) {
+        Ok(term) => term.encode(env),
+        Err(_) => string.encode(env),
     }
 }
 

--- a/rustler/src/serde/atoms.rs
+++ b/rustler/src/serde/atoms.rs
@@ -20,7 +20,7 @@ atoms! {
  * Attempts to create an atom term from the provided string (if the atom already exists in the atom table). If not, returns a string term.
  */
 pub fn str_to_term<'a>(env: Env<'a>, string: &str) -> Term<'a> {
-    match Atom::try_from_str(env, string) {
+    match Atom::existing_from_str(env, string) {
         Ok(term) => term.encode(env),
         Err(_) => string.encode(env),
     }

--- a/rustler/src/serde/de.rs
+++ b/rustler/src/serde/de.rs
@@ -310,8 +310,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         let tuple = util::validate_tuple(self.term, Some(2))?;
-        let name_term =
-            atoms::str_to_term(&self.term.get_env(), name).or(Err(Error::ExpectedStructName))?;
+        let name_term = atoms::str_to_term(self.term.get_env(), name);
 
         if tuple[0].ne(&name_term) {
             return Err(Error::InvalidStructName);
@@ -353,8 +352,7 @@ impl<'de, 'a: 'de> de::Deserializer<'de> for Deserializer<'a> {
         V: Visitor<'de>,
     {
         let mut tuple = util::validate_tuple(self.term, Some(len + 1))?;
-        let name_term =
-            atoms::str_to_term(&self.term.get_env(), name).or(Err(Error::ExpectedStructName))?;
+        let name_term = atoms::str_to_term(self.term.get_env(), name);
 
         if tuple[0].ne(&name_term) {
             return Err(Error::InvalidStructName);

--- a/rustler/src/serde/ser.rs
+++ b/rustler/src/serde/ser.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::serde::{atoms, error::Error, util};
+use crate::serde::{atoms, error::Error};
 use crate::wrapper::list::make_list;
 use crate::{types::tuple, Encoder, Env, OwnedBinary, Term};
 use serde::ser::{self, Serialize};
@@ -184,7 +184,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        atoms::str_to_term(&self.env, variant).or(Err(Error::InvalidVariantName))
+        Ok(atoms::str_to_term(self.env, variant))
     }
 
     #[inline]
@@ -199,7 +199,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
     where
         T: ?Sized + ser::Serialize,
     {
-        let name_term = atoms::str_to_term(&self.env, name).or(Err(Error::InvalidVariantName))?;
+        let name_term = atoms::str_to_term(self.env, name);
         let mut ser = SequenceSerializer::new(self, Some(2), Some(name_term));
         ser.add(value.serialize(self)?);
         ser.to_tuple()
@@ -247,7 +247,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        let name_term = atoms::str_to_term(&self.env, name).or(Err(Error::InvalidVariantName))?;
+        let name_term = atoms::str_to_term(self.env, name);
         Ok(SequenceSerializer::new(self, Some(len), Some(name_term)))
     }
 
@@ -279,7 +279,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        let name_term = util::str_to_term(&self.env, name).or(Err(Error::InvalidStructName))?;
+        let name_term = atoms::str_to_term(self.env, name);
         Ok(MapSerializer::new(self, Some(len), Some(name_term)))
     }
 
@@ -510,7 +510,7 @@ impl<'a> ser::SerializeStruct for MapSerializer<'a> {
     where
         T: ?Sized + Serialize,
     {
-        let key_term = atoms::str_to_term(&self.ser.env, key).or(Err(Error::InvalidStructKey))?;
+        let key_term = atoms::str_to_term(self.ser.env, key);
         self.add_key(key_term);
         self.add_val(value.serialize(self.ser)?);
         Ok(())

--- a/rustler/src/serde/util.rs
+++ b/rustler/src/serde/util.rs
@@ -1,10 +1,5 @@
 use crate::serde::{atoms, Error};
-use crate::{types::tuple, Binary, Decoder, Encoder, Env, Term};
-
-/// Converts an `&str` to either an existing atom or an Elixir bitstring.
-pub fn str_to_term<'a>(env: &Env<'a>, string: &str) -> Result<Term<'a>, Error> {
-    atoms::str_to_term(env, string).or_else(|_| Ok(string.encode(*env)))
-}
+use crate::{types::tuple, Binary, Decoder, Term};
 
 /// Attempts to convert a stringable term into a `String`.
 pub fn term_to_str(term: &Term) -> Result<String, Error> {
@@ -85,8 +80,7 @@ pub fn validate_struct<'a>(term: &Term<'a>, name: Option<&str>) -> Result<Term<'
 
     match name {
         Some(name) => {
-            let name_term =
-                atoms::str_to_term(&term.get_env(), name).or(Err(Error::InvalidStructName))?;
+            let name_term = atoms::str_to_term(term.get_env(), name);
 
             if struct_name_term.eq(&name_term) {
                 Ok(struct_name_term)

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -23,12 +23,12 @@ impl Atom {
     }
 
     unsafe fn from_nif_term(term: NIF_TERM) -> Self {
-        Atom { term }
+        Self { term }
     }
 
     pub fn from_term(term: Term) -> NifResult<Self> {
         if term.is_atom() {
-            Ok(unsafe { Atom::from_nif_term(term.as_c_arg()) })
+            Ok(unsafe { Self::from_nif_term(term.as_c_arg()) })
         } else {
             Err(Error::BadArg)
         }
@@ -41,7 +41,7 @@ impl Atom {
     ///
     /// This function uses Latin-1 encoding for compatibility.
     pub fn from_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
-        Atom::from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
+        Self::from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
     }
 
     /// Return the atom whose text representation is UTF-8 `bytes`.
@@ -57,7 +57,7 @@ impl Atom {
 
         #[cfg(feature = "nif_version_2_17")]
         {
-            Atom::from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
+            Self::from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
         }
 
         #[cfg(not(feature = "nif_version_2_17"))]
@@ -70,13 +70,13 @@ impl Atom {
                 }
                 latin1.push(c as u8);
             }
-            Atom::from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
+            Self::from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
         }
     }
 
-    fn from_encoded_bytes(env: Env, bytes: &[u8], encoding: ErlNifCharEncoding) -> NifResult<Atom> {
+    fn from_encoded_bytes(env: Env, bytes: &[u8], encoding: ErlNifCharEncoding) -> NifResult<Self> {
         unsafe {
-            atom::make_atom(env.as_c_arg(), bytes, encoding).map(|term| Atom::from_nif_term(term))
+            atom::make_atom(env.as_c_arg(), bytes, encoding).map(|term| Self::from_nif_term(term))
         }
     }
 
@@ -85,9 +85,16 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
-    /// NIF 2.17, 255 characters later), or the atom already exists
-    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
-        Atom::try_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
+    /// NIF 2.17, 255 characters later), or the atom does not exist.
+    pub fn existing_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+        Self::existing_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
+    }
+
+    /// Return the atom whose text representation is Latin1 `bytes`, like `erlang:binary_to_existing_atom/1`,
+    /// if atom with given text representation exists.
+    #[deprecated(since = "0.38.0", note = "Use existing_from_(utf8_)bytes")]
+    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Self>> {
+        Self::existing_from_bytes(env, bytes).map(Some)
     }
 
     /// Return the atom whose text representation is UTF8 `bytes`, like `erlang:binary_to_existing_atom/2`,
@@ -95,16 +102,16 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
-    /// NIF 2.17, 255 characters later), or the atom already exists.
+    /// NIF 2.17, 255 characters later), or the atom does not exist.
     ///
     /// On NIF 2.17+ (`OTP 26+`), this uses UTF-8 atom APIs directly.
     /// On older NIF versions, UTF-8 is transcoded to Latin-1 before lookup.
-    pub fn try_from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+    pub fn existing_from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
         use ErlNifCharEncoding::*;
 
         #[cfg(feature = "nif_version_2_17")]
         {
-            Self::try_from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
+            Self::existing_from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
         }
 
         #[cfg(not(feature = "nif_version_2_17"))]
@@ -117,7 +124,7 @@ impl Atom {
                 }
                 latin1.push(c as u8);
             }
-            Self::try_from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
+            Self::existing_from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
         }
     }
 
@@ -126,8 +133,8 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
-    /// NIF 2.17, 255 characters later), or the atom already exists.
-    fn try_from_encoded_bytes(
+    /// NIF 2.17, 255 characters later), or the atom does not exist.
+    fn existing_from_encoded_bytes(
         env: Env,
         bytes: &[u8],
         encoding: ErlNifCharEncoding,
@@ -142,16 +149,24 @@ impl Atom {
     ///
     /// # Errors
     /// `Error::BadArg` if atom creation fails.
-    pub fn from_str(env: Env, string: &str) -> NifResult<Atom> {
+    pub fn from_str(env: Env, string: &str) -> NifResult<Self> {
         Self::from_utf8_bytes(env, string.as_bytes())
     }
 
     /// Return the atom whose text representation is the given `string`.
     ///
     /// # Errors
-    /// `Error::BadArg` if atom creation fails or if the atom exists already.
-    pub fn try_from_str(env: Env, string: &str) -> NifResult<Atom> {
-        Self::try_from_utf8_bytes(env, string.as_bytes())
+    /// `Error::BadArg` if atom lookup fails.
+    pub fn existing_from_str(env: Env, string: &str) -> NifResult<Self> {
+        Self::existing_from_utf8_bytes(env, string.as_bytes())
+    }
+
+    /// Return the atom whose text representation is the given `string`.
+    ///
+    /// Deprecated in favor of [`Atom::from_str_existing`].
+    #[deprecated(since = "0.38.0", note = "Use existing_from_str")]
+    pub fn try_from_str(env: Env, string: &str) -> NifResult<Option<Self>> {
+        Self::existing_from_str(env, string).map(Some)
     }
 }
 

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -1,3 +1,4 @@
+use crate::sys::ErlNifCharEncoding;
 use crate::wrapper::atom;
 use crate::wrapper::NIF_TERM;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
@@ -36,24 +37,100 @@ impl Atom {
     /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_atom/2`.
     ///
     /// # Errors
-    /// `Error::BadArg` if `bytes.len() > 255`.
-    pub fn from_bytes(env: Env, bytes: &[u8]) -> NifResult<Atom> {
-        if bytes.len() > 255 {
+    /// `Error::BadArg` if atom creation fails.
+    ///
+    /// This function uses Latin-1 encoding for compatibility.
+    pub fn from_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+        Atom::from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
+    }
+
+    /// Return the atom whose text representation is UTF-8 `bytes`.
+    ///
+    /// On NIF 2.17+ (`OTP 26+`), this uses UTF-8 atom APIs directly.
+    /// On older NIF versions, UTF-8 is transcoded to Latin-1 before atom creation.
+    pub fn from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+        #[cfg(feature = "nif_version_2_17")]
+        {
+            Atom::from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_UTF8)
+        }
+
+        #[cfg(not(feature = "nif_version_2_17"))]
+        {
+            let string = std::str::from_utf8(bytes).map_err(|_| Error::BadArg)?;
+            let mut latin1 = Vec::with_capacity(string.len());
+            for c in string.chars() {
+                if (c as u32) >= 256 {
+                    return Err(Error::BadArg);
+                }
+                latin1.push(c as u8);
+            }
+            Atom::from_encoded_bytes(env, &latin1, ErlNifCharEncoding::ERL_NIF_LATIN1)
+        }
+    }
+
+    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_atom/2`.
+    ///
+    /// # Errors
+    /// `Error::BadArg` if atom creation fails.
+    ///
+    /// The encoding is selected by `encoding`.
+    /// On legacy NIF versions, atom text length is validated before calling into NIF.
+    fn from_encoded_bytes(env: Env, bytes: &[u8], encoding: ErlNifCharEncoding) -> NifResult<Atom> {
+        if cfg!(not(feature = "nif_version_2_17")) && bytes.len() > 255 {
             return Err(Error::BadArg);
         }
-        unsafe { Ok(Atom::from_nif_term(atom::make_atom(env.as_c_arg(), bytes))) }
+
+        let term = unsafe { atom::make_atom(env.as_c_arg(), bytes, encoding) };
+        if term == 0 {
+            Err(Error::BadArg)
+        } else {
+            Ok(unsafe { Atom::from_nif_term(term) })
+        }
+    }
+
+    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Self>> {
+        Atom::try_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
+    }
+
+    /// Return the existing atom whose text representation is UTF-8 `bytes`.
+    ///
+    /// On NIF 2.17+ (`OTP 26+`), this uses UTF-8 atom APIs directly.
+    /// On older NIF versions, UTF-8 is transcoded to Latin-1 before lookup.
+    pub fn try_from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Self>> {
+        #[cfg(feature = "nif_version_2_17")]
+        {
+            Atom::try_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_UTF8)
+        }
+
+        #[cfg(not(feature = "nif_version_2_17"))]
+        {
+            let string = std::str::from_utf8(bytes).map_err(|_| Error::BadArg)?;
+            let mut latin1 = Vec::with_capacity(string.len());
+            for c in string.chars() {
+                if (c as u32) >= 256 {
+                    return Err(Error::BadArg);
+                }
+                latin1.push(c as u8);
+            }
+            Atom::try_from_encoded_bytes(env, &latin1, ErlNifCharEncoding::ERL_NIF_LATIN1)
+        }
     }
 
     /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_existing_atom/2`, if atom with given text representation exists.
     ///
     /// # Errors
-    /// `Error::BadArg` if `bytes.len() > 255`.
-    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Atom>> {
-        if bytes.len() > 255 {
-            return Err(Error::BadArg);
-        }
+    /// `Error::BadArg` on legacy NIF versions when atom text exceeds the maximum size.
+    ///
+    /// The encoding is selected by `encoding`.
+    /// If the atom does not already exist (or text is invalid for the selected encoding),
+    /// this returns `Ok(None)`.
+    fn try_from_encoded_bytes(
+        env: Env,
+        bytes: &[u8],
+        encoding: ErlNifCharEncoding,
+    ) -> NifResult<Option<Atom>> {
         unsafe {
-            match atom::make_existing_atom(env.as_c_arg(), bytes) {
+            match atom::make_existing_atom(env.as_c_arg(), bytes, encoding) {
                 Some(term) => Ok(Some(Atom::from_nif_term(term))),
                 None => Ok(None),
             }
@@ -63,23 +140,9 @@ impl Atom {
     /// Return the atom whose text representation is the given `string`, like `erlang:list_to_atom/2`.
     ///
     /// # Errors
-    /// `Error::BadArg` if `string` contains characters that aren't in Latin-1, or if it's too
-    /// long. The maximum length is 255 characters.
+    /// `Error::BadArg` if atom creation fails.
     pub fn from_str(env: Env, string: &str) -> NifResult<Atom> {
-        if string.is_ascii() {
-            // Fast path.
-            Atom::from_bytes(env, string.as_bytes())
-        } else {
-            // Convert from Rust UTF-8 to Latin-1.
-            let mut bytes = Vec::with_capacity(string.len());
-            for c in string.chars() {
-                if (c as u32) >= 256 {
-                    return Err(Error::BadArg);
-                }
-                bytes.push(c as u8);
-            }
-            Atom::from_bytes(env, &bytes)
-        }
+        Atom::from_utf8_bytes(env, string.as_bytes())
     }
 }
 

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -34,7 +34,7 @@ impl Atom {
         }
     }
 
-    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_atom/2`.
+    /// Return the atom whose text representation is Latin1 `bytes`.
     ///
     /// # Errors
     /// `Error::BadArg` if atom creation fails.
@@ -46,12 +46,18 @@ impl Atom {
 
     /// Return the atom whose text representation is UTF-8 `bytes`.
     ///
+    /// # Errors
+    /// `Error::BadArg` if atom creation fails. Before NIF 2.17, it will also
+    /// return `Error::BadArg` if the atom can not be encoded to Latin1.
+    ///
     /// On NIF 2.17+ (`OTP 26+`), this uses UTF-8 atom APIs directly.
     /// On older NIF versions, UTF-8 is transcoded to Latin-1 before atom creation.
     pub fn from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+        use ErlNifCharEncoding::*;
+
         #[cfg(feature = "nif_version_2_17")]
         {
-            Atom::from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_UTF8)
+            Atom::from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
         }
 
         #[cfg(not(feature = "nif_version_2_17"))]
@@ -64,42 +70,41 @@ impl Atom {
                 }
                 latin1.push(c as u8);
             }
-            Atom::from_encoded_bytes(env, &latin1, ErlNifCharEncoding::ERL_NIF_LATIN1)
+            Atom::from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
         }
     }
 
-    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_atom/2`.
+    fn from_encoded_bytes(env: Env, bytes: &[u8], encoding: ErlNifCharEncoding) -> NifResult<Atom> {
+        unsafe {
+            atom::make_atom(env.as_c_arg(), bytes, encoding).map(|term| Atom::from_nif_term(term))
+        }
+    }
+
+    /// Return the atom whose text representation is Latin1 `bytes`, like `erlang:binary_to_existing_atom/1`,
+    /// if atom with given text representation exists.
     ///
     /// # Errors
-    /// `Error::BadArg` if atom creation fails.
-    ///
-    /// The encoding is selected by `encoding`.
-    /// On legacy NIF versions, atom text length is validated before calling into NIF.
-    fn from_encoded_bytes(env: Env, bytes: &[u8], encoding: ErlNifCharEncoding) -> NifResult<Atom> {
-        if cfg!(not(feature = "nif_version_2_17")) && bytes.len() > 255 {
-            return Err(Error::BadArg);
-        }
-
-        let term = unsafe { atom::make_atom(env.as_c_arg(), bytes, encoding) };
-        if term == 0 {
-            Err(Error::BadArg)
-        } else {
-            Ok(unsafe { Atom::from_nif_term(term) })
-        }
-    }
-
-    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Self>> {
+    /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
+    /// NIF 2.17, 255 characters later), or the atom already exists
+    pub fn try_from_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
         Atom::try_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_LATIN1)
     }
 
-    /// Return the existing atom whose text representation is UTF-8 `bytes`.
+    /// Return the atom whose text representation is UTF8 `bytes`, like `erlang:binary_to_existing_atom/2`,
+    /// if atom with given text representation exists.
+    ///
+    /// # Errors
+    /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
+    /// NIF 2.17, 255 characters later), or the atom already exists.
     ///
     /// On NIF 2.17+ (`OTP 26+`), this uses UTF-8 atom APIs directly.
     /// On older NIF versions, UTF-8 is transcoded to Latin-1 before lookup.
-    pub fn try_from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Option<Self>> {
+    pub fn try_from_utf8_bytes(env: Env, bytes: &[u8]) -> NifResult<Self> {
+        use ErlNifCharEncoding::*;
+
         #[cfg(feature = "nif_version_2_17")]
         {
-            Atom::try_from_encoded_bytes(env, bytes, ErlNifCharEncoding::ERL_NIF_UTF8)
+            Self::try_from_encoded_bytes(env, bytes, ERL_NIF_UTF8)
         }
 
         #[cfg(not(feature = "nif_version_2_17"))]
@@ -112,37 +117,41 @@ impl Atom {
                 }
                 latin1.push(c as u8);
             }
-            Atom::try_from_encoded_bytes(env, &latin1, ErlNifCharEncoding::ERL_NIF_LATIN1)
+            Self::try_from_encoded_bytes(env, &latin1, ERL_NIF_LATIN1)
         }
     }
 
-    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_existing_atom/2`, if atom with given text representation exists.
+    /// Return the atom whose text representation is `bytes`, like `erlang:binary_to_existing_atom/2`,
+    /// if atom with given text representation exists.
     ///
     /// # Errors
-    /// `Error::BadArg` on legacy NIF versions when atom text exceeds the maximum size.
-    ///
-    /// The encoding is selected by `encoding`.
-    /// If the atom does not already exist (or text is invalid for the selected encoding),
-    /// this returns `Ok(None)`.
+    /// `Error::BadArg` if the bytes are incorrectly encoded, the array is too long (255 bytes before
+    /// NIF 2.17, 255 characters later), or the atom already exists.
     fn try_from_encoded_bytes(
         env: Env,
         bytes: &[u8],
         encoding: ErlNifCharEncoding,
-    ) -> NifResult<Option<Atom>> {
+    ) -> NifResult<Self> {
         unsafe {
-            match atom::make_existing_atom(env.as_c_arg(), bytes, encoding) {
-                Some(term) => Ok(Some(Atom::from_nif_term(term))),
-                None => Ok(None),
-            }
+            atom::make_existing_atom(env.as_c_arg(), bytes, encoding)
+                .map(|term| Self::from_nif_term(term))
         }
     }
 
-    /// Return the atom whose text representation is the given `string`, like `erlang:list_to_atom/2`.
+    /// Return the atom whose text representation is the given `string`.
     ///
     /// # Errors
     /// `Error::BadArg` if atom creation fails.
     pub fn from_str(env: Env, string: &str) -> NifResult<Atom> {
-        Atom::from_utf8_bytes(env, string.as_bytes())
+        Self::from_utf8_bytes(env, string.as_bytes())
+    }
+
+    /// Return the atom whose text representation is the given `string`.
+    ///
+    /// # Errors
+    /// `Error::BadArg` if atom creation fails or if the atom exists already.
+    pub fn try_from_str(env: Env, string: &str) -> NifResult<Atom> {
+        Self::try_from_utf8_bytes(env, string.as_bytes())
     }
 }
 

--- a/rustler/src/wrapper/atom.rs
+++ b/rustler/src/wrapper/atom.rs
@@ -8,12 +8,25 @@ use crate::wrapper::{c_char, c_uint, NIF_ENV, NIF_TERM};
 use crate::Error;
 
 #[cfg(not(feature = "nif_version_2_17"))]
-pub unsafe fn make_atom(env: NIF_ENV, name: &[u8], _encoding: ErlNifCharEncoding) -> NIF_TERM {
-    enif_make_atom_len(env, name.as_ptr() as *const c_char, name.len())
+pub unsafe fn make_atom(
+    env: NIF_ENV,
+    name: &[u8],
+    _encoding: ErlNifCharEncoding,
+) -> Result<NIF_TERM, Error> {
+    let res = enif_make_atom_len(env, name.as_ptr() as *const c_char, name.len());
+    if res != 0 {
+        Ok(res)
+    } else {
+        Err(Error::BadArg)
+    }
 }
 
 #[cfg(feature = "nif_version_2_17")]
-pub unsafe fn make_atom(env: NIF_ENV, name: &[u8], encoding: ErlNifCharEncoding) -> NIF_TERM {
+pub unsafe fn make_atom(
+    env: NIF_ENV,
+    name: &[u8],
+    encoding: ErlNifCharEncoding,
+) -> Result<NIF_TERM, Error> {
     let mut atom_out: NIF_TERM = 0;
 
     // Create a new atom with the requested encoding.
@@ -26,29 +39,31 @@ pub unsafe fn make_atom(env: NIF_ENV, name: &[u8], encoding: ErlNifCharEncoding)
         encoding,
     ) != 0
     {
-        return atom_out;
+        Ok(atom_out)
+    } else {
+        Err(Error::BadArg)
     }
-
-    0
 }
 
 pub unsafe fn make_existing_atom(
     env: NIF_ENV,
     name: &[u8],
     encoding: ErlNifCharEncoding,
-) -> Option<NIF_TERM> {
+) -> Result<NIF_TERM, Error> {
     let mut atom_out: NIF_TERM = 0;
-    let success = enif_make_existing_atom_len(
+
+    if enif_make_existing_atom_len(
         env,
         name.as_ptr() as *const c_char,
         name.len(),
         &mut atom_out as *mut NIF_TERM,
         encoding,
-    );
-    if success == 0 {
-        return None;
+    ) != 0
+    {
+        Ok(atom_out)
+    } else {
+        Err(Error::BadArg)
     }
-    Some(atom_out)
 }
 
 /// Get the contents of this atom as a string.

--- a/rustler/src/wrapper/atom.rs
+++ b/rustler/src/wrapper/atom.rs
@@ -1,22 +1,49 @@
-use crate::sys::ErlNifCharEncoding::ERL_NIF_LATIN1;
-use crate::sys::{
-    enif_get_atom, enif_get_atom_length, enif_make_atom_len, enif_make_existing_atom_len,
-};
+#[cfg(not(feature = "nif_version_2_17"))]
+use crate::sys::enif_make_atom_len;
+#[cfg(feature = "nif_version_2_17")]
+use crate::sys::enif_make_new_atom_len;
+use crate::sys::ErlNifCharEncoding;
+use crate::sys::{enif_get_atom, enif_get_atom_length, enif_make_existing_atom_len};
 use crate::wrapper::{c_char, c_uint, NIF_ENV, NIF_TERM};
 use crate::Error;
 
-pub unsafe fn make_atom(env: NIF_ENV, name: &[u8]) -> NIF_TERM {
+#[cfg(not(feature = "nif_version_2_17"))]
+pub unsafe fn make_atom(env: NIF_ENV, name: &[u8], _encoding: ErlNifCharEncoding) -> NIF_TERM {
     enif_make_atom_len(env, name.as_ptr() as *const c_char, name.len())
 }
 
-pub unsafe fn make_existing_atom(env: NIF_ENV, name: &[u8]) -> Option<NIF_TERM> {
+#[cfg(feature = "nif_version_2_17")]
+pub unsafe fn make_atom(env: NIF_ENV, name: &[u8], encoding: ErlNifCharEncoding) -> NIF_TERM {
+    let mut atom_out: NIF_TERM = 0;
+
+    // Create a new atom with the requested encoding.
+    // Returns 0 if creation fails (e.g. invalid text/encoding).
+    if enif_make_new_atom_len(
+        env,
+        name.as_ptr() as *const c_char,
+        name.len(),
+        &mut atom_out as *mut NIF_TERM,
+        encoding,
+    ) != 0
+    {
+        return atom_out;
+    }
+
+    0
+}
+
+pub unsafe fn make_existing_atom(
+    env: NIF_ENV,
+    name: &[u8],
+    encoding: ErlNifCharEncoding,
+) -> Option<NIF_TERM> {
     let mut atom_out: NIF_TERM = 0;
     let success = enif_make_existing_atom_len(
         env,
         name.as_ptr() as *const c_char,
         name.len(),
         &mut atom_out as *mut NIF_TERM,
-        ERL_NIF_LATIN1,
+        encoding,
     );
     if success == 0 {
         return None;
@@ -33,10 +60,40 @@ pub unsafe fn make_existing_atom(env: NIF_ENV, name: &[u8]) -> Option<NIF_TERM> 
 ///
 /// `Error::BadArg` if `term` is not an atom.
 ///
+#[cfg(feature = "nif_version_2_17")]
 pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
     // Determine the length of the atom, in bytes.
     let mut len = 0;
-    let success = enif_get_atom_length(env, term, &mut len, ERL_NIF_LATIN1);
+    let success = enif_get_atom_length(env, term, &mut len, ErlNifCharEncoding::ERL_NIF_UTF8);
+    if success == 0 {
+        return Err(Error::BadArg);
+    }
+
+    // Get the bytes from the atom into a buffer.
+    // enif_get_atom() writes a null terminated string,
+    // so add 1 to the atom's length to make room for it.
+    let mut string = String::with_capacity(len as usize + 1);
+    let bytes = string.as_mut_vec();
+    let nbytes = enif_get_atom(
+        env,
+        term,
+        bytes.as_mut_ptr(),
+        len + 1,
+        ErlNifCharEncoding::ERL_NIF_UTF8,
+    );
+    assert!(nbytes as c_uint == len + 1);
+
+    // This relies on Erlang guaranteeing valid UTF-8 for ERL_NIF_UTF8 reads.
+    bytes.set_len(len as usize); // drop the null byte
+
+    Ok(string)
+}
+
+#[cfg(not(feature = "nif_version_2_17"))]
+pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
+    // Determine the length of the atom, in bytes.
+    let mut len = 0;
+    let success = enif_get_atom_length(env, term, &mut len, ErlNifCharEncoding::ERL_NIF_LATIN1);
     if success == 0 {
         return Err(Error::BadArg);
     }
@@ -45,7 +102,13 @@ pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
     // enif_get_atom() writes a null terminated string,
     // so add 1 to the atom's length to make room for it.
     let mut bytes: Vec<u8> = Vec::with_capacity(len as usize + 1);
-    let nbytes = enif_get_atom(env, term, bytes.as_mut_ptr(), len + 1, ERL_NIF_LATIN1);
+    let nbytes = enif_get_atom(
+        env,
+        term,
+        bytes.as_mut_ptr(),
+        len + 1,
+        ErlNifCharEncoding::ERL_NIF_LATIN1,
+    );
     assert!(nbytes as c_uint == len + 1);
 
     // This is safe unless the VM is lying to us.

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -97,7 +97,9 @@ defmodule RustlerTest do
   def atom_to_string(_), do: err()
   def atom_equals_ok(_), do: err()
   def binary_to_atom(_), do: err()
+  def binary_to_atom_utf8(_), do: err()
   def binary_to_existing_atom(_), do: err()
+  def binary_to_existing_atom_utf8(_), do: err()
 
   def threaded_fac(_), do: err()
   def threaded_sleep(_), do: err()

--- a/rustler_tests/native/rustler_test/src/test_atom.rs
+++ b/rustler_tests/native/rustler_test/src/test_atom.rs
@@ -26,10 +26,10 @@ pub fn binary_to_atom_utf8(env: Env, binary: Binary) -> NifResult<Atom> {
 
 #[rustler::nif]
 pub fn binary_to_existing_atom(env: Env, binary: Binary) -> Option<Atom> {
-    Atom::try_from_bytes(env, binary.as_slice()).ok()
+    Atom::existing_from_bytes(env, binary.as_slice()).ok()
 }
 
 #[rustler::nif]
 pub fn binary_to_existing_atom_utf8(env: Env, binary: Binary) -> Option<Atom> {
-    Atom::try_from_utf8_bytes(env, binary.as_slice()).ok()
+    Atom::existing_from_utf8_bytes(env, binary.as_slice()).ok()
 }

--- a/rustler_tests/native/rustler_test/src/test_atom.rs
+++ b/rustler_tests/native/rustler_test/src/test_atom.rs
@@ -21,7 +21,19 @@ pub fn binary_to_atom(env: Env, binary: Binary) -> NifResult<Atom> {
 }
 
 #[rustler::nif]
+pub fn binary_to_atom_utf8(env: Env, binary: Binary) -> NifResult<Atom> {
+    let atom = Atom::from_utf8_bytes(env, binary.as_slice())?;
+    Ok(atom)
+}
+
+#[rustler::nif]
 pub fn binary_to_existing_atom(env: Env, binary: Binary) -> NifResult<Option<Atom>> {
     let atom = Atom::try_from_bytes(env, binary.as_slice())?;
+    Ok(atom)
+}
+
+#[rustler::nif]
+pub fn binary_to_existing_atom_utf8(env: Env, binary: Binary) -> NifResult<Option<Atom>> {
+    let atom = Atom::try_from_utf8_bytes(env, binary.as_slice())?;
     Ok(atom)
 }

--- a/rustler_tests/native/rustler_test/src/test_atom.rs
+++ b/rustler_tests/native/rustler_test/src/test_atom.rs
@@ -16,24 +16,20 @@ pub fn atom_equals_ok(atom: Atom) -> bool {
 
 #[rustler::nif]
 pub fn binary_to_atom(env: Env, binary: Binary) -> NifResult<Atom> {
-    let atom = Atom::from_bytes(env, binary.as_slice())?;
-    Ok(atom)
+    Atom::from_bytes(env, binary.as_slice())
 }
 
 #[rustler::nif]
 pub fn binary_to_atom_utf8(env: Env, binary: Binary) -> NifResult<Atom> {
-    let atom = Atom::from_utf8_bytes(env, binary.as_slice())?;
-    Ok(atom)
+    Atom::from_utf8_bytes(env, binary.as_slice())
 }
 
 #[rustler::nif]
-pub fn binary_to_existing_atom(env: Env, binary: Binary) -> NifResult<Option<Atom>> {
-    let atom = Atom::try_from_bytes(env, binary.as_slice())?;
-    Ok(atom)
+pub fn binary_to_existing_atom(env: Env, binary: Binary) -> Option<Atom> {
+    Atom::try_from_bytes(env, binary.as_slice()).ok()
 }
 
 #[rustler::nif]
-pub fn binary_to_existing_atom_utf8(env: Env, binary: Binary) -> NifResult<Option<Atom>> {
-    let atom = Atom::try_from_utf8_bytes(env, binary.as_slice())?;
-    Ok(atom)
+pub fn binary_to_existing_atom_utf8(env: Env, binary: Binary) -> Option<Atom> {
+    Atom::try_from_utf8_bytes(env, binary.as_slice()).ok()
 }

--- a/rustler_tests/test/atom_test.exs
+++ b/rustler_tests/test/atom_test.exs
@@ -7,6 +7,24 @@ defmodule RustlerTest.AtomTest do
     assert RustlerTest.atom_to_string(:erlang.list_to_atom([197])) == "Å"
   end
 
+  test "utf8 atom roundtrip" do
+    utf8 = "ÀrgerÖ"
+
+    utf8_atom = RustlerTest.binary_to_atom_utf8(utf8)
+    assert utf8_atom == String.to_atom(utf8)
+    assert RustlerTest.atom_to_string(utf8_atom) == utf8
+  end
+
+  test "utf8 atom roundtrip on nif 2.17+" do
+    if RustlerTest.Helper.has_nif_version("2.17") do
+      utf8 = "こんにちは"
+
+      utf8_atom = RustlerTest.binary_to_atom_utf8(utf8)
+      assert utf8_atom == String.to_atom(utf8)
+      assert RustlerTest.atom_to_string(utf8_atom) == utf8
+    end
+  end
+
   test "binary to atom" do
     assert RustlerTest.binary_to_atom("test_atom") == :test_atom
   end

--- a/rustler_tests/test/atom_test.exs
+++ b/rustler_tests/test/atom_test.exs
@@ -44,4 +44,36 @@ defmodule RustlerTest.AtomTest do
     refute RustlerTest.atom_equals_ok(:fish)
     assert catch_error(RustlerTest.atom_equals_ok("ok")) == :badarg
   end
+
+  test "binary to existing atom utf8" do
+    utf8 = "test_non_existing_ÀrgerÖ"
+
+    assert RustlerTest.binary_to_existing_atom_utf8(utf8) == nil
+    assert RustlerTest.binary_to_atom_utf8(utf8)
+    assert RustlerTest.binary_to_existing_atom_utf8(utf8) != nil
+
+    if RustlerTest.Helper.has_nif_version("2.17") do
+      utf8 = "test_non_existing_こんにちは"
+
+      assert RustlerTest.binary_to_existing_atom_utf8(utf8) == nil
+      assert RustlerTest.binary_to_atom_utf8(utf8)
+      assert RustlerTest.binary_to_existing_atom_utf8(utf8) != nil
+    end
+  end
+
+  test "reject invalid utf8" do
+    invalid_utf8 = <<0xE5>>
+
+    assert catch_error(RustlerTest.binary_to_atom_utf8(invalid_utf8)) == :badarg
+    assert RustlerTest.binary_to_existing_atom_utf8(invalid_utf8) == nil
+  end
+
+  test "reject not-latin1-encodable string" do
+    unless RustlerTest.Helper.has_nif_version("2.17") do
+      non_latin1_utf8 = "こんにちは"
+
+      assert catch_error(RustlerTest.binary_to_atom_utf8(non_latin1_utf8)) == :badarg
+      assert RustlerTest.binary_to_existing_atom_utf8(non_latin1_utf8) == nil
+    end
+  end
 end


### PR DESCRIPTION
- Add `(try_)from_utf8_bytes` on all NIF versions, use builtin fast path
  on NIF 2.17 upwards
- Use direct UTF8 conversions for strings

Implements #645 
