### PR TITLE
Change hash_internal to return u64

### DIFF
--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -102,15 +102,9 @@ impl<'a> Term<'a> {
     /// Non-portable hash function that only guarantees the same hash for the same term within
     /// one Erlang VM instance.
     ///
-    /// It takes 32-bit salt values and generates hashes within 0..2^32-1.
-    pub fn hash_internal(&self, salt: u32) -> u32 {
-        unsafe {
-            enif_hash(
-                ErlNifHash::ERL_NIF_INTERNAL_HASH,
-                self.as_c_arg(),
-                salt as u64,
-            ) as u32
-        }
+    /// It takes 64-bit salt values and generates hashes within 0..2^64-1 (0..2^32-1 before OTP 27).
+    pub fn hash_internal(&self, salt: u64) -> u64 {
+        unsafe { enif_hash(ErlNifHash::ERL_NIF_INTERNAL_HASH, self.as_c_arg(), salt) }
     }
 
     /// Portable hash function that gives the same hash for the same Erlang term regardless of
@@ -164,7 +158,7 @@ impl Hash for Term<'_> {
         // As far as I can see, there is really no way
         // to get a seed from the hasher. This is definitely
         // not optimal, but it's the best we can do for now.
-        state.write_u32(self.hash_internal(0));
+        state.write_u64(self.hash_internal(0));
     }
 }
 

--- a/rustler_tests/native/rustler_test/src/test_term.rs
+++ b/rustler_tests/native/rustler_test/src/test_term.rs
@@ -45,7 +45,7 @@ pub fn term_cmp<'a>(a: Term<'a>, b: Term<'a>) -> Atom {
 }
 
 #[rustler::nif]
-pub fn term_internal_hash(term: Term, salt: u32) -> u32 {
+pub fn term_internal_hash(term: Term, salt: u64) -> u64 {
     term.hash_internal(salt)
 }
 


### PR DESCRIPTION
[Commit ef0d257501 in erlang/otp](https://github.com/erlang/otp/commit/ef0d257501) changed `enif_hash()` to use `erts_internal_salted_hash()`, which returns a unsigned 64-bit integer, as well as accepting a 64-bit salt. This commit was released as part of OTP 27, and there was no NIF version bump, as the signature for `enif_hash` didn't actually change.

This PR changes the signature of hash_internal to reflect the reality that `enif_hash` produces values in 0..2^64-1. The [erl_nif documentation](https://github.com/erlang/otp/blob/master/erts/doc/references/erl_nif.md) is out of date.

I found this was needed when trying to hash Erlang terms in a NIF, and the chosen hash implementation (hashbrown) used the most significant 7 bits for a particular optimization, which were truncated before these changes.

Thank you all for Rustler. It was a pleasure writing my first Rust NIF <3