### PR TITLE
Fix Windows callback-table order for enif_set/is_pid_undefined

### DIFF
--- a/rustler/build.rs
+++ b/rustler/build.rs
@@ -805,8 +805,8 @@ fn build_api(b: &mut dyn ApiBuilder, opts: &GenerateOptions) {
             "enif_make_monitor_term",
             "env: *mut ErlNifEnv, mon: *const ErlNifMonitor",
         );
-        b.func("c_int", "enif_is_pid_undefined", "pid: *const ErlNifPid");
         b.func("", "enif_set_pid_undefined", "pid: *mut ErlNifPid");
+        b.func("c_int", "enif_is_pid_undefined", "pid: *const ErlNifPid");
         b.func(
             "ErlNifTermType",
             "enif_term_type",


### PR DESCRIPTION
On Windows the BEAM passes its `enif_*` function pointers as the `TWinDynNifCallbacks` struct, whose fields are read **by offset**, so the order the functions are declared in `build.rs` must match the declaration order in OTP's `erl_nif_api_funcs.h`.

The slots for `enif_set_pid_undefined` and `enif_is_pid_undefined` are currently transposed relative to the header, so on Windows a call to one dispatches to the other. Both are NIF 2.15 (OTP 22) functions, so this affects every supported NIF version.

Unix is unaffected because symbols are resolved by name via `dlsym` rather than by table offset.

The signatures are unchanged — only the order of the two `b.func` calls is swapped to match the header. I diffed the full 180-entry table against `erl_nif_api_funcs.h` and this pair was the only divergence.