### PR TITLE
Relax mutability requirement of ResourceArc::as_c_arg()

### DIFF
--- a/rustler/src/resource/arc.rs
+++ b/rustler/src/resource/arc.rs
@@ -109,7 +109,7 @@ where
     /// Note that this pointer does not necessarily point to the contained type but is commonly used
     /// as an object identifier for an allocated resource when interacting with low-level VM functions
     /// like [`enif_select()`](crate::sys::enif_select).
-    pub fn as_c_arg(&mut self) -> *const c_void {
+    pub fn as_c_arg(&self) -> *const c_void {
         self.raw
     }
 


### PR DESCRIPTION
The ResourceArc::as_c_arg() previously required a mutable borrow of `self` even thouh it only returned as const pointer. This mutability is not required and can be safely relaxed.

The previous mutability actually causes problems where one only needs to use the provided object pointer as a handle to the erlang VM, for example when setting up `enif_select()`.