### PR TITLE
Document the lib configuration option

### DIFF
--- a/rustler_mix/lib/rustler.ex
+++ b/rustler_mix/lib/rustler.ex
@@ -69,6 +69,10 @@ defmodule Rustler do
       `{:my_app, "priv/native/<artifact>"}`. Due to the way `:erlang.load_nif/2`
       works, the artifact should not include the file extension (i.e. `.so`, `.dll`).
 
+    * `:lib` - Specify whether Rustler should compile and load the crate as a NIF
+      library (default: `true`). Set this to `false` for crates that only produce
+      binaries via the `:binaries` option and do not expose a NIF library.
+
     * `:mode` - Specify which mode to compile the crate with (default: `:release`)
 
     * `:path` - By default, rustler expects the crate to be found in `native/<crate>` in the


### PR DESCRIPTION
## Summary
- document the `:lib` Rustler configuration option
- mention its default and when to set it to `false` for binary-only crates

Closes #391

## Verification
- `git diff --check`
- `cargo check -p rustler --manifest-path /Users/wuyangfan/rustler-contrib/Cargo.toml`

## Risk
- Documentation-only change; no runtime behavior changes.
