### PR TITLE
Alternative NIF Filler adjustment for Android

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -23,12 +23,14 @@ serde = ["dep:serde"]
 
 [dependencies]
 inventory = "0.3"
-rustler_codegen = { path = "../rustler_codegen", version = "0.37.4"}
+rustler_codegen = { path = "../rustler_codegen", version = "0.37.4" }
 num-bigint = { version = "0.4", optional = true }
 serde = { version = "1", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 libloading = "0.9"
+# For RTLD_NOLOAD
+libc = "0.2"
 
 [build-dependencies]
 regex-lite = "0.1"

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -5,7 +5,10 @@ pub(crate) trait DynNifFiller {
 #[cfg(not(target_os = "windows"))]
 mod internal {
     use super::DynNifFiller;
-    use libloading::os::unix::{Library, RTLD_GLOBAL, RTLD_NOW};
+    use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
+    use libloading::os::unix::Library;
+
+    const FLAGS: i32 = RTLD_GLOBAL | RTLD_NOLOAD | RTLD_NOW;
 
     // Path to the shared object that contains the BEAM
     const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
@@ -20,7 +23,7 @@ mod internal {
                 Ok(val) if !val.is_empty() => Some(val),
                 _ => None,
             };
-            let lib = unsafe { Library::open(beam_location, RTLD_NOW | RTLD_GLOBAL) };
+            let lib = unsafe { Library::open(beam_location, FLAGS) };
             DlsymNifFiller {
                 lib: lib.unwrap().into(),
             }

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -4,10 +4,11 @@ pub(crate) trait DynNifFiller {
 
 #[cfg(not(target_os = "windows"))]
 mod internal {
-    use std::ffi::OsStr;
-
     use super::DynNifFiller;
     use libloading::os::unix::{Library, RTLD_GLOBAL, RTLD_NOW};
+
+    // Path to the shared object that contains the BEAM
+    const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
 
     pub(crate) struct DlsymNifFiller {
         lib: libloading::Library,
@@ -15,7 +16,11 @@ mod internal {
 
     impl DlsymNifFiller {
         pub(crate) fn new() -> Self {
-            let lib = unsafe { Library::open(None::<&OsStr>, RTLD_NOW | RTLD_GLOBAL) };
+            let beam_location = match std::env::var(BEAM_LOC) {
+                Ok(val) if !val.is_empty() => Some(val),
+                _ => None,
+            };
+            let lib = unsafe { Library::open(beam_location, RTLD_NOW | RTLD_GLOBAL) };
             DlsymNifFiller {
                 lib: lib.unwrap().into(),
             }


### PR DESCRIPTION
On Android, `RTLD_GLOBAL` is broken for backwards compatibility reasons in that it does not return symbols that are not available on the main executable. To work around this, one can `dlopen` the _actual_ binary that contains the symbols. This change allows setting the path via an environment variable, it will use `NULL` as before if the environment variable is not set.

@GenericJam Could you test whether this would work for you as well as an alternative to #726? You would need to set the environment variable `RUSTLER_BEAM_LIBRARY_PATH` to the path of the `.so` that contains the `enif_*` symbols.