### PR TITLE
Add hashing for LocalPid

### DIFF
--- a/rustler/src/types/local_pid.rs
+++ b/rustler/src/types/local_pid.rs
@@ -2,6 +2,7 @@ use crate::sys::{enif_compare_pids, enif_is_process_alive, enif_self};
 use crate::wrapper::{pid, ErlNifPid};
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::mem::MaybeUninit;
 
 #[derive(Copy, Clone)]
@@ -86,5 +87,13 @@ impl Env<'_> {
     pub fn is_process_alive(self, pid: LocalPid) -> bool {
         let res = unsafe { enif_is_process_alive(self.as_c_arg(), pid.as_c_arg()) };
         res != 0
+    }
+}
+
+impl Hash for LocalPid {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        use crate::sys::{enif_hash, ErlNifHash};
+        let hash = unsafe { enif_hash(ErlNifHash::ERL_NIF_INTERNAL_HASH, self.as_c_arg().pid, 0) };
+        state.write_u64(hash);
     }
 }

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -39,6 +39,7 @@ defmodule RustlerTest do
 
   def compare_local_pids(_, _), do: err()
   def are_equal_local_pids(_, _), do: err()
+  def pid_hash(_), do: err()
 
   def term_debug(_), do: err()
 

--- a/rustler_tests/native/rustler_test/src/test_local_pid.rs
+++ b/rustler_tests/native/rustler_test/src/test_local_pid.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use rustler::LocalPid;
 
@@ -14,4 +15,13 @@ pub fn compare_local_pids(lhs: LocalPid, rhs: LocalPid) -> i32 {
 #[rustler::nif]
 pub fn are_equal_local_pids(lhs: LocalPid, rhs: LocalPid) -> bool {
     lhs == rhs
+}
+
+#[rustler::nif]
+pub fn pid_hash(pid: LocalPid) -> u64 {
+    let mut s = DefaultHasher::new();
+
+    pid.hash(&mut s);
+
+    return s.finish();
 }

--- a/rustler_tests/test/local_pid_test.exs
+++ b/rustler_tests/test/local_pid_test.exs
@@ -32,4 +32,10 @@ defmodule RustlerTest.LocalPidTest do
       assert RustlerTest.are_equal_local_pids(lhs, rhs) == expected
     end
   end
+
+  test "local pid hash" do
+    pid = make_pid()
+
+    assert is_number(RustlerTest.pid_hash(pid))
+  end
 end


### PR DESCRIPTION
Use `ERL_NIF_INTERNAL_HASH` to generate a hash in a similar fashion as we do for `Atom`.

Fix #755