### PR TITLE
Implement `From<&[u8]>` for binary

### DIFF
--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -262,6 +262,17 @@ impl FromIterator<u8> for OwnedBinary {
     }
 }
 
+impl<T: AsRef<[u8]>> From<T> for OwnedBinary {
+    fn from(data: T) -> Self {
+        let buf = data.as_ref();
+        let mut bin = Self::new(buf.len()).expect("Allocation failed");
+
+        bin.as_mut_slice().copy_from_slice(buf);
+
+        bin
+    }
+}
+
 /// An immutable smart-pointer to an Erlang binary.
 ///
 /// See [module-level doc](index.html) for more information.

--- a/rustler/src/types/binary.rs
+++ b/rustler/src/types/binary.rs
@@ -135,6 +135,14 @@ impl OwnedBinary {
         })
     }
 
+    /// Copies 'data''s data into a new `OwnedBinary`.
+    pub fn from_slice(data: impl AsRef<[u8]>) -> Self {
+        let data = data.as_ref();
+        let mut bin = OwnedBinary::new(data.len()).expect("allocation failed");
+        bin.as_mut_slice().copy_from_slice(data);
+        bin
+    }
+
     /// Attempts to reallocate `self` with the new size.
     ///
     /// Memory outside the range of the original binary will not be initialized. If
@@ -264,12 +272,7 @@ impl FromIterator<u8> for OwnedBinary {
 
 impl<T: AsRef<[u8]>> From<T> for OwnedBinary {
     fn from(data: T) -> Self {
-        let buf = data.as_ref();
-        let mut bin = Self::new(buf.len()).expect("Allocation failed");
-
-        bin.as_mut_slice().copy_from_slice(buf);
-
-        bin
+        Self::from_slice(data)
     }
 }
 

--- a/rustler_tests/lib/rustler_test.ex
+++ b/rustler_tests/lib/rustler_test.ex
@@ -96,6 +96,14 @@ defmodule RustlerTest do
   def decode_iolist(_), do: err()
   def first_four_bytes_of_iolist(_), do: err()
 
+  def array_into_binary(), do: err()
+  def vec_into_binary(), do: err()
+  def slice_into_binary(), do: err()
+  def str_into_binary(), do: err()
+  def string_into_binary(), do: err()
+
+  def binary_from_str(), do: err()
+
   def atom_to_string(_), do: err()
   def atom_equals_ok(_), do: err()
   def binary_to_atom(_), do: err()

--- a/rustler_tests/native/rustler_test/src/test_binary.rs
+++ b/rustler_tests/native/rustler_test/src/test_binary.rs
@@ -96,3 +96,33 @@ pub fn first_four_bytes_of_iolist<'a>(term: Term<'a>) -> Binary<'a> {
     let sub = bin.make_subbinary(0, 4).unwrap();
     sub
 }
+
+#[rustler::nif]
+pub fn array_into_binary() -> OwnedBinary {
+    [1, 2, 3].into()
+}
+
+#[rustler::nif]
+pub fn vec_into_binary() -> OwnedBinary {
+    vec![1, 2, 3].into()
+}
+
+#[rustler::nif]
+pub fn slice_into_binary() -> OwnedBinary {
+    [1, 2, 3][..].into()
+}
+
+#[rustler::nif]
+pub fn str_into_binary() -> OwnedBinary {
+    "foobar".into()
+}
+
+#[rustler::nif]
+pub fn string_into_binary() -> OwnedBinary {
+    String::from("foobar").into()
+}
+
+#[rustler::nif]
+pub fn binary_from_str() -> OwnedBinary {
+    OwnedBinary::from("foobar")
+}

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -69,11 +69,11 @@ defmodule RustlerTest.BinaryTest do
     assert RustlerTest.array_into_binary() == <<1, 2, 3>>
     assert RustlerTest.vec_into_binary() == <<1, 2, 3>>
     assert RustlerTest.slice_into_binary() == <<1, 2, 3>>
-    assert RustlerTest.str_into_binary() == <<1, 2, 3>>
-    assert RustlerTest.string_into_binary() == <<1, 2, 3>>
+    assert RustlerTest.str_into_binary() == "foobar"
+    assert RustlerTest.string_into_binary() == "foobar"
   end
 
   test "trait From" do
-    assert RustlerTest.binary_from_str() == <<1, 2, 3>>
+    assert RustlerTest.binary_from_str() == "foobar"
   end
 end

--- a/rustler_tests/test/binary_test.exs
+++ b/rustler_tests/test/binary_test.exs
@@ -64,4 +64,16 @@ defmodule RustlerTest.BinaryTest do
     assert RustlerTest.first_four_bytes_of_iolist(["hi", " ", "there"]) == "hi t"
     assert RustlerTest.first_four_bytes_of_iolist([[?h, ?i], ~c" ", ["there"]]) == "hi t"
   end
+
+  test "trait Into" do
+    assert RustlerTest.array_into_binary() == <<1, 2, 3>>
+    assert RustlerTest.vec_into_binary() == <<1, 2, 3>>
+    assert RustlerTest.slice_into_binary() == <<1, 2, 3>>
+    assert RustlerTest.str_into_binary() == <<1, 2, 3>>
+    assert RustlerTest.string_into_binary() == <<1, 2, 3>>
+  end
+
+  test "trait From" do
+    assert RustlerTest.binary_from_str() == <<1, 2, 3>>
+  end
 end


### PR DESCRIPTION
This allows for simpler work with binaries that aren't UTF-8 encoded
strings. Currently there is either need to construct such data in place
(which limits usage of some Rust libraries) or you need to write
additional code to translate one form into another. This implementation
is simple and performant enough for this usecase.
