### PR TITLE
Add comment to Cargo.toml on where to find nif versions

### DIFF
--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -14,12 +14,14 @@ big_integer = ["dep:num-bigint"]
 default = ["nif_version_2_15"]
 derive = []
 allocator = []
+serde = ["dep:serde"]
+# for nif versions and their changes see
+# https://github.com/erlang/otp/blob/master/erts/emulator/beam/erl_nif.h
 nif_version_2_14 = []
 nif_version_2_15 = ["nif_version_2_14"]
 nif_version_2_16 = ["nif_version_2_15"]
 nif_version_2_17 = ["nif_version_2_16"]
 nif_version_2_18 = ["nif_version_2_17"]
-serde = ["dep:serde"]
 
 [dependencies]
 inventory = "0.3"


### PR DESCRIPTION
To prevent confusions about OTP versions, Erlang versions, and NIF Versions a comment was added to Cargo.toml about where to find NIF versions and it's changelog.