### PR TITLE
Support NifMap decoding when elixir map has missing fields

### DIFF
--- a/rustler_codegen/src/attrs.rs
+++ b/rustler_codegen/src/attrs.rs
@@ -36,6 +36,7 @@ pub(crate) trait TryFromRustlerNestedAttr: Sized {
 pub(crate) enum RustlerAttr {
     Encode,
     Decode,
+    OptionalDecode,
     Module(String),
     Tag(String),
 }
@@ -71,7 +72,7 @@ impl RustlerAttr {
 
 impl TryFromRustlerNestedAttr for RustlerAttr {
     fn parse_failure_message() -> impl Display {
-        "Expected encode, decode and/or optional in rustler attribute"
+        "Expected encode, decode and/or optional_decode in rustler attribute"
     }
 
     fn collect_attrs_for_ident(ident: &Ident, meta: &Meta) -> Option<Vec<Self>> {
@@ -87,6 +88,32 @@ impl TryFromRustlerNestedAttr for RustlerAttr {
         match ident.to_string().as_ref() {
             "encode" => Some(Self::Encode),
             "decode" => Some(Self::Decode),
+            "optional_decode" => Some(Self::OptionalDecode),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RustlerFieldAttr {
+    OptionalDecode,
+}
+
+impl TryFromRustlerNestedAttr for RustlerFieldAttr {
+    fn parse_failure_message() -> impl Display {
+        "Expected optional_decode in rustler field attribute"
+    }
+
+    fn collect_attrs_for_ident(ident: &Ident, meta: &Meta) -> Option<Vec<Self>> {
+        match ident.to_string().as_ref() {
+            "rustler" => Some(Self::parse_rustler(meta)),
+            _ => None,
+        }
+    }
+
+    fn try_from_rustler_nested_attr(ident: &Ident) -> Option<Self> {
+        match ident.to_string().as_ref() {
+            "optional_decode" => Some(Self::OptionalDecode),
             _ => None,
         }
     }

--- a/rustler_codegen/src/attrs.rs
+++ b/rustler_codegen/src/attrs.rs
@@ -1,0 +1,93 @@
+use std::fmt::Display;
+
+use syn::{Ident, Lit, Meta};
+
+pub(crate) trait TryFromRustlerNestedAttr: Sized {
+    fn collect_attrs_for_ident(ident: &Ident, meta: &Meta) -> Option<Vec<Self>>;
+    fn try_from_rustler_nested_attr(ident: &Ident) -> Option<Self>;
+    fn parse_failure_message() -> impl Display;
+
+    fn parse_rustler<T: TryFromRustlerNestedAttr>(meta: &Meta) -> Vec<T> {
+        if let Meta::List(ref list) = meta {
+            let mut attrs: Vec<T> = vec![];
+            let _ = list.parse_nested_meta(|nested_meta| {
+                let parsed_attr = nested_meta
+                    .path
+                    .get_ident()
+                    .and_then(T::try_from_rustler_nested_attr);
+
+                match parsed_attr {
+                    None => Err(nested_meta.error(T::parse_failure_message())),
+                    Some(attr) => {
+                        attrs.push(attr);
+                        Ok(())
+                    }
+                }
+            });
+
+            return attrs;
+        }
+
+        panic!("Expected nested attributes inside the rustler attribute");
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum RustlerAttr {
+    Encode,
+    Decode,
+    Module(String),
+    Tag(String),
+}
+
+impl RustlerAttr {
+    fn try_parse_tag(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(ref name_value) = meta {
+            let expr = &name_value.value;
+
+            if let syn::Expr::Lit(lit_expr) = expr {
+                if let Lit::Str(ref tag) = lit_expr.lit {
+                    return Some(vec![RustlerAttr::Tag(tag.value())]);
+                }
+            }
+        }
+        panic!("Cannot parse tag")
+    }
+
+    fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
+        if let Meta::NameValue(name_value) = meta {
+            let expr = &name_value.value;
+
+            if let syn::Expr::Lit(lit_expr) = expr {
+                if let Lit::Str(ref module) = lit_expr.lit {
+                    let ident = format!("Elixir.{}", module.value());
+                    return Some(vec![RustlerAttr::Module(ident)]);
+                }
+            }
+        }
+        panic!("Cannot parse module")
+    }
+}
+
+impl TryFromRustlerNestedAttr for RustlerAttr {
+    fn parse_failure_message() -> impl Display {
+        "Expected encode, decode and/or optional in rustler attribute"
+    }
+
+    fn collect_attrs_for_ident(ident: &Ident, meta: &Meta) -> Option<Vec<Self>> {
+        match ident.to_string().as_ref() {
+            "rustler" => Some(Self::parse_rustler(meta)),
+            "tag" => Self::try_parse_tag(meta),
+            "module" => Self::try_parse_module(meta),
+            _ => None,
+        }
+    }
+
+    fn try_from_rustler_nested_attr(ident: &Ident) -> Option<Self> {
+        match ident.to_string().as_ref() {
+            "encode" => Some(Self::Encode),
+            "decode" => Some(Self::Decode),
+            _ => None,
+        }
+    }
+}

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -1,9 +1,9 @@
 use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Data, Field, Fields, Ident, Lifetime, Lit, Meta, TypeParam, Variant};
+use syn::{Data, Field, Fields, Ident, Lifetime, TypeParam, Variant};
 
-use super::RustlerAttr;
+use crate::attrs::{RustlerAttr, TryFromRustlerNestedAttr};
 
 ///
 /// A parsing context struct.
@@ -168,67 +168,18 @@ impl<'a> Context<'a> {
     }
 
     fn get_rustler_attrs(attr: &syn::Attribute) -> Vec<RustlerAttr> {
+        Self::parse_attr::<RustlerAttr>(attr)
+    }
+
+    fn parse_attr<T: TryFromRustlerNestedAttr>(attr: &syn::Attribute) -> Vec<T> {
         attr.path()
             .segments
             .iter()
             .filter_map(|segment| {
                 let meta = &attr.meta;
-                match segment.ident.to_string().as_ref() {
-                    "rustler" => Some(Context::parse_rustler(meta)),
-                    "tag" => Context::try_parse_tag(meta),
-                    "module" => Context::try_parse_module(meta),
-                    _ => None,
-                }
+                T::collect_attrs_for_ident(&segment.ident, meta)
             })
             .flatten()
             .collect()
-    }
-
-    fn parse_rustler(meta: &Meta) -> Vec<RustlerAttr> {
-        if let Meta::List(ref list) = meta {
-            let mut attrs: Vec<RustlerAttr> = vec![];
-            let _ = list.parse_nested_meta(|nested_meta| {
-                if nested_meta.path.is_ident("encode") {
-                    attrs.push(RustlerAttr::Encode);
-                    Ok(())
-                } else if nested_meta.path.is_ident("decode") {
-                    attrs.push(RustlerAttr::Decode);
-                    Ok(())
-                } else {
-                    Err(nested_meta.error("Expected encode and/or decode in rustler attribute"))
-                }
-            });
-
-            return attrs;
-        }
-
-        panic!("Expected encode and/or decode in rustler attribute");
-    }
-
-    fn try_parse_tag(meta: &Meta) -> Option<Vec<RustlerAttr>> {
-        if let Meta::NameValue(ref name_value) = meta {
-            let expr = &name_value.value;
-
-            if let syn::Expr::Lit(lit_expr) = expr {
-                if let Lit::Str(ref tag) = lit_expr.lit {
-                    return Some(vec![RustlerAttr::Tag(tag.value())]);
-                }
-            }
-        }
-        panic!("Cannot parse tag")
-    }
-
-    fn try_parse_module(meta: &Meta) -> Option<Vec<RustlerAttr>> {
-        if let Meta::NameValue(name_value) = meta {
-            let expr = &name_value.value;
-
-            if let syn::Expr::Lit(lit_expr) = expr {
-                if let Lit::Str(ref module) = lit_expr.lit {
-                    let ident = format!("Elixir.{}", module.value());
-                    return Some(vec![RustlerAttr::Module(ident)]);
-                }
-            }
-        }
-        panic!("Cannot parse module")
     }
 }

--- a/rustler_codegen/src/context.rs
+++ b/rustler_codegen/src/context.rs
@@ -1,9 +1,30 @@
 use heck::ToSnakeCase;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Data, Field, Fields, Ident, Lifetime, TypeParam, Variant};
+use syn::{Data, Field, Fields, Ident, Lifetime, Type, TypeParam, Variant};
 
-use crate::attrs::{RustlerAttr, TryFromRustlerNestedAttr};
+use crate::attrs::{RustlerAttr, RustlerFieldAttr, TryFromRustlerNestedAttr};
+
+///
+/// A helper struct to make it easier to access field attributes.
+///
+/// `StructField` holds a reference to the field itself as well as any parsed attributes declared on that field.
+///
+pub(crate) struct StructField<'a> {
+    pub field: &'a Field,
+    pub attrs: Vec<RustlerFieldAttr>,
+
+    /// `true` if we identified that this field is of type `Option`.
+    pub is_option_type: bool,
+}
+
+impl<'a> StructField<'a> {
+    pub fn optional_decode(&self) -> bool {
+        self.attrs
+            .iter()
+            .any(|attr| matches!(attr, RustlerFieldAttr::OptionalDecode))
+    }
+}
 
 ///
 /// A parsing context struct.
@@ -17,7 +38,7 @@ pub(crate) struct Context<'a> {
     pub lifetimes: Vec<Lifetime>,
     pub type_parameters: Vec<TypeParam>,
     pub variants: Option<Vec<&'a Variant>>,
-    pub struct_fields: Option<Vec<&'a Field>>,
+    pub struct_fields: Option<Vec<StructField<'a>>>,
     pub is_tuple_struct: bool,
 }
 
@@ -43,7 +64,13 @@ impl<'a> Context<'a> {
         };
 
         let struct_fields = match ast.data {
-            Data::Struct(ref data_struct) => Some(data_struct.fields.iter().collect()),
+            Data::Struct(ref data_struct) => Some(
+                data_struct
+                    .fields
+                    .iter()
+                    .map(Self::struct_field_with_parsed_attrs)
+                    .collect(),
+            ),
             _ => None,
         };
 
@@ -104,14 +131,20 @@ impl<'a> Context<'a> {
             .any(|attr| matches!(attr, RustlerAttr::Decode))
     }
 
+    pub fn optional_decode(&self) -> bool {
+        self.attrs
+            .iter()
+            .any(|attr| matches!(attr, RustlerAttr::OptionalDecode))
+    }
+
     pub fn field_atoms(&self) -> Option<Vec<TokenStream>> {
         self.struct_fields.as_ref().map(|struct_fields| {
             struct_fields
                 .iter()
                 .map(|field| {
-                    let atom_fun = Self::field_to_atom_fun(field);
+                    let atom_fun = Self::field_to_atom_fun(field.field);
 
-                    let ident = field.ident.as_ref().unwrap();
+                    let ident = field.field.ident.as_ref().unwrap();
                     let ident_str = ident.to_string();
                     let ident_str = Self::remove_raw(&ident_str);
 
@@ -133,6 +166,32 @@ impl<'a> Context<'a> {
         let ident_str = Self::remove_raw(&ident_str);
 
         Ident::new(&format!("atom_{ident_str}"), Span::call_site())
+    }
+
+    fn struct_field_with_parsed_attrs(field: &'a Field) -> StructField<'a> {
+        let attrs: Vec<_> = field
+            .attrs
+            .iter()
+            .flat_map(Self::get_rustler_field_attrs)
+            .collect();
+
+        StructField {
+            field,
+            attrs,
+            is_option_type: Self::is_option_type(&field.ty),
+        }
+    }
+
+    fn is_option_type(t: &Type) -> bool {
+        match t {
+            Type::Path(type_path) => {
+                // Has a chance of returning false negatives (in case Option was aliased to another name and the field uses the other name as the type) and false positives (if some other module has an `Option` type - we only check that the name is `Option`).
+                let type_name = type_path.path.segments.last().unwrap();
+                type_name.ident == "Option"
+            }
+            Type::Paren(p) => Self::is_option_type(&p.elem),
+            _ => false,
+        }
     }
 
     pub fn escape_ident_with_index(ident_str: &str, index: usize, infix: &str) -> Ident {
@@ -169,6 +228,10 @@ impl<'a> Context<'a> {
 
     fn get_rustler_attrs(attr: &syn::Attribute) -> Vec<RustlerAttr> {
         Self::parse_attr::<RustlerAttr>(attr)
+    }
+
+    fn get_rustler_field_attrs(attr: &syn::Attribute) -> Vec<RustlerFieldAttr> {
+        Self::parse_attr::<RustlerFieldAttr>(attr)
     }
 
     fn parse_attr<T: TryFromRustlerNestedAttr>(attr: &syn::Attribute) -> Vec<T> {

--- a/rustler_codegen/src/ex_struct.rs
+++ b/rustler_codegen/src/ex_struct.rs
@@ -1,10 +1,11 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 
-use syn::{self, spanned::Spanned, Field, Ident};
+use syn::{self, spanned::Spanned, Ident};
 
 use super::context::Context;
-use super::RustlerAttr;
+use crate::attrs::RustlerAttr;
+use crate::context::StructField;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput, add_exception: bool) -> TokenStream {
     let ctx = Context::from_ast(ast);
@@ -65,13 +66,13 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput, add_exception: bool) -> Toke
     gen
 }
 
-fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
+fn gen_decoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     let struct_name = ctx.ident;
     let struct_name_str = struct_name.to_string();
 
     let idents: Vec<_> = fields
         .iter()
-        .map(|field| field.ident.as_ref().unwrap())
+        .map(|field| field.field.ident.as_ref().unwrap())
         .collect();
 
     let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = fields
@@ -79,10 +80,10 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .zip(idents.iter())
         .enumerate()
         .map(|(index, (field, ident))| {
-            let atom_fun = Context::field_to_atom_fun(field);
+            let atom_fun = Context::field_to_atom_fun(field.field);
             let variable = Context::escape_ident_with_index(&ident.to_string(), index, "struct");
 
-            let assignment = quote_spanned! { field.span() =>
+            let assignment = quote_spanned! { field.field.span() =>
                 let #variable = try_decode_field(term, #atom_fun())?;
             };
 
@@ -131,7 +132,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 
 fn gen_encoder(
     ctx: &Context,
-    fields: &[&Field],
+    fields: &[StructField],
     atoms_module_name: &Ident,
     add_exception: bool,
 ) -> TokenStream {
@@ -144,8 +145,8 @@ fn gen_encoder(
     let (mut data_keys, mut data_values): (Vec<_>, Vec<_>) = fields
         .iter()
         .map(|field| {
-            let field_ident = field.ident.as_ref().unwrap();
-            let atom_fun = Context::field_to_atom_fun(field);
+            let field_ident = field.field.ident.as_ref().unwrap();
+            let atom_fun = Context::field_to_atom_fun(field.field);
             (
                 quote! { ::rustler::Encoder::encode(&#atom_fun(), env) },
                 quote! { ::rustler::Encoder::encode(&self.#field_ident, env) },

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -185,6 +185,76 @@ pub fn nif_exception(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// And vice versa, decoding this map would result in `value`.
+///
+/// By default, any fields with type `Option` need to be present in the map, otherwise decoding will fail:
+///
+/// ```ignore
+/// #[derive(NifMap)]
+/// struct MapWithOption {
+///     x: i32,
+///     y: Option<i32>,
+///     z: Option<i32>,
+/// }
+/// ```
+///
+/// ```elixir
+/// # Both of these will successfully decode into MapWithOption:
+/// %{x: 1, y: 2, z: 3}
+/// %{x: 1, y: nil, z: 3}
+/// # These will not:
+/// %{x: 1}
+/// %{x: 1, y: 2}
+/// %{x: 1, y: nil}
+/// %{x: 1, z: 3}
+/// %{x: 1, z: nil}
+/// ```
+///
+/// If you wish to treat missing keys in an Elixir map as `None` in the struct, use the `#[rustler(optional_decode)]` attribute:
+///
+/// ```ignore
+/// #[derive(NifMap)]
+/// #[rustler(optional_decode)] // Allows any fields with type Option to be missing in the map.
+/// struct MapWithOption {
+///     x: i32,
+///     y: Option<i32>,
+///     z: Option<i32>,
+/// }
+/// ```
+///
+/// ```elixir
+/// # All of these will successfully decode into MapWithOption:
+/// %{x: 1, y: 2, z: 3}
+/// %{x: 1, y: nil, z: 3}
+/// %{x: 1}
+/// %{x: 1, y: 2}
+/// %{x: 1, y: nil}
+/// %{x: 1, z: 3}
+/// %{x: 1, z: nil}
+/// ```
+///
+/// `#[rustler(optional_decode)]` can also be applied only to specific fields:
+///
+/// ```ignore
+/// #[derive(NifMap)]
+/// struct MapWithOption {
+///     x: i32,
+///     #[rustler(optional_decode)]
+///     y: Option<i32>,
+///     z: Option<i32>,
+/// }
+/// ```
+///
+/// ```elixir
+/// # These will successfully decode into MapWithOption:
+/// %{x: 1, y: 2, z: 3}
+/// %{x: 1, y: nil, z: 3}
+/// %{x: 1, z: 3}
+/// %{x: 1, z: nil}
+/// # These will not:
+/// %{x: 1}
+/// %{x: 1, y: 2}
+/// %{x: 1, y: nil}
+/// ```
 #[proc_macro_derive(NifMap, attributes(rustler, optional_decode))]
 pub fn nif_map(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -185,7 +185,7 @@ pub fn nif_exception(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// And vice versa, decoding this map would result in `value`.
-#[proc_macro_derive(NifMap, attributes(rustler))]
+#[proc_macro_derive(NifMap, attributes(rustler, optional_decode))]
 pub fn nif_map(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     map::transcoder_decorator(&ast).into()

--- a/rustler_codegen/src/lib.rs
+++ b/rustler_codegen/src/lib.rs
@@ -2,6 +2,7 @@
 
 use proc_macro::TokenStream;
 
+pub(crate) mod attrs;
 mod context;
 mod encode_decode_templates;
 mod ex_struct;
@@ -14,14 +15,6 @@ mod tagged_enum;
 mod tuple;
 mod unit_enum;
 mod untagged_enum;
-
-#[derive(Debug)]
-enum RustlerAttr {
-    Encode,
-    Decode,
-    Module(String),
-    Tag(String),
-}
 
 /// Initialise the Native Implemented Function (NIF) environment
 /// and register NIF functions in an Elixir module.

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -1,7 +1,9 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 
-use syn::{self, spanned::Spanned, Field, Ident};
+use syn::{self, spanned::Spanned, Ident};
+
+use crate::context::StructField;
 
 use super::context::Context;
 
@@ -50,12 +52,12 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
+fn gen_decoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     let struct_name = ctx.ident;
 
     let idents: Vec<_> = fields
         .iter()
-        .map(|field| field.ident.as_ref().unwrap())
+        .map(|field| field.field.ident.as_ref().unwrap())
         .collect();
 
     let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = fields
@@ -63,10 +65,10 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .zip(idents.iter())
         .enumerate()
         .map(|(index, (field, ident))| {
-            let atom_fun = Context::field_to_atom_fun(field);
+            let atom_fun = Context::field_to_atom_fun(field.field);
             let variable = Context::escape_ident_with_index(&ident.to_string(), index, "map");
 
-            let assignment = quote_spanned! { field.span() =>
+            let assignment = quote_spanned! { field.field.span() =>
             let #variable = try_decode_field(term, #atom_fun())?;
             };
 
@@ -106,12 +108,12 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
     )
 }
 
-fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
+fn gen_encoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     let (keys, values): (Vec<_>, Vec<_>) = fields
         .iter()
         .map(|field| {
-            let field_ident = field.ident.as_ref().unwrap();
-            let atom_fun = Context::field_to_atom_fun(field);
+            let field_ident = field.field.ident.as_ref().unwrap();
+            let atom_fun = Context::field_to_atom_fun(field.field);
             (
                 quote! { ::rustler::Encoder::encode(&#atom_fun(), env) },
                 quote! { ::rustler::Encoder::encode(&self.#field_ident, env) },

--- a/rustler_codegen/src/map.rs
+++ b/rustler_codegen/src/map.rs
@@ -55,21 +55,25 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
 fn gen_decoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     let struct_name = ctx.ident;
 
-    let idents: Vec<_> = fields
-        .iter()
-        .map(|field| field.field.ident.as_ref().unwrap())
-        .collect();
-
+    let has_global_optional = ctx.optional_decode();
     let (assignments, field_defs): (Vec<TokenStream>, Vec<TokenStream>) = fields
         .iter()
-        .zip(idents.iter())
         .enumerate()
-        .map(|(index, (field, ident))| {
+        .map(|(index, field)| {
+            let ident = field.field.ident.as_ref().unwrap();
+            let is_optional = has_global_optional || field.optional_decode();
+
             let atom_fun = Context::field_to_atom_fun(field.field);
             let variable = Context::escape_ident_with_index(&ident.to_string(), index, "map");
 
-            let assignment = quote_spanned! { field.field.span() =>
-            let #variable = try_decode_field(term, #atom_fun())?;
+            let assignment = if field.is_option_type {
+                quote_spanned! { field.field.span() =>
+                let #variable = try_decode_field_optional(term, #atom_fun(), #is_optional)?;
+                }
+            } else {
+                quote_spanned! { field.field.span() =>
+                let #variable = try_decode_field(term, #atom_fun())?;
+                }
             };
 
             let field_def = quote! {
@@ -84,22 +88,38 @@ fn gen_decoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident)
         quote! {
             use #atoms_module_name::*;
 
+            fn try_decode_field_optional<'a, T>(
+                term: ::rustler::Term<'a>,
+                field: ::rustler::Atom,
+                is_optional: bool,
+            ) -> ::rustler::NifResult<Option<T>>
+            where
+                T: ::rustler::Decoder<'a>,
+            {
+                let field_is_missing = term.map_get(&field).is_err();
+                if is_optional && field_is_missing {
+                    Ok(None)
+                } else {
+                    try_decode_field(term, field)
+                }
+            }
+
             fn try_decode_field<'a, T>(
-                term: rustler::Term<'a>,
-                field: rustler::Atom,
-                ) -> ::rustler::NifResult<T>
-                where
-                    T: rustler::Decoder<'a>,
-                {
-                    use rustler::Encoder;
-                    match ::rustler::Decoder::decode(term.map_get(&field)?) {
-                        Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(format!(
-                                        "Could not decode field :{:?} on %{{}}",
-                                        field
-                        )))),
-                        Ok(value) => Ok(value),
-                    }
-                };
+                term: ::rustler::Term<'a>,
+                field: ::rustler::Atom,
+            ) -> ::rustler::NifResult<T>
+            where
+                T: ::rustler::Decoder<'a>,
+            {
+                use rustler::Encoder;
+                match ::rustler::Decoder::decode(term.map_get(&field)?) {
+                    Err(_) => Err(::rustler::Error::RaiseTerm(Box::new(format!(
+                        "Could not decode field :{:?} on %{{}}",
+                        field
+                    )))),
+                    Ok(value) => Ok(value),
+                }
+            }
 
             #(#assignments);*
 

--- a/rustler_codegen/src/record.rs
+++ b/rustler_codegen/src/record.rs
@@ -1,10 +1,11 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
 
-use syn::{self, spanned::Spanned, Field, Ident, Index};
+use syn::{self, spanned::Spanned, Ident, Index};
 
 use super::context::Context;
-use super::RustlerAttr;
+use crate::attrs::RustlerAttr;
+use crate::context::StructField;
 
 pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     let ctx = Context::from_ast(ast);
@@ -49,7 +50,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
+fn gen_decoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     let struct_name = ctx.ident;
 
     // Make a decoder for each of the fields in the struct.
@@ -57,7 +58,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
         .iter()
         .enumerate()
         .map(|(index, field)| {
-            let ident = field.ident.as_ref();
+            let ident = field.field.ident.as_ref();
             let pos_in_struct = if let Some(ident) = ident {
                 ident.to_string()
             } else {
@@ -67,7 +68,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
 
             let variable = Context::escape_ident(&pos_in_struct, "record");
 
-            let assignment = quote_spanned! { field.span() =>
+            let assignment = quote_spanned! { field.field.span() =>
                 let #variable = try_decode_index(&terms, #pos_in_struct, #actual_index)?;
             };
 
@@ -135,19 +136,19 @@ fn gen_decoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> T
     )
 }
 
-fn gen_encoder(ctx: &Context, fields: &[&Field], atoms_module_name: &Ident) -> TokenStream {
+fn gen_encoder(ctx: &Context, fields: &[StructField], atoms_module_name: &Ident) -> TokenStream {
     // Make a field encoder expression for each of the items in the struct.
     let field_encoders: Vec<TokenStream> = fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
             let literal_index = Index::from(index);
-            let field_source = match field.ident.as_ref() {
+            let field_source = match field.field.ident.as_ref() {
                 None => quote! { self.#literal_index },
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote_spanned! { field.span() => ::rustler::Encoder::encode(&#field_source, env) }
+            quote_spanned! { field.field.span() => ::rustler::Encoder::encode(&#field_source, env) }
         })
         .collect();
 

--- a/rustler_codegen/src/tuple.rs
+++ b/rustler_codegen/src/tuple.rs
@@ -1,7 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 
-use syn::{self, spanned::Spanned, Field, Index};
+use syn::{self, spanned::Spanned, Index};
+
+use crate::context::StructField;
 
 use super::context::Context;
 
@@ -33,7 +35,7 @@ pub fn transcoder_decorator(ast: &syn::DeriveInput) -> TokenStream {
     gen
 }
 
-fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
+fn gen_decoder(ctx: &Context, fields: &[StructField]) -> TokenStream {
     let struct_name = ctx.ident;
     let struct_name_str = struct_name.to_string();
 
@@ -42,7 +44,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
         .iter()
         .enumerate()
         .map(|(index, field)| {
-            let ident = field.ident.as_ref();
+            let ident = field.field.ident.as_ref();
             let pos_in_struct = if let Some(ident) = ident {
                 ident.to_string()
             } else {
@@ -51,7 +53,7 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
 
             let variable = Context::escape_ident(&pos_in_struct, "struct");
 
-            let assignment = quote_spanned! { field.span() =>
+            let assignment = quote_spanned! { field.field.span() =>
                 let #variable = try_decode_index(&terms, #pos_in_struct, #index)?;
             };
 
@@ -105,19 +107,19 @@ fn gen_decoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
     )
 }
 
-fn gen_encoder(ctx: &Context, fields: &[&Field]) -> TokenStream {
+fn gen_encoder(ctx: &Context, fields: &[StructField]) -> TokenStream {
     // Make a field encoder expression for each of the items in the struct.
     let field_encoders: Vec<TokenStream> = fields
         .iter()
         .enumerate()
         .map(|(index, field)| {
             let literal_index = Index::from(index);
-            let field_source = match field.ident.as_ref() {
+            let field_source = match field.field.ident.as_ref() {
                 None => quote! { self.#literal_index },
                 Some(ident) => quote! { self.#ident },
             };
 
-            quote_spanned! { field.span() => ::rustler::Encoder::encode(&#field_source, env) }
+            quote_spanned! { field.field.span() => ::rustler::Encoder::encode(&#field_source, env) }
         })
         .collect();
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -115,6 +115,8 @@ defmodule RustlerTest do
   def tuple_echo(_), do: err()
   def record_echo(_), do: err()
   def map_echo(_), do: err()
+  def map_with_optional_echo(_), do: err()
+  def map_with_optional_field_echo(_), do: err()
   def exception_echo(_), do: err()
   def struct_echo(_), do: err()
   def unit_enum_echo(_), do: err()

--- a/rustler_tests/native/rustler_compile_tests/src/lib.rs
+++ b/rustler_tests/native/rustler_compile_tests/src/lib.rs
@@ -38,4 +38,19 @@ pub mod lifetimes {
         pub i: Binary<'a>,
         pub j: Binary<'b>,
     }
+
+    #[derive(NifMap)]
+    #[rustler(optional_decode)]
+    pub struct GenericMapWithOptional<'a, 'b> {
+        pub i: Binary<'a>,
+        pub j: Binary<'b>,
+    }
+
+    #[derive(NifMap)]
+    pub struct GenericMapWithOptionalField<'a, 'b> {
+        #[rustler(optional_decode)]
+        pub i: Option<Binary<'a>>,
+        pub j: Binary<'b>,
+        pub k: Option<Binary<'a>>,
+    }
 }

--- a/rustler_tests/native/rustler_test/src/test_codegen.rs
+++ b/rustler_tests/native/rustler_test/src/test_codegen.rs
@@ -54,6 +54,31 @@ pub fn map_echo(map: AddMap) -> AddMap {
     map
 }
 
+#[derive(NifMap)]
+#[rustler(optional_decode)]
+pub struct MapWithOptional {
+    x: i32,
+    y: Option<i32>,
+}
+
+#[rustler::nif]
+pub fn map_with_optional_echo(map: MapWithOptional) -> MapWithOptional {
+    map
+}
+
+#[derive(NifMap)]
+pub struct MapWithOptionalField {
+    x: i32,
+    #[rustler(optional_decode)]
+    y: Option<i32>,
+    z: Option<i32>,
+}
+
+#[rustler::nif]
+pub fn map_with_optional_field_echo(map: MapWithOptionalField) -> MapWithOptionalField {
+    map
+}
+
 #[derive(Debug, NifStruct)]
 #[must_use] // Added to test Issue #152
 #[module = "AddStruct"]

--- a/rustler_tests/test/codegen_test.exs
+++ b/rustler_tests/test/codegen_test.exs
@@ -45,11 +45,42 @@ defmodule RustlerTest.CodegenTest do
       assert value == RustlerTest.map_echo(value)
     end
 
+    test "transcoder 2" do
+      value = %{x: 1, y: 2}
+      assert value == RustlerTest.map_with_optional_echo(value)
+
+      value = %{x: 1}
+      expected_value = %{x: 1, y: nil}
+      assert expected_value == RustlerTest.map_with_optional_echo(value)
+    end
+
+    test "transcoder 3" do
+      value = %{x: 1, y: 2, z: nil}
+      assert value == RustlerTest.map_with_optional_field_echo(value)
+      value = %{x: 1, y: 2, z: 3}
+      assert value == RustlerTest.map_with_optional_field_echo(value)
+
+      value = %{x: 1, z: nil}
+      expected_value = %{x: 1, y: nil, z: nil}
+      assert expected_value == RustlerTest.map_with_optional_field_echo(value)
+      value = %{x: 1, z: 3}
+      expected_value = %{x: 1, y: nil, z: 3}
+      assert expected_value == RustlerTest.map_with_optional_field_echo(value)
+    end
+
     test "with invalid map" do
       value = %{lhs: "invalid", rhs: 2, loc: {57, 15}}
 
       assert_raise ErlangError, "Erlang error: \"Could not decode field :lhs on %{}\"", fn ->
         assert value == RustlerTest.map_echo(value)
+      end
+    end
+
+    test "with invalid map with optional field" do
+      value = %{x: 1}
+
+      assert_raise ArgumentError, fn ->
+        assert value == RustlerTest.map_with_optional_field_echo(value)
       end
     end
   end


### PR DESCRIPTION
Closes #745.

This PR currently only implements the behaviour for `NifMap`, but it could in theory support `NifStruct` as well, although the utility of that is way lower, since elixir structs will always have the fields - but in Rust they could map to a struct with more fields that will always become `None`.

It also only implements the decoding behaviour, but encoding could be done similarly: if the option is `None`, don't add that key to the elixir map. I could implement that for completeness.

The PR has 3 commits, it might be easier to review commit by commit to understand the changes faster.
The implementation is not ideal (e.g. the way I check whether a type is `Option` has false negatives and false positives, as explained in the comments), but given the alternative (explained later) and how the rest of the code behaves, I decided this was a good approach to take.

Instead of checking if the type of a field is `Option`, we could've done the entire implementation at runtime: when the elixir map doesn't have the field we're looking for, delegate the return value to a trait. This trait would return `Ok(None)` for `Option<T>` types, and and `Err(_)` value for all other types. However, this would require some sort of extra trait to gate the implementation specifically for `Option<T>`, because we can't just have an implementation for `T` and `Option<T>`. My idea here would be to add an extra "marker" trait for each type that implements `rustler::Decoder` except for `Option<T>`. This would be a lot of overhead compared to just checking the type at procgen time, so I opted for that approach instead.