### PR TITLE
Implement registering and calling stop callback of resources

### DIFF
--- a/rustler/src/resource/registration.rs
+++ b/rustler/src/resource/registration.rs
@@ -3,8 +3,9 @@ use super::util::align_alloced_mem_for_struct;
 use super::ResourceInitError;
 use crate::env::EnvKind;
 use crate::sys::{
-    c_char, c_void, ErlNifEnv, ErlNifMonitor, ErlNifPid, ErlNifResourceDown, ErlNifResourceDtor,
-    ErlNifResourceFlags, ErlNifResourceType, ErlNifResourceTypeInit,
+    c_char, c_int, c_void, ErlNifEnv, ErlNifEvent, ErlNifMonitor, ErlNifPid, ErlNifResourceDown,
+    ErlNifResourceDtor, ErlNifResourceFlags, ErlNifResourceStop, ErlNifResourceType,
+    ErlNifResourceTypeInit,
 };
 use crate::{Env, LocalPid, Monitor, Resource};
 use std::any::TypeId;
@@ -65,6 +66,7 @@ impl Registration {
             type_name: None,
         }
         .maybe_add_destructor_callback::<T>()
+        .maybe_add_stop_callback::<T>()
         .maybe_add_down_callback::<T>()
         .maybe_add_dyncall_callback::<T>()
     }
@@ -83,6 +85,22 @@ impl Registration {
                     dtor: resource_destructor::<T> as *const ErlNifResourceDtor,
                     #[cfg(feature = "nif_version_2_16")]
                     members: max(self.init.members, 1),
+                    ..self.init
+                },
+                ..self
+            }
+        } else {
+            self
+        }
+    }
+
+    const fn maybe_add_stop_callback<T: Resource>(self) -> Self {
+        if T::IMPLEMENTS_STOP {
+            Self {
+                init: ErlNifResourceTypeInit {
+                    stop: resource_stop::<T> as *const ErlNifResourceStop,
+                    #[cfg(feature = "nif_version_2_16")]
+                    members: max(self.init.members, 2),
                     ..self.init
                 },
                 ..self
@@ -170,6 +188,23 @@ where
     let obj = ptr::read::<T>(aligned as *mut T);
     if T::IMPLEMENTS_DESTRUCTOR {
         obj.destructor(env);
+    }
+}
+
+unsafe extern "C" fn resource_stop<T>(
+    caller_env: *mut ErlNifEnv,
+    handle: *mut c_void,
+    event: ErlNifEvent,
+    is_direct_call: c_int,
+) where
+    T: Resource,
+{
+    let env = Env::new_internal(&caller_env, caller_env, EnvKind::Callback);
+    let aligned = align_alloced_mem_for_struct::<T>(handle);
+    let obj = ptr::read::<T>(aligned as *mut T);
+    let is_direct_call = is_direct_call == 1;
+    if T::IMPLEMENTS_STOP {
+        obj.stop(env, event, is_direct_call);
     }
 }
 

--- a/rustler/src/resource/traits.rs
+++ b/rustler/src/resource/traits.rs
@@ -2,7 +2,7 @@ use std::any::TypeId;
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
-use crate::sys::ErlNifResourceType;
+use crate::sys::{ErlNifEvent, ErlNifResourceType};
 use crate::{Env, LocalPid, Monitor};
 
 type NifResourcePtr = *const ErlNifResourceType;
@@ -30,14 +30,15 @@ pub(crate) unsafe fn register_resource_type(type_id: TypeId, resource_type: NifR
 /// In particular, the type needs to handle all synchronization itself (thus we require it to
 /// implement `Sync`) and callbacks or NIFs can run on arbitrary threads (thus we require `Send`).
 ///
-/// Currently only `destructor` and `down` callbacks are possible. If a callback is implemented,
-/// the respective associated constant `IMPLEMENTS_...` must be set to `true` for the registration
-/// to take it into account. All callbacks provide (empty) default implementations.
+/// If a callback is implemented, the respective associated constant `IMPLEMENTS_...`
+/// must be set to `true` for the registration to take it into account.
+/// All callbacks provide (empty) default implementations.
 pub trait Resource: Sized + Send + Sync + 'static {
     const IMPLEMENTS_DESTRUCTOR: bool = false;
+    const IMPLEMENTS_STOP: bool = false;
     const IMPLEMENTS_DOWN: bool = false;
 
-    #[cfg(feature = "nif_version_2_16")]
+    #[cfg(feature = "nif_version_2_15")]
     const IMPLEMENTS_DYNCALL: bool = false;
 
     /// Callback function that is executed right before dropping a resource object.
@@ -48,6 +49,14 @@ pub trait Resource: Sized + Send + Sync + 'static {
     /// requires access to a NIF env, e.g. to send messages.
     #[allow(unused_mut, unused)]
     fn destructor(mut self, env: Env<'_>) {}
+
+    /// The stop callback of a resource.
+    /// It is called on the behalf of [`enif_select()`](crate::sys::enif_select).
+    ///
+    /// - event is the OS event
+    /// - is_direct_call is true if the call is made directly from enif_select or false if it is a scheduled call (potentially from another thread).
+    #[allow(unused)]
+    fn stop<'a>(&'a self, env: Env<'a>, event: ErlNifEvent, is_direct_call: bool) {}
 
     /// Callback function to handle process monitoring.
     ///


### PR DESCRIPTION
I have implemented a new `stop()` callback compatible with [ErlNifResourceStop](https://www.erlang.org/doc/apps/erts/erl_nif.html#ErlNifResourceStop) as an addition to the `Resource` trait.

This has been manually verified to work by implementing a small program on top of it.
The codegen for the `#[resource_impl]` macro also just works.

resolves #735 