### PR TITLE
Add direct symbol references back

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+default:
+    @just --choose
+
 build:
     cargo build
     cd rustler_mix && mix deps.get && mix compile

--- a/rustler/Cargo.toml
+++ b/rustler/Cargo.toml
@@ -29,11 +29,9 @@ rustler_codegen = { path = "../rustler_codegen", version = "0.38.0"}
 num-bigint = { version = "0.5", optional = true }
 serde = { version = "1", optional = true }
 
-[target.'cfg(not(windows))'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 libloading = "0.9"
-# For RTLD_NOLOAD
 libc = "0.2"
-
 
 [package.metadata.release]
 

--- a/rustler/otp_headers/codegen/src/generator.rs
+++ b/rustler/otp_headers/codegen/src/generator.rs
@@ -1,17 +1,20 @@
 mod callbacks;
 mod direct;
 mod forwarders;
+mod variadic_macros;
 mod writer;
 
+use crate::generator::direct::DirectVariadicGettersApiBuilder;
 use crate::overrides::apply_api_signature_fixes;
 use crate::parser::{
     ApiArg, CBaseType, CParam, CPrimitiveType, CType, parse_api_declarations_source,
 };
 use callbacks::CallbacksApiBuilder;
-use direct::{DirectSymbolsApiBuilder, DirectVariadicApiBuilder};
+use direct::DirectSymbolsApiBuilder;
 use forwarders::ForwardersApiBuilder;
 use std::fmt::Write as _;
 use std::io::Write;
+use variadic_macros::VariadicApiBuilder;
 use writer::WriterBuilder;
 
 /// Which complete API implementation to emit: `Main` is the default,
@@ -43,9 +46,15 @@ trait ApiBuilder {
         DONE
     }
 
-    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res;
-    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res;
-    fn dummy(&mut self, name: &str) -> Res;
+    fn func(&mut self, _ret: &CType, _name: &str, _args: &[ApiArg]) -> Res {
+        DONE
+    }
+    fn variadic_func(&mut self, _ret: &CType, _name: &str, _args: &[ApiArg]) -> Res {
+        DONE
+    }
+    fn dummy(&mut self, _name: &str) -> Res {
+        DONE
+    }
 }
 
 fn render_arg_name(name: &str) -> String {
@@ -187,11 +196,13 @@ pub fn generate<W: Write>(out: &mut W, opts: &GenerateOptions) -> Res {
         Emit::Main => {
             build_api(&mut CallbacksApiBuilder(out), opts)?;
             build_api(&mut ForwardersApiBuilder(out), opts)?;
+            build_api(&mut VariadicApiBuilder(out), opts)?;
             build_api(&mut WriterBuilder(out), opts)?;
         }
         Emit::Direct => {
             build_api(&mut DirectSymbolsApiBuilder(out), opts)?;
-            build_api(&mut DirectVariadicApiBuilder(out), opts)?;
+            build_api(&mut DirectVariadicGettersApiBuilder(out), opts)?;
+            build_api(&mut VariadicApiBuilder(out), opts)?;
         }
     }
 

--- a/rustler/otp_headers/codegen/src/generator.rs
+++ b/rustler/otp_headers/codegen/src/generator.rs
@@ -1,13 +1,35 @@
+mod callbacks;
+mod direct;
+mod forwarders;
+mod writer;
+
 use crate::overrides::apply_api_signature_fixes;
 use crate::parser::{
     ApiArg, CBaseType, CParam, CPrimitiveType, CType, parse_api_declarations_source,
 };
+use callbacks::CallbacksApiBuilder;
+use direct::{DirectSymbolsApiBuilder, DirectVariadicApiBuilder};
+use forwarders::ForwardersApiBuilder;
 use std::fmt::Write as _;
 use std::io::Write;
+use writer::WriterBuilder;
+
+/// Which complete API implementation to emit: `Main` is the default,
+/// callback-table-based implementation (symbols filled in at runtime, e.g.
+/// via `dlsym`); `Direct` links directly against the real NIF API symbols
+/// under their original names. Both are self-contained (each includes the
+/// shared consts/macros/aliases), so `sys` can pick whichever one it needs
+/// via `cfg` with a single `include!` and no extra module wrapping.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Emit {
+    Main,
+    Direct,
+}
 
 pub struct GenerateOptions {
     pub declarations_source: String,
     pub ulong_size: usize,
+    pub emit: Emit,
 }
 
 type Res = std::io::Result<()>;
@@ -155,128 +177,23 @@ fn render_function_type(ret: &CType, params: &[CParam], variadic: bool, spaced: 
     out
 }
 
-struct CallbacksApiBuilder<'a, W: Write>(&'a mut W);
-impl<W: Write> ApiBuilder for CallbacksApiBuilder<'_, W> {
-    fn init(&mut self) -> Res {
-        writeln!(self.0, "#[allow(dead_code)]")?;
-        writeln!(self.0, "#[derive(Default, Copy, Clone)]")?;
-        writeln!(self.0, "pub struct DynNifCallbacks {{")
-    }
-
-    fn finish(&mut self) -> Res {
-        writeln!(self.0, "}}")
-    }
-
-    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        let args = render_type_args(args);
-        write!(self.0, "    {name}: Option<")?;
-        write_fn_type(self.0, &args, ret)?;
-        writeln!(self.0, ">,")
-    }
-
-    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        let args = render_type_args(args);
-        write!(self.0, "    {name}: Option<")?;
-        write_variadic_fn_type(self.0, &args, ret)?;
-        writeln!(self.0, ">,")
-    }
-    fn dummy(&mut self, name: &str) -> Res {
-        write!(self.0, "    {name}: Option<")?;
-        write_fn_type(
-            self.0,
-            "",
-            &CType::Base {
-                base: CBaseType::Primitive(CPrimitiveType::Void),
-                is_const: false,
-            },
-        )?;
-        writeln!(self.0, ">,")
-    }
-}
-
-struct ForwardersApiBuilder<'a, W: Write>(&'a mut W);
-impl<W: Write> ApiBuilder for ForwardersApiBuilder<'_, W> {
-    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        let args_sig = render_type_args(args);
-        let args_names = render_arg_names(args);
-
-        writeln!(
-            self.0,
-            "/// See [{name}](http://www.erlang.org/doc/man/erl_nif.html#{name}) in the Erlang docs."
-        )?;
-        writeln!(self.0, "#[inline]")?;
-        writeln!(self.0, "pub unsafe extern \"C\" fn {name}({args_sig})")?;
-        write_ret(self.0, ret)?;
-        writeln!(self.0, "{{")?;
-        writeln!(
-            self.0,
-            "    (DYN_NIF_CALLBACKS.{name}.unwrap_unchecked())({args_names})"
-        )?;
-        writeln!(self.0, "}}\n")
-    }
-
-    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        let args_sig = render_type_args(args);
-        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
-        )?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
-        )?;
-        writeln!(self.0, "}}\n")?;
-        writeln!(self.0, "pub use {name};\n")?;
-
-        write!(self.0, "pub unsafe fn get_{name}() -> ")?;
-        write_variadic_fn_type(self.0, &args_sig, ret)?;
-        writeln!(self.0, " {{")?;
-        writeln!(self.0, "    DYN_NIF_CALLBACKS.{name}.unwrap_unchecked()")?;
-        writeln!(self.0, "}}\n")
-    }
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
-    }
-}
-
-struct WriterBuilder<'a, W: Write>(&'a mut W);
-
-impl<W: Write> ApiBuilder for WriterBuilder<'_, W> {
-    fn init(&mut self) -> Res {
-        write!(
-            self.0,
-            "impl DynNifCallbacks {{\n    fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {{\n"
-        )
-    }
-
-    fn finish(&mut self) -> Res {
-        writeln!(self.0, "    }}\n}}")
-    }
-
-    fn func(&mut self, _ret: &CType, name: &str, _args: &[ApiArg]) -> Res {
-        writeln!(
-            self.0,
-            "        filler.write(&mut self.{name}, \"{name}\0\");"
-        )
-    }
-    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        self.func(ret, name, args)
-    }
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
-    }
-}
-
 pub fn generate<W: Write>(out: &mut W, opts: &GenerateOptions) -> Res {
     writeln!(
         out,
         "pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;"
     )?;
 
-    build_api(&mut CallbacksApiBuilder(out), opts)?;
-    build_api(&mut ForwardersApiBuilder(out), opts)?;
-    build_api(&mut WriterBuilder(out), opts)?;
+    match opts.emit {
+        Emit::Main => {
+            build_api(&mut CallbacksApiBuilder(out), opts)?;
+            build_api(&mut ForwardersApiBuilder(out), opts)?;
+            build_api(&mut WriterBuilder(out), opts)?;
+        }
+        Emit::Direct => {
+            build_api(&mut DirectSymbolsApiBuilder(out), opts)?;
+            build_api(&mut DirectVariadicApiBuilder(out), opts)?;
+        }
+    }
 
     if opts.ulong_size != 4 {
         write!(

--- a/rustler/otp_headers/codegen/src/generator/callbacks.rs
+++ b/rustler/otp_headers/codegen/src/generator/callbacks.rs
@@ -1,0 +1,44 @@
+use crate::parser::{ApiArg, CBaseType, CPrimitiveType, CType};
+use std::io::Write;
+
+use super::{ApiBuilder, Res, render_type_args, write_fn_type, write_variadic_fn_type};
+
+pub(super) struct CallbacksApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for CallbacksApiBuilder<'_, W> {
+    fn init(&mut self) -> Res {
+        writeln!(self.0, "#[allow(dead_code)]")?;
+        writeln!(self.0, "#[derive(Default, Copy, Clone)]")?;
+        writeln!(self.0, "pub struct DynNifCallbacks {{")
+    }
+
+    fn finish(&mut self) -> Res {
+        writeln!(self.0, "}}")
+    }
+
+    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args = render_type_args(args);
+        write!(self.0, "    {name}: Option<")?;
+        write_fn_type(self.0, &args, ret)?;
+        writeln!(self.0, ">,")
+    }
+
+    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args = render_type_args(args);
+        write!(self.0, "    {name}: Option<")?;
+        write_variadic_fn_type(self.0, &args, ret)?;
+        writeln!(self.0, ">,")
+    }
+    fn dummy(&mut self, name: &str) -> Res {
+        write!(self.0, "    {name}: Option<")?;
+        write_fn_type(
+            self.0,
+            "",
+            &CType::Base {
+                base: CBaseType::Primitive(CPrimitiveType::Void),
+                is_const: false,
+            },
+        )?;
+        writeln!(self.0, ">,")
+    }
+}

--- a/rustler/otp_headers/codegen/src/generator/callbacks.rs
+++ b/rustler/otp_headers/codegen/src/generator/callbacks.rs
@@ -1,7 +1,9 @@
-use crate::parser::{ApiArg, CBaseType, CPrimitiveType, CType};
 use std::io::Write;
 
-use super::{ApiBuilder, Res, render_type_args, write_fn_type, write_variadic_fn_type};
+use super::{
+    ApiArg, ApiBuilder, CBaseType, CPrimitiveType, CType, Res, render_type_args, write_fn_type,
+    write_variadic_fn_type,
+};
 
 pub(super) struct CallbacksApiBuilder<'a, W: Write>(pub(super) &'a mut W);
 

--- a/rustler/otp_headers/codegen/src/generator/callbacks.rs
+++ b/rustler/otp_headers/codegen/src/generator/callbacks.rs
@@ -8,6 +8,7 @@ pub(super) struct CallbacksApiBuilder<'a, W: Write>(pub(super) &'a mut W);
 impl<W: Write> ApiBuilder for CallbacksApiBuilder<'_, W> {
     fn init(&mut self) -> Res {
         writeln!(self.0, "#[allow(dead_code)]")?;
+        writeln!(self.0, "#[repr(C)]")?;
         writeln!(self.0, "#[derive(Default, Copy, Clone)]")?;
         writeln!(self.0, "pub struct DynNifCallbacks {{")
     }

--- a/rustler/otp_headers/codegen/src/generator/direct.rs
+++ b/rustler/otp_headers/codegen/src/generator/direct.rs
@@ -78,7 +78,7 @@ impl<W: Write> ApiBuilder for DirectVariadicApiBuilder<'_, W> {
         writeln!(self.0, "}}\n")?;
         writeln!(self.0, "pub use {name};\n")?;
 
-        write!(self.0, "pub unsafe fn get_{name}() -> ")?;
+        write!(self.0, "pub unsafe fn get_{name}() -> unsafe ")?;
         write_variadic_fn_type(self.0, &args_sig, ret)?;
         writeln!(self.0, " {{")?;
         writeln!(

--- a/rustler/otp_headers/codegen/src/generator/direct.rs
+++ b/rustler/otp_headers/codegen/src/generator/direct.rs
@@ -13,6 +13,7 @@ pub(super) struct DirectSymbolsApiBuilder<'a, W: Write>(pub(super) &'a mut W);
 impl<W: Write> ApiBuilder for DirectSymbolsApiBuilder<'_, W> {
     fn init(&mut self) -> Res {
         writeln!(self.0, "#[allow(dead_code)]")?;
+        writeln!(self.0, "#[repr(C)]")?;
         writeln!(self.0, "#[derive(Default, Copy, Clone)]")?;
         writeln!(self.0, "pub struct DynNifCallbacks {{}}")?;
         writeln!(

--- a/rustler/otp_headers/codegen/src/generator/direct.rs
+++ b/rustler/otp_headers/codegen/src/generator/direct.rs
@@ -1,0 +1,85 @@
+use crate::{
+    generator::DONE,
+    parser::{ApiArg, CType},
+};
+use std::io::Write;
+
+use super::{ApiBuilder, Res, render_type_args, write_ret, write_variadic_fn_type};
+
+/// Builds the `extern "C"` block declaring direct links against the real
+/// NIF API symbols, under their original names.
+pub(super) struct DirectSymbolsApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for DirectSymbolsApiBuilder<'_, W> {
+    fn init(&mut self) -> Res {
+        writeln!(self.0, "extern \"C\" {{")
+    }
+
+    fn finish(&mut self) -> Res {
+        writeln!(self.0, "}}\n")
+    }
+
+    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args = render_type_args(args);
+        write!(self.0, "    pub fn {name}({args})")?;
+        write_ret(self.0, ret)?;
+        writeln!(self.0, ";")
+    }
+
+    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args = render_type_args(args);
+        // Variadic functions also get a `{name}!` call macro (see
+        // `VariadicMacroApiBuilder`), which needs the bare `{name}` value
+        // namespace slot for its own `pub use {name};` self re-export.
+        // Declare this one under a different Rust identifier (keeping the
+        // real linked symbol name via `#[link_name]`) to avoid clashing.
+        writeln!(self.0, "    #[link_name = \"{name}\"]")?;
+        write!(self.0, "    fn __variadic_{name}({args}, ...)")?;
+        write_ret(self.0, ret)?;
+        writeln!(self.0, ";")
+    }
+
+    fn dummy(&mut self, _name: &str) -> Res {
+        DONE
+    }
+}
+
+/// Builds `get_{name}` accessors (outside of the `extern "C"` block) and
+/// call macros for variadic functions: a variadic C function pointer can't
+/// be named directly as a value, only called, so this wraps it in a plain
+/// function that returns its address.
+pub(super) struct DirectVariadicApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for DirectVariadicApiBuilder<'_, W> {
+    fn func(&mut self, _ret: &CType, _name: &str, _args: &[ApiArg]) -> Res {
+        DONE
+    }
+
+    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args_sig = render_type_args(args);
+        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
+        )?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
+        )?;
+        writeln!(self.0, "}}\n")?;
+        writeln!(self.0, "pub use {name};\n")?;
+
+        write!(self.0, "pub unsafe fn get_{name}() -> ")?;
+        write_variadic_fn_type(self.0, &args_sig, ret)?;
+        writeln!(self.0, " {{")?;
+        writeln!(
+            self.0,
+            "    std::mem::transmute(__variadic_{name} as *const ())"
+        )?;
+        writeln!(self.0, "}}\n")
+    }
+
+    fn dummy(&mut self, _name: &str) -> Res {
+        DONE
+    }
+}

--- a/rustler/otp_headers/codegen/src/generator/direct.rs
+++ b/rustler/otp_headers/codegen/src/generator/direct.rs
@@ -1,10 +1,6 @@
-use crate::{
-    generator::DONE,
-    parser::{ApiArg, CType},
-};
 use std::io::Write;
 
-use super::{ApiBuilder, Res, render_type_args, write_ret, write_variadic_fn_type};
+use super::{ApiArg, ApiBuilder, CType, Res, render_type_args, write_ret, write_variadic_fn_type};
 
 /// Builds the `extern "C"` block declaring direct links against the real
 /// NIF API symbols, under their original names.
@@ -47,48 +43,19 @@ impl<W: Write> ApiBuilder for DirectSymbolsApiBuilder<'_, W> {
         write_ret(self.0, ret)?;
         writeln!(self.0, ";")
     }
-
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
-    }
 }
 
-/// Builds `get_{name}` accessors (outside of the `extern "C"` block) and
-/// call macros for variadic functions: a variadic C function pointer can't
-/// be named directly as a value, only called, so this wraps it in a plain
-/// function that returns its address.
-pub(super) struct DirectVariadicApiBuilder<'a, W: Write>(pub(super) &'a mut W);
-
-impl<W: Write> ApiBuilder for DirectVariadicApiBuilder<'_, W> {
-    fn func(&mut self, _ret: &CType, _name: &str, _args: &[ApiArg]) -> Res {
-        DONE
-    }
-
+pub(super) struct DirectVariadicGettersApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+impl<W: Write> ApiBuilder for DirectVariadicGettersApiBuilder<'_, W> {
     fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
-        let args_sig = render_type_args(args);
-        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
-        )?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
-        )?;
-        writeln!(self.0, "}}\n")?;
-        writeln!(self.0, "pub use {name};\n")?;
-
+        let args = render_type_args(args);
         write!(self.0, "pub unsafe fn get_{name}() -> unsafe ")?;
-        write_variadic_fn_type(self.0, &args_sig, ret)?;
+        write_variadic_fn_type(self.0, &args, ret)?;
         writeln!(self.0, " {{")?;
         writeln!(
             self.0,
             "    std::mem::transmute(__variadic_{name} as *const ())"
         )?;
         writeln!(self.0, "}}\n")
-    }
-
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
     }
 }

--- a/rustler/otp_headers/codegen/src/generator/direct.rs
+++ b/rustler/otp_headers/codegen/src/generator/direct.rs
@@ -12,6 +12,14 @@ pub(super) struct DirectSymbolsApiBuilder<'a, W: Write>(pub(super) &'a mut W);
 
 impl<W: Write> ApiBuilder for DirectSymbolsApiBuilder<'_, W> {
     fn init(&mut self) -> Res {
+        writeln!(self.0, "#[allow(dead_code)]")?;
+        writeln!(self.0, "#[derive(Default, Copy, Clone)]")?;
+        writeln!(self.0, "pub struct DynNifCallbacks {{}}")?;
+        writeln!(
+            self.0,
+            "impl DynNifCallbacks {{ fn write_symbols(&mut self, _: impl DynNifFiller) {{}} }}"
+        )?;
+
         writeln!(self.0, "extern \"C\" {{")
     }
 

--- a/rustler/otp_headers/codegen/src/generator/forwarders.rs
+++ b/rustler/otp_headers/codegen/src/generator/forwarders.rs
@@ -1,0 +1,57 @@
+use crate::parser::{ApiArg, CType};
+use std::io::Write;
+
+use super::{
+    ApiBuilder, DONE, Res, render_arg_names, render_type_args, write_ret, write_variadic_fn_type,
+};
+
+/// Builds the callable forwarder functions used when the direct-symbols
+/// code path isn't selected: each one calls through `DYN_NIF_CALLBACKS`,
+/// which is filled in at runtime.
+pub(super) struct ForwardersApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for ForwardersApiBuilder<'_, W> {
+    fn func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args_sig = render_type_args(args);
+        let args_names = render_arg_names(args);
+
+        writeln!(
+            self.0,
+            "/// See [{name}](http://www.erlang.org/doc/man/erl_nif.html#{name}) in the Erlang docs."
+        )?;
+        writeln!(self.0, "#[inline]")?;
+        writeln!(self.0, "pub unsafe extern \"C\" fn {name}({args_sig})")?;
+        write_ret(self.0, ret)?;
+        writeln!(self.0, "{{")?;
+        writeln!(
+            self.0,
+            "    (DYN_NIF_CALLBACKS.{name}.unwrap_unchecked())({args_names})"
+        )?;
+        writeln!(self.0, "}}\n")
+    }
+
+    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        let args_sig = render_type_args(args);
+        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
+        )?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
+        )?;
+        writeln!(self.0, "}}\n")?;
+        writeln!(self.0, "pub use {name};\n")?;
+
+        write!(self.0, "pub unsafe fn get_{name}() -> ")?;
+        write_variadic_fn_type(self.0, &args_sig, ret)?;
+        writeln!(self.0, " {{")?;
+        writeln!(self.0, "    DYN_NIF_CALLBACKS.{name}.unwrap_unchecked()")?;
+        writeln!(self.0, "}}\n")
+    }
+
+    fn dummy(&mut self, _name: &str) -> Res {
+        DONE
+    }
+}

--- a/rustler/otp_headers/codegen/src/generator/forwarders.rs
+++ b/rustler/otp_headers/codegen/src/generator/forwarders.rs
@@ -1,8 +1,8 @@
-use crate::parser::{ApiArg, CType};
 use std::io::Write;
 
 use super::{
-    ApiBuilder, DONE, Res, render_arg_names, render_type_args, write_ret, write_variadic_fn_type,
+    ApiArg, ApiBuilder, CType, Res, render_arg_names, render_type_args, write_ret,
+    write_variadic_fn_type,
 };
 
 /// Builds the callable forwarder functions used when the direct-symbols
@@ -32,26 +32,11 @@ impl<W: Write> ApiBuilder for ForwardersApiBuilder<'_, W> {
 
     fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
         let args_sig = render_type_args(args);
-        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
-        )?;
-        writeln!(
-            self.0,
-            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
-        )?;
-        writeln!(self.0, "}}\n")?;
-        writeln!(self.0, "pub use {name};\n")?;
 
         write!(self.0, "pub unsafe fn get_{name}() -> ")?;
         write_variadic_fn_type(self.0, &args_sig, ret)?;
         writeln!(self.0, " {{")?;
         writeln!(self.0, "    DYN_NIF_CALLBACKS.{name}.unwrap_unchecked()")?;
         writeln!(self.0, "}}\n")
-    }
-
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
     }
 }

--- a/rustler/otp_headers/codegen/src/generator/variadic_macros.rs
+++ b/rustler/otp_headers/codegen/src/generator/variadic_macros.rs
@@ -1,0 +1,24 @@
+use std::io::Write;
+
+use super::{ApiArg, ApiBuilder, CType, Res};
+
+/// Builds call macros for variadic functions: a variadic C function pointer
+/// can't be named directly as a value, only called, so this wraps it in a plain
+/// function that returns its address.
+pub(super) struct VariadicApiBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for VariadicApiBuilder<'_, W> {
+    fn variadic_func(&mut self, _: &CType, name: &str, _: &[ApiArg]) -> Res {
+        writeln!(self.0, "#[macro_export] macro_rules! {name} {{")?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),* ) => {{ $crate::sys::get_{name}()($($arg),*) }};"
+        )?;
+        writeln!(
+            self.0,
+            "    ( $( $arg:expr ),+, ) => {{ {name}!($($arg),*) }};"
+        )?;
+        writeln!(self.0, "}}\n")?;
+        writeln!(self.0, "pub use {name};\n")
+    }
+}

--- a/rustler/otp_headers/codegen/src/generator/writer.rs
+++ b/rustler/otp_headers/codegen/src/generator/writer.rs
@@ -1,0 +1,35 @@
+use crate::parser::{ApiArg, CType};
+use std::io::Write;
+
+use super::{ApiBuilder, DONE, Res};
+
+/// Builds `DynNifCallbacks::write_symbols`, which fills in the callback
+/// table at runtime (e.g. via `dlsym`). Part of the `Main` emit, used only
+/// when the direct-symbols code path isn't selected (see `sys/functions.rs`).
+pub(super) struct WriterBuilder<'a, W: Write>(pub(super) &'a mut W);
+
+impl<W: Write> ApiBuilder for WriterBuilder<'_, W> {
+    fn init(&mut self) -> Res {
+        write!(
+            self.0,
+            "impl DynNifCallbacks {{\n    fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {{\n"
+        )
+    }
+
+    fn finish(&mut self) -> Res {
+        writeln!(self.0, "    }}\n}}")
+    }
+
+    fn func(&mut self, _ret: &CType, name: &str, _args: &[ApiArg]) -> Res {
+        writeln!(
+            self.0,
+            "        filler.write(&mut self.{name}, \"{name}\0\");"
+        )
+    }
+    fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
+        self.func(ret, name, args)
+    }
+    fn dummy(&mut self, _name: &str) -> Res {
+        DONE
+    }
+}

--- a/rustler/otp_headers/codegen/src/generator/writer.rs
+++ b/rustler/otp_headers/codegen/src/generator/writer.rs
@@ -1,7 +1,6 @@
-use crate::parser::{ApiArg, CType};
 use std::io::Write;
 
-use super::{ApiBuilder, DONE, Res};
+use super::{ApiArg, ApiBuilder, CType, Res};
 
 /// Builds `DynNifCallbacks::write_symbols`, which fills in the callback
 /// table at runtime (e.g. via `dlsym`). Part of the `Main` emit, used only
@@ -26,10 +25,8 @@ impl<W: Write> ApiBuilder for WriterBuilder<'_, W> {
             "        filler.write(&mut self.{name}, \"{name}\0\");"
         )
     }
+
     fn variadic_func(&mut self, ret: &CType, name: &str, args: &[ApiArg]) -> Res {
         self.func(ret, name, args)
-    }
-    fn dummy(&mut self, _name: &str) -> Res {
-        DONE
     }
 }

--- a/rustler/otp_headers/codegen/src/main.rs
+++ b/rustler/otp_headers/codegen/src/main.rs
@@ -2,7 +2,7 @@ mod generator;
 mod overrides;
 mod parser;
 
-use generator::{GenerateOptions, generate};
+use generator::{Emit, GenerateOptions, generate};
 use std::fs;
 use std::io::{self, Read};
 use std::path::Path;
@@ -15,16 +15,33 @@ fn parse_ulong_size_arg(value: &str) -> u8 {
     }
 }
 
+fn parse_emit_arg(value: &str) -> Emit {
+    match value {
+        "main" => Emit::Main,
+        "direct" => Emit::Direct,
+        _ => panic!("Invalid --emit value `{value}`; expected main or direct"),
+    }
+}
+
 fn main() {
     let args = std::env::args().skip(1);
     let mut header_path: Option<String> = None;
     let mut ulong_size: Option<u8> = None;
+    let mut emit: Option<Emit> = None;
 
     for arg in args {
         if let Some(value) = arg.strip_prefix("--ulong-size=") {
             let value = parse_ulong_size_arg(value);
             if ulong_size.replace(value).is_some() {
                 panic!("--ulong-size provided more than once");
+            }
+            continue;
+        }
+
+        if let Some(value) = arg.strip_prefix("--emit=") {
+            let value = parse_emit_arg(value);
+            if emit.replace(value).is_some() {
+                panic!("--emit provided more than once");
             }
             continue;
         }
@@ -51,10 +68,12 @@ fn main() {
     };
 
     let ulong_size = ulong_size.expect("Missing --ulong-size=<4|8>");
+    let emit = emit.unwrap_or(Emit::Main);
 
     let opts = GenerateOptions {
         declarations_source,
         ulong_size: ulong_size as usize,
+        emit,
     };
 
     let mut out = std::io::stdout();

--- a/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
@@ -149,7 +149,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -160,7 +160,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -171,7 +171,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -182,7 +182,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
@@ -1,0 +1,183 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_int64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int;
+    pub fn enif_get_uint64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int;
+    pub fn enif_make_int64(arg1: *mut ErlNifEnv, arg2: i64) -> ERL_NIF_TERM;
+    pub fn enif_make_uint64(arg1: *mut ErlNifEnv, arg2: u64) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+

--- a/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
@@ -142,16 +142,28 @@ extern "C" {
     pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -160,10 +172,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -171,18 +179,10 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 

--- a/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_14/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.rs
@@ -338,23 +338,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -394,13 +380,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -959,13 +938,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1102,6 +1074,34 @@ pub unsafe extern "C" fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *c
  -> c_int{
     (DYN_NIF_CALLBACKS.enif_make_map_from_arrays.unwrap_unchecked())(env, keys, values, cnt, map_out)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_14/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.4.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
@@ -1,0 +1,200 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+
+/// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_int64(env: *mut ErlNifEnv, i: i64) -> ERL_NIF_TERM
+    { enif_make_long(env, i) }
+
+/// See [enif_make_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_uint64(env: *mut ErlNifEnv, i: u64) -> ERL_NIF_TERM
+    { enif_make_ulong(env, i) }
+
+/// See [enif_get_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_int64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int
+    { enif_get_long(env, term, ip) }
+
+/// See [enif_get_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_uint64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int
+    { enif_get_ulong(env, term, ip) }
+        

--- a/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
@@ -138,16 +138,28 @@ extern "C" {
     pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -156,10 +168,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -167,20 +175,12 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 
 
 /// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org

--- a/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.direct.rs
@@ -145,7 +145,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -156,7 +156,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -167,7 +167,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -178,7 +178,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_14/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_14/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_14/api.8.rs
@@ -334,23 +334,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -390,13 +376,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -927,13 +906,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1070,6 +1042,34 @@ pub unsafe extern "C" fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *c
  -> c_int{
     (DYN_NIF_CALLBACKS.enif_make_map_from_arrays.unwrap_unchecked())(env, keys, values, cnt, map_out)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
@@ -154,7 +154,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -165,7 +165,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -176,7 +176,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -187,7 +187,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
@@ -1,0 +1,188 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_int64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int;
+    pub fn enif_get_uint64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int;
+    pub fn enif_make_int64(arg1: *mut ErlNifEnv, arg2: i64) -> ERL_NIF_TERM;
+    pub fn enif_make_uint64(arg1: *mut ErlNifEnv, arg2: u64) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+

--- a/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.direct.rs
@@ -147,16 +147,28 @@ extern "C" {
     pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -165,10 +177,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -176,18 +184,10 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 

--- a/rustler/otp_headers/nif_version_2_15/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_15/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.4.rs
@@ -343,23 +343,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -399,13 +385,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -964,13 +943,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1142,6 +1114,34 @@ pub unsafe extern "C" fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM)
  -> ErlNifTermType{
     (DYN_NIF_CALLBACKS.enif_term_type.unwrap_unchecked())(env, term)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
@@ -150,7 +150,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -161,7 +161,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -172,7 +172,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -183,7 +183,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
@@ -143,16 +143,28 @@ extern "C" {
     pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -161,10 +173,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -172,20 +180,12 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 
 
 /// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org

--- a/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.direct.rs
@@ -1,0 +1,205 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+
+/// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_int64(env: *mut ErlNifEnv, i: i64) -> ERL_NIF_TERM
+    { enif_make_long(env, i) }
+
+/// See [enif_make_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_uint64(env: *mut ErlNifEnv, i: u64) -> ERL_NIF_TERM
+    { enif_make_ulong(env, i) }
+
+/// See [enif_get_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_int64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int
+    { enif_get_long(env, term, ip) }
+
+/// See [enif_get_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_uint64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int
+    { enif_get_ulong(env, term, ip) }
+        

--- a/rustler/otp_headers/nif_version_2_15/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_15/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_15/api.8.rs
@@ -339,23 +339,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -395,13 +381,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -932,13 +911,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1110,6 +1082,34 @@ pub unsafe extern "C" fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM)
  -> ErlNifTermType{
     (DYN_NIF_CALLBACKS.enif_term_type.unwrap_unchecked())(env, term)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
@@ -1,0 +1,190 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_int64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int;
+    pub fn enif_get_uint64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int;
+    pub fn enif_make_int64(arg1: *mut ErlNifEnv, arg2: i64) -> ERL_NIF_TERM;
+    pub fn enif_make_uint64(arg1: *mut ErlNifEnv, arg2: u64) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+

--- a/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
@@ -149,16 +149,28 @@ extern "C" {
     pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -167,10 +179,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -178,18 +186,10 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 

--- a/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
@@ -156,7 +156,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -167,7 +167,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -178,7 +178,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -189,7 +189,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_16/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_16/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.4.rs
@@ -345,23 +345,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -401,13 +387,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -966,13 +945,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1158,6 +1130,34 @@ pub unsafe extern "C" fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: 
  -> c_int{
     (DYN_NIF_CALLBACKS.enif_dynamic_resource_call.unwrap_unchecked())(arg1, mod_, name, rsrc, call_data)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
@@ -1,0 +1,207 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+
+/// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_int64(env: *mut ErlNifEnv, i: i64) -> ERL_NIF_TERM
+    { enif_make_long(env, i) }
+
+/// See [enif_make_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_uint64(env: *mut ErlNifEnv, i: u64) -> ERL_NIF_TERM
+    { enif_make_ulong(env, i) }
+
+/// See [enif_get_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_int64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int
+    { enif_get_long(env, term, ip) }
+
+/// See [enif_get_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_uint64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int
+    { enif_get_ulong(env, term, ip) }
+        

--- a/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
@@ -145,16 +145,28 @@ extern "C" {
     pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -163,10 +175,6 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
@@ -174,20 +182,12 @@ pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv,
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
 }
 
 pub use enif_snprintf;
-
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
 
 
 /// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org

--- a/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.direct.rs
@@ -152,7 +152,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -163,7 +163,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -174,7 +174,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -185,7 +185,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_16/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_16/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_16/api.8.rs
@@ -341,23 +341,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -397,13 +383,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -934,13 +913,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1126,6 +1098,34 @@ pub unsafe extern "C" fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: 
  -> c_int{
     (DYN_NIF_CALLBACKS.enif_dynamic_resource_call.unwrap_unchecked())(arg1, mod_, name, rsrc, call_data)
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
@@ -161,7 +161,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -172,7 +172,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -183,7 +183,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -194,7 +194,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 
@@ -205,7 +205,7 @@ pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: s
 
 pub use enif_set_option;
 
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     std::mem::transmute(__variadic_enif_set_option as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
@@ -1,0 +1,206 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_int64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int;
+    pub fn enif_get_uint64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int;
+    pub fn enif_make_int64(arg1: *mut ErlNifEnv, arg2: i64) -> ERL_NIF_TERM;
+    pub fn enif_make_uint64(arg1: *mut ErlNifEnv, arg2: u64) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+    pub fn enif_get_string_length(env: *mut ErlNifEnv, list: ERL_NIF_TERM, len: *mut c_uint, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_set_option"]
+    fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
+
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+

--- a/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
@@ -154,16 +154,32 @@ extern "C" {
     fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -172,20 +188,12 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
 }
 
 pub use enif_fprintf;
-
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
 
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
@@ -194,18 +202,10 @@ pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, fo
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_set_option as *const ())
-}
 

--- a/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_17/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_17/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.4.rs
@@ -349,23 +349,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -405,13 +391,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -970,13 +949,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1184,16 +1156,44 @@ pub unsafe extern "C" fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *cons
     (DYN_NIF_CALLBACKS.enif_make_new_atom_len.unwrap_unchecked())(env, name, len, atom, encoding)
 }
 
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
-}
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
@@ -1,0 +1,223 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+    pub fn enif_get_string_length(env: *mut ErlNifEnv, list: ERL_NIF_TERM, len: *mut c_uint, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_set_option"]
+    fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
+
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
+
+/// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_int64(env: *mut ErlNifEnv, i: i64) -> ERL_NIF_TERM
+    { enif_make_long(env, i) }
+
+/// See [enif_make_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_uint64(env: *mut ErlNifEnv, i: u64) -> ERL_NIF_TERM
+    { enif_make_ulong(env, i) }
+
+/// See [enif_get_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_int64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int
+    { enif_get_long(env, term, ip) }
+
+/// See [enif_get_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_uint64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int
+    { enif_get_ulong(env, term, ip) }
+        

--- a/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
@@ -157,7 +157,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -168,7 +168,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -179,7 +179,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -190,7 +190,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 
@@ -201,7 +201,7 @@ pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: s
 
 pub use enif_set_option;
 
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     std::mem::transmute(__variadic_enif_set_option as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
@@ -150,16 +150,32 @@ extern "C" {
     fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -168,20 +184,12 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
 }
 
 pub use enif_fprintf;
-
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
 
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
@@ -190,20 +198,12 @@ pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, fo
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_set_option as *const ())
-}
 
 
 /// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org

--- a/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_17/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_17/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_17/api.8.rs
@@ -345,23 +345,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -401,13 +387,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -938,13 +917,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1152,16 +1124,44 @@ pub unsafe extern "C" fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *cons
     (DYN_NIF_CALLBACKS.enif_make_new_atom_len.unwrap_unchecked())(env, name, len, atom, encoding)
 }
 
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
-}
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
@@ -157,16 +157,32 @@ extern "C" {
     pub fn enif_max_atom_cache_index() -> c_uint;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -175,20 +191,12 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
 }
 
 pub use enif_fprintf;
-
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
 
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
@@ -197,18 +205,10 @@ pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, fo
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_set_option as *const ())
-}
 

--- a/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
@@ -164,7 +164,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -175,7 +175,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -186,7 +186,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -197,7 +197,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 
@@ -208,7 +208,7 @@ pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: s
 
 pub use enif_set_option;
 
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     std::mem::transmute(__variadic_enif_set_option as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
@@ -1,0 +1,209 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_int64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int;
+    pub fn enif_get_uint64(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int;
+    pub fn enif_make_int64(arg1: *mut ErlNifEnv, arg2: i64) -> ERL_NIF_TERM;
+    pub fn enif_make_uint64(arg1: *mut ErlNifEnv, arg2: u64) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+    pub fn enif_get_string_length(env: *mut ErlNifEnv, list: ERL_NIF_TERM, len: *mut c_uint, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_set_option"]
+    fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
+    pub fn enif_term_size(term: ERL_NIF_TERM) -> size_t;
+    pub fn enif_get_atom_cache_index(env: *mut ErlNifEnv, atom: ERL_NIF_TERM, index: *mut c_uint) -> c_int;
+    pub fn enif_max_atom_cache_index() -> c_uint;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
+
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+

--- a/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_18/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_18/api.4.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.4.rs
@@ -352,23 +352,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -408,13 +394,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -973,13 +952,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1187,13 +1159,6 @@ pub unsafe extern "C" fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *cons
     (DYN_NIF_CALLBACKS.enif_make_new_atom_len.unwrap_unchecked())(env, name, len, atom, encoding)
 }
 
-#[macro_export] macro_rules! enif_set_option {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
-}
-
-pub use enif_set_option;
-
 pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
 }
@@ -1218,6 +1183,41 @@ pub unsafe extern "C" fn enif_max_atom_cache_index()
  -> c_uint{
     (DYN_NIF_CALLBACKS.enif_max_atom_cache_index.unwrap_unchecked())()
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
@@ -153,16 +153,32 @@ extern "C" {
     pub fn enif_max_atom_cache_index() -> c_uint;
 }
 
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
 #[macro_export] macro_rules! enif_make_tuple {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
 }
 
 pub use enif_make_tuple;
-
-pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_tuple as *const ())
-}
 
 #[macro_export] macro_rules! enif_make_list {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
@@ -171,20 +187,12 @@ pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
-    std::mem::transmute(__variadic_enif_make_list as *const ())
-}
-
 #[macro_export] macro_rules! enif_fprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
 }
 
 pub use enif_fprintf;
-
-pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_fprintf as *const ())
-}
 
 #[macro_export] macro_rules! enif_snprintf {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
@@ -193,20 +201,12 @@ pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, fo
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_snprintf as *const ())
-}
-
 #[macro_export] macro_rules! enif_set_option {
     ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
     ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
 }
 
 pub use enif_set_option;
-
-pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
-    std::mem::transmute(__variadic_enif_set_option as *const ())
-}
 
 
 /// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org

--- a/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
@@ -1,0 +1,226 @@
+pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+extern "C" {
+    pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
+    pub fn enif_alloc(size: size_t) -> *mut c_void;
+    pub fn enif_free(ptr: *mut c_void);
+    pub fn enif_is_atom(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_ref(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_inspect_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_alloc_binary(size: size_t, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_realloc_binary(bin: *mut ErlNifBinary, size: size_t) -> c_int;
+    pub fn enif_release_binary(bin: *mut ErlNifBinary);
+    pub fn enif_get_int(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_int) -> c_int;
+    pub fn enif_get_ulong(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_ulong) -> c_int;
+    pub fn enif_get_double(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, dp: *mut c_double) -> c_int;
+    pub fn enif_get_list_cell(env: *mut ErlNifEnv, term: ERL_NIF_TERM, head: *mut ERL_NIF_TERM, tail: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_tuple(env: *mut ErlNifEnv, tpl: ERL_NIF_TERM, arity: *mut c_int, array: *mut *const ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_identical(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_compare(lhs: ERL_NIF_TERM, rhs: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_binary(env: *mut ErlNifEnv, bin: *mut ErlNifBinary) -> ERL_NIF_TERM;
+    pub fn enif_make_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_int(env: *mut ErlNifEnv, i: c_int) -> ERL_NIF_TERM;
+    pub fn enif_make_ulong(env: *mut ErlNifEnv, i: c_ulong) -> ERL_NIF_TERM;
+    pub fn enif_make_double(env: *mut ErlNifEnv, d: c_double) -> ERL_NIF_TERM;
+    pub fn enif_make_atom(env: *mut ErlNifEnv, name: *const c_char) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, arg4: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_make_tuple"]
+    fn __variadic_enif_make_tuple(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    #[link_name = "enif_make_list"]
+    fn __variadic_enif_make_list(env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM;
+    pub fn enif_make_list_cell(env: *mut ErlNifEnv, car: ERL_NIF_TERM, cdr: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_make_string(env: *mut ErlNifEnv, string: *const c_char, arg3: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_make_ref(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    pub fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size_t);
+    #[link_name = "enif_fprintf"]
+    fn __variadic_enif_fprintf(filep: *mut c_void, format: *const c_char, ...) -> c_int;
+    pub fn enif_inspect_iolist_as_binary(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_make_sub_binary(arg1: *mut ErlNifEnv, bin_term: ERL_NIF_TERM, pos: size_t, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_get_string(arg1: *mut ErlNifEnv, list: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_atom(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, buf: *mut c_char, len: c_uint, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_is_fun(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_pid(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_port(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_uint(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_uint) -> c_int;
+    pub fn enif_get_long(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut c_long) -> c_int;
+    pub fn enif_make_uint(arg1: *mut ErlNifEnv, i: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_long(arg1: *mut ErlNifEnv, i: c_long) -> ERL_NIF_TERM;
+    pub fn enif_make_tuple_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_make_list_from_array(arg1: *mut ErlNifEnv, arr: *const ERL_NIF_TERM, cnt: c_uint) -> ERL_NIF_TERM;
+    pub fn enif_is_empty_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type(arg1: *mut ErlNifEnv, module_str: *const c_char, name_str: *const c_char, dtor: Option<unsafe extern "C" fn (*mut ErlNifEnv, *mut c_void)>, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_alloc_resource(type_: *const ErlNifResourceType, size: size_t) -> *mut c_void;
+    pub fn enif_release_resource(obj: *const c_void);
+    pub fn enif_make_resource(arg1: *mut ErlNifEnv, obj: *const c_void) -> ERL_NIF_TERM;
+    pub fn enif_get_resource(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, type_: *const ErlNifResourceType, objp: *mut *const c_void) -> c_int;
+    pub fn enif_sizeof_resource(obj: *mut c_void) -> size_t;
+    pub fn enif_make_new_binary(arg1: *mut ErlNifEnv, size: size_t, termp: *mut ERL_NIF_TERM) -> *mut c_uchar;
+    pub fn enif_is_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_tuple(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_atom_length(arg1: *mut ErlNifEnv, atom: ERL_NIF_TERM, len: *mut c_uint, arg4: ErlNifCharEncoding) -> c_int;
+    pub fn enif_get_list_length(env: *mut ErlNifEnv, term: ERL_NIF_TERM, len: *mut c_uint) -> c_int;
+    pub fn enif_make_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t) -> ERL_NIF_TERM;
+    pub fn enif_make_existing_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, arg5: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_string_len(env: *mut ErlNifEnv, string: *const c_char, len: size_t, arg4: ErlNifCharEncoding) -> ERL_NIF_TERM;
+    pub fn enif_alloc_env() -> *mut ErlNifEnv;
+    pub fn enif_free_env(env: *mut ErlNifEnv);
+    pub fn enif_clear_env(env: *mut ErlNifEnv);
+    pub fn enif_send(env: *mut ErlNifEnv, to_pid: *const ErlNifPid, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_copy(dst_env: *mut ErlNifEnv, src_term: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_self(caller_env: *mut ErlNifEnv, pid: *mut ErlNifPid) -> *mut ErlNifPid;
+    pub fn enif_get_local_pid(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_keep_resource(obj: *const c_void);
+    pub fn enif_make_resource_binary(arg1: *mut ErlNifEnv, obj: *const c_void, data: *const c_void, size: size_t) -> ERL_NIF_TERM;
+    pub fn enif_is_exception(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_reverse_list(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM, list: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_is_number(arg1: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_dlopen(lib: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_dlsym(handle: *mut c_void, symbol: *const c_char, err_handler: Option<unsafe extern "C" fn (*mut c_void, *const c_char)>, err_arg: *mut c_void) -> *mut c_void;
+    pub fn enif_consume_timeslice(arg1: *mut ErlNifEnv, percent: c_int) -> c_int;
+    pub fn enif_is_map(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_size(env: *mut ErlNifEnv, term: ERL_NIF_TERM, size: *mut size_t) -> c_int;
+    pub fn enif_make_new_map(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_map_put(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_get_map_value(env: *mut ErlNifEnv, map: ERL_NIF_TERM, key: ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_update(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, value: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_remove(env: *mut ErlNifEnv, map_in: ERL_NIF_TERM, key: ERL_NIF_TERM, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_map_iterator_create(env: *mut ErlNifEnv, map: ERL_NIF_TERM, iter: *mut ErlNifMapIterator, entry: ErlNifMapIteratorEntry) -> c_int;
+    pub fn enif_map_iterator_destroy(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator);
+    pub fn enif_map_iterator_is_head(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_is_tail(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_next(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_prev(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator) -> c_int;
+    pub fn enif_map_iterator_get_pair(env: *mut ErlNifEnv, iter: *mut ErlNifMapIterator, key: *mut ERL_NIF_TERM, value: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_schedule_nif(arg1: *mut ErlNifEnv, arg2: *const c_char, arg3: c_int, arg4: unsafe extern "C" fn(*mut ErlNifEnv, c_int, *const ERL_NIF_TERM) -> ERL_NIF_TERM, arg5: c_int, arg6: *const ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_has_pending_exception(env: *mut ErlNifEnv, reason: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_raise_exception(env: *mut ErlNifEnv, reason: ERL_NIF_TERM) -> ERL_NIF_TERM;
+    pub fn enif_getenv(key: *const c_char, value: *mut c_char, value_size: *mut size_t) -> c_int;
+    pub fn enif_monotonic_time(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_time_offset(arg1: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_convert_time_unit(arg1: ErlNifTime, arg2: ErlNifTimeUnit, arg3: ErlNifTimeUnit) -> ErlNifTime;
+    pub fn enif_now_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_cpu_time(env: *mut ErlNifEnv) -> ERL_NIF_TERM;
+    pub fn enif_make_unique_integer(env: *mut ErlNifEnv, properties: ErlNifUniqueInteger) -> ERL_NIF_TERM;
+    pub fn enif_is_current_process_alive(env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_is_process_alive(env: *mut ErlNifEnv, pid: *const ErlNifPid) -> c_int;
+    pub fn enif_is_port_alive(env: *mut ErlNifEnv, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_get_local_port(env: *mut ErlNifEnv, arg2: ERL_NIF_TERM, port_id: *mut ErlNifPort) -> c_int;
+    pub fn enif_term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM, bin: *mut ErlNifBinary) -> c_int;
+    pub fn enif_binary_to_term(env: *mut ErlNifEnv, data: *const c_uchar, sz: size_t, term: *mut ERL_NIF_TERM, opts: c_uint) -> size_t;
+    pub fn enif_port_command(env: *mut ErlNifEnv, to_port: *const ErlNifPort, msg_env: *mut ErlNifEnv, msg: ERL_NIF_TERM) -> c_int;
+    pub fn enif_thread_type() -> c_int;
+    #[link_name = "enif_snprintf"]
+    fn __variadic_enif_snprintf(buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int;
+    pub fn enif_select(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, ref_: ERL_NIF_TERM) -> c_int;
+    pub fn enif_open_resource_type_x(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_monitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, arg3: *const ErlNifPid, monitor: *mut ErlNifMonitor) -> c_int;
+    pub fn enif_demonitor_process(arg1: *mut ErlNifEnv, obj: *const c_void, monitor: *const ErlNifMonitor) -> c_int;
+    pub fn enif_compare_monitors(arg1: *const ErlNifMonitor, arg2: *const ErlNifMonitor) -> c_int;
+    pub fn enif_hash(type_: ErlNifHash, term: ERL_NIF_TERM, salt: u64) -> u64;
+    pub fn enif_whereis_pid(env: *mut ErlNifEnv, name: ERL_NIF_TERM, pid: *mut ErlNifPid) -> c_int;
+    pub fn enif_whereis_port(env: *mut ErlNifEnv, name: ERL_NIF_TERM, port: *mut ErlNifPort) -> c_int;
+    pub fn enif_ioq_create(opts: ErlNifIOQueueOpts) -> *mut ErlNifIOQueue;
+    pub fn enif_ioq_destroy(q: *mut ErlNifIOQueue);
+    pub fn enif_ioq_enq_binary(q: *mut ErlNifIOQueue, bin: *mut ErlNifBinary, skip: size_t) -> c_int;
+    pub fn enif_ioq_enqv(q: *mut ErlNifIOQueue, iov: *mut ErlNifIOVec, skip: size_t) -> c_int;
+    pub fn enif_ioq_size(q: *mut ErlNifIOQueue) -> size_t;
+    pub fn enif_ioq_deq(q: *mut ErlNifIOQueue, count: size_t, size: *mut size_t) -> c_int;
+    pub fn enif_ioq_peek(q: *mut ErlNifIOQueue, iovlen: *mut c_int) -> *mut SysIOVec;
+    pub fn enif_inspect_iovec(env: *mut ErlNifEnv, max_length: size_t, iovec_term: ERL_NIF_TERM, tail: *mut ERL_NIF_TERM, iovec: *mut *mut ErlNifIOVec) -> c_int;
+    pub fn enif_free_iovec(iov: *mut ErlNifIOVec);
+    pub fn enif_ioq_peek_head(env: *mut ErlNifEnv, q: *mut ErlNifIOQueue, size: *mut size_t, head: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_make_map_from_arrays(env: *mut ErlNifEnv, keys: *const ERL_NIF_TERM, values: *const ERL_NIF_TERM, cnt: size_t, map_out: *mut ERL_NIF_TERM) -> c_int;
+    pub fn enif_select_x(env: *mut ErlNifEnv, e: ErlNifEvent, flags: ErlNifSelectFlags, obj: *mut c_void, pid: *const ErlNifPid, msg: ERL_NIF_TERM, msg_env: *mut ErlNifEnv) -> c_int;
+    pub fn enif_make_monitor_term(env: *mut ErlNifEnv, arg2: *const ErlNifMonitor) -> ERL_NIF_TERM;
+    pub fn enif_set_pid_undefined(pid: *mut ErlNifPid);
+    pub fn enif_is_pid_undefined(pid: *const ErlNifPid) -> c_int;
+    pub fn enif_term_type(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ErlNifTermType;
+    pub fn enif_init_resource_type(arg1: *mut ErlNifEnv, name_str: *const c_char, arg3: *const ErlNifResourceTypeInit, flags: ErlNifResourceFlags, tried: *mut ErlNifResourceFlags) -> *const ErlNifResourceType;
+    pub fn enif_dynamic_resource_call(arg1: *mut ErlNifEnv, mod_: ERL_NIF_TERM, name: ERL_NIF_TERM, rsrc: ERL_NIF_TERM, call_data: *mut c_void) -> c_int;
+    pub fn enif_get_string_length(env: *mut ErlNifEnv, list: ERL_NIF_TERM, len: *mut c_uint, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom(env: *mut ErlNifEnv, name: *const c_char, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    pub fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *const c_char, len: size_t, atom: *mut ERL_NIF_TERM, encoding: ErlNifCharEncoding) -> c_int;
+    #[link_name = "enif_set_option"]
+    fn __variadic_enif_set_option(env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int;
+    pub fn enif_term_size(term: ERL_NIF_TERM) -> size_t;
+    pub fn enif_get_atom_cache_index(env: *mut ErlNifEnv, atom: ERL_NIF_TERM, index: *mut c_uint) -> c_int;
+    pub fn enif_max_atom_cache_index() -> c_uint;
+}
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_tuple as *const ())
+}
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+    std::mem::transmute(__variadic_enif_make_list as *const ())
+}
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_fprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_snprintf as *const ())
+}
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
+
+pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+    std::mem::transmute(__variadic_enif_set_option as *const ())
+}
+
+
+/// See [enif_make_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_int64(env: *mut ErlNifEnv, i: i64) -> ERL_NIF_TERM
+    { enif_make_long(env, i) }
+
+/// See [enif_make_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_make_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_make_uint64(env: *mut ErlNifEnv, i: u64) -> ERL_NIF_TERM
+    { enif_make_ulong(env, i) }
+
+/// See [enif_get_int64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_int64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_int64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut i64) -> c_int
+    { enif_get_long(env, term, ip) }
+
+/// See [enif_get_uint64](http://www.erlang.org/doc/man/erl_nif.html#enif_get_uint64) at erlang.org
+#[inline]
+pub unsafe fn enif_get_uint64(env: *mut ErlNifEnv, term: ERL_NIF_TERM, ip: *mut u64) -> c_int
+    { enif_get_ulong(env, term, ip) }
+        

--- a/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
@@ -160,7 +160,7 @@ extern "C" {
 
 pub use enif_make_tuple;
 
-pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_tuple() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_tuple as *const ())
 }
 
@@ -171,7 +171,7 @@ pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: 
 
 pub use enif_make_list;
 
-pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
+pub unsafe fn get_enif_make_list() -> unsafe extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     std::mem::transmute(__variadic_enif_make_list as *const ())
 }
 
@@ -182,7 +182,7 @@ pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c
 
 pub use enif_fprintf;
 
-pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_fprintf() -> unsafe extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_fprintf as *const ())
 }
 
@@ -193,7 +193,7 @@ pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *
 
 pub use enif_snprintf;
 
-pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
+pub unsafe fn get_enif_snprintf() -> unsafe extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     std::mem::transmute(__variadic_enif_snprintf as *const ())
 }
 
@@ -204,7 +204,7 @@ pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: s
 
 pub use enif_set_option;
 
-pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
+pub unsafe fn get_enif_set_option() -> unsafe extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     std::mem::transmute(__variadic_enif_set_option as *const ())
 }
 

--- a/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
@@ -1,4 +1,8 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
+#[allow(dead_code)]
+#[derive(Default, Copy, Clone)]
+pub struct DynNifCallbacks {}
+impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }
 extern "C" {
     pub fn enif_priv_data(arg1: *mut ErlNifEnv) -> *mut c_void;
     pub fn enif_alloc(size: size_t) -> *mut c_void;

--- a/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.direct.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {}
 impl DynNifCallbacks { fn write_symbols(&mut self, _: impl DynNifFiller) {} }

--- a/rustler/otp_headers/nif_version_2_18/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.rs
@@ -1,5 +1,6 @@
 pub const ERL_NIF_ENTRY_OPTIONS: c_uint = ERL_NIF_DIRTY_NIF_OPTION;
 #[allow(dead_code)]
+#[repr(C)]
 #[derive(Default, Copy, Clone)]
 pub struct DynNifCallbacks {
     enif_priv_data: Option<extern "C" fn (arg1: *mut ErlNifEnv) -> *mut c_void>,

--- a/rustler/otp_headers/nif_version_2_18/api.8.rs
+++ b/rustler/otp_headers/nif_version_2_18/api.8.rs
@@ -348,23 +348,9 @@ pub unsafe extern "C" fn enif_make_existing_atom(env: *mut ErlNifEnv, name: *con
     (DYN_NIF_CALLBACKS.enif_make_existing_atom.unwrap_unchecked())(env, name, atom, arg4)
 }
 
-#[macro_export] macro_rules! enif_make_tuple {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
-}
-
-pub use enif_make_tuple;
-
 pub unsafe fn get_enif_make_tuple() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_tuple.unwrap_unchecked()
 }
-
-#[macro_export] macro_rules! enif_make_list {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
-}
-
-pub use enif_make_list;
 
 pub unsafe fn get_enif_make_list() -> extern "C" fn (env: *mut ErlNifEnv, cnt: c_uint, ...) -> ERL_NIF_TERM {
     DYN_NIF_CALLBACKS.enif_make_list.unwrap_unchecked()
@@ -404,13 +390,6 @@ pub unsafe extern "C" fn enif_system_info(sip: *mut ErlNifSysInfo, si_size: size
 {
     (DYN_NIF_CALLBACKS.enif_system_info.unwrap_unchecked())(sip, si_size)
 }
-
-#[macro_export] macro_rules! enif_fprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
-}
-
-pub use enif_fprintf;
 
 pub unsafe fn get_enif_fprintf() -> extern "C" fn (filep: *mut c_void, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_fprintf.unwrap_unchecked()
@@ -941,13 +920,6 @@ pub unsafe extern "C" fn enif_thread_type()
     (DYN_NIF_CALLBACKS.enif_thread_type.unwrap_unchecked())()
 }
 
-#[macro_export] macro_rules! enif_snprintf {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
-}
-
-pub use enif_snprintf;
-
 pub unsafe fn get_enif_snprintf() -> extern "C" fn (buffer: *mut c_char, size: size_t, format: *const c_char, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_snprintf.unwrap_unchecked()
 }
@@ -1155,13 +1127,6 @@ pub unsafe extern "C" fn enif_make_new_atom_len(env: *mut ErlNifEnv, name: *cons
     (DYN_NIF_CALLBACKS.enif_make_new_atom_len.unwrap_unchecked())(env, name, len, atom, encoding)
 }
 
-#[macro_export] macro_rules! enif_set_option {
-    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
-    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
-}
-
-pub use enif_set_option;
-
 pub unsafe fn get_enif_set_option() -> extern "C" fn (env: *mut ErlNifEnv, opt: ErlNifOption, ...) -> c_int {
     DYN_NIF_CALLBACKS.enif_set_option.unwrap_unchecked()
 }
@@ -1186,6 +1151,41 @@ pub unsafe extern "C" fn enif_max_atom_cache_index()
  -> c_uint{
     (DYN_NIF_CALLBACKS.enif_max_atom_cache_index.unwrap_unchecked())()
 }
+
+#[macro_export] macro_rules! enif_make_tuple {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_tuple()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_tuple!($($arg),*) };
+}
+
+pub use enif_make_tuple;
+
+#[macro_export] macro_rules! enif_make_list {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_make_list()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_make_list!($($arg),*) };
+}
+
+pub use enif_make_list;
+
+#[macro_export] macro_rules! enif_fprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_fprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_fprintf!($($arg),*) };
+}
+
+pub use enif_fprintf;
+
+#[macro_export] macro_rules! enif_snprintf {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_snprintf()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_snprintf!($($arg),*) };
+}
+
+pub use enif_snprintf;
+
+#[macro_export] macro_rules! enif_set_option {
+    ( $( $arg:expr ),* ) => { $crate::sys::get_enif_set_option()($($arg),*) };
+    ( $( $arg:expr ),+, ) => { enif_set_option!($($arg),*) };
+}
+
+pub use enif_set_option;
 
 impl DynNifCallbacks {
     fn write_symbols<T: DynNifFiller>(&mut self, filler: T) {

--- a/rustler/otp_headers/update.sh
+++ b/rustler/otp_headers/update.sh
@@ -38,14 +38,24 @@ for nif_version in "${!versions[@]}"; do
     for sizeof_long in 4 8
     do
         echo "   Generating Rust API for SIZEOF_LONG=$sizeof_long..."
-        output="$this_dir/api.$sizeof_long.rs"
 
-        # Run the header through the C preprocessor and then our codegen script
-        cpp -D "SIZEOF_LONG=$sizeof_long" \
+        # Run the header through the C preprocessor once and feed the
+        # result to the codegen tool once per output file, since it's a
+        # single stdin -> stdout transform.
+        preprocessed=$(cpp -D "SIZEOF_LONG=$sizeof_long" \
             --include "$script_dir/preamble.h" \
-            <<<"$section" \
-            | cargo run --quiet --manifest-path "$script_dir/codegen/Cargo.toml" -- \
-              --ulong-size="$sizeof_long" \
-            > "$output"
+            <<<"$section")
+
+        for emit in main direct
+        do
+            output="$this_dir/api.$sizeof_long.$emit.rs"
+            [ "$emit" = "main" ] && output="$this_dir/api.$sizeof_long.rs"
+
+            cargo run --quiet --manifest-path "$script_dir/codegen/Cargo.toml" -- \
+                --ulong-size="$sizeof_long" \
+                --emit="$emit" \
+                <<<"$preprocessed" \
+                > "$output"
+        done
     done
 done

--- a/rustler/src/codegen_runtime.rs
+++ b/rustler/src/codegen_runtime.rs
@@ -19,7 +19,7 @@ pub use crate::wrapper::{
     NIF_ENV, NIF_MAJOR_VERSION, NIF_MINOR_VERSION, NIF_TERM,
 };
 
-pub use crate::sys::{internal_set_symbols, internal_write_symbols, DynNifCallbacks};
+pub use crate::sys::{internal_set_symbols, internal_write_symbols};
 
 pub unsafe trait NifReturnable {
     unsafe fn into_returned(self, env: Env) -> NifReturned;

--- a/rustler/src/codegen_runtime.rs
+++ b/rustler/src/codegen_runtime.rs
@@ -19,7 +19,7 @@ pub use crate::wrapper::{
     NIF_ENV, NIF_MAJOR_VERSION, NIF_MINOR_VERSION, NIF_TERM,
 };
 
-pub use crate::sys::{internal_set_symbols, internal_write_symbols};
+pub use crate::sys::{internal_set_symbols, internal_write_symbols, DynNifCallbacks};
 
 pub unsafe trait NifReturnable {
     unsafe fn into_returned(self, env: Env) -> NifReturned;

--- a/rustler/src/sys.rs
+++ b/rustler/src/sys.rs
@@ -7,6 +7,12 @@ Low level Rust bindings to the [Erlang NIF API](http://www.erlang.org/doc/man/er
 #![allow(clippy::missing_safety_doc)]
 
 mod functions;
+// Also enabled automatically for statically-linked musl builds - see
+// `sys/functions.rs`.
+#[cfg(not(any(
+    feature = "static_nif",
+    all(target_env = "musl", target_feature = "crt-static")
+)))]
 mod nif_filler;
 mod types;
 

--- a/rustler/src/sys.rs
+++ b/rustler/src/sys.rs
@@ -7,12 +7,6 @@ Low level Rust bindings to the [Erlang NIF API](http://www.erlang.org/doc/man/er
 #![allow(clippy::missing_safety_doc)]
 
 mod functions;
-// Also enabled automatically for statically-linked musl builds - see
-// `sys/functions.rs`.
-#[cfg(not(any(
-    feature = "static_nif",
-    all(target_env = "musl", target_feature = "crt-static")
-)))]
 mod nif_filler;
 mod types;
 

--- a/rustler/src/sys/functions.rs
+++ b/rustler/src/sys/functions.rs
@@ -1,18 +1,42 @@
 #![allow(clippy::type_complexity)]
+#![allow(dead_code)]
+// `DYN_NIF_CALLBACKS` (defined in the generated `api.*.rs`, only compiled
+// in when not using direct symbols) is a mutable static accessed directly;
+// see `internal_set_symbols`/`internal_write_symbols` below.
+#![allow(static_mut_refs)]
 
-use super::{
-    nif_filler::{self, DynNifFiller},
-    types::*,
-};
+// Statically-linked musl builds link the BEAM directly into the final
+// binary, so the real NIF API symbols are available at link time just like
+// with the `static_nif` feature - no need for a runtime dlsym-based filler
+// there either. This condition (or its negation) is the single place that
+// decides between the two code paths; the generated `api.*.rs`/
+// `api.*.direct.rs` files are self-contained and cfg-free.
+#[cfg(all(
+    not(windows),
+    not(feature = "static_nif"),
+    not(all(target_env = "musl", target_feature = "crt-static"))
+))]
+use super::nif_filler;
+#[cfg(all(
+    not(feature = "static_nif"),
+    not(all(target_env = "musl", target_feature = "crt-static"))
+))]
+use super::nif_filler::DynNifFiller;
+use super::types::*;
 
 static mut DYN_NIF_CALLBACKS: DynNifCallbacks =
     unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
 
-pub unsafe fn internal_set_symbols(callbacks: DynNifCallbacks) {
-    DYN_NIF_CALLBACKS = callbacks;
+pub unsafe fn internal_set_symbols(callbacks: *mut DynNifCallbacks) {
+    if !callbacks.is_null() {
+        DYN_NIF_CALLBACKS = *callbacks;
+    }
 }
 
-#[allow(static_mut_refs)]
+/// Write symbols to `DYN_NIF_CALLBACKS`. This function is not called on Windows
+/// as the symbols are filled directly via `internal_set_symbols` from `init!`,
+/// and it is a no-op if directly linked symbols are used, as we do by default
+/// on Linux.
 pub unsafe fn internal_write_symbols() {
     let filler = nif_filler::new();
     DYN_NIF_CALLBACKS.write_symbols(filler);
@@ -45,6 +69,7 @@ macro_rules! use_snippet {
     };
 
     (include, $version:expr, $sizeof_long:expr) => {
+        #[cfg(not(target_os = "linux"))]
         include!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/otp_headers/",
@@ -53,6 +78,17 @@ macro_rules! use_snippet {
             "api.",
             $sizeof_long,
             ".rs"
+        ));
+
+        #[cfg(target_os = "linux")]
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/otp_headers/",
+            $version,
+            "/",
+            "api.",
+            $sizeof_long,
+            ".direct.rs"
         ));
     };
 }

--- a/rustler/src/sys/functions.rs
+++ b/rustler/src/sys/functions.rs
@@ -47,7 +47,7 @@ macro_rules! use_snippet {
     };
 
     (include, $version:expr, $sizeof_long:expr) => {
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(any(target_os = "macos", windows))]
         include!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/otp_headers/",
@@ -58,7 +58,7 @@ macro_rules! use_snippet {
             ".rs"
         ));
 
-        #[cfg(target_os = "linux")]
+        #[cfg(not(any(target_os = "macos", windows)))]
         include!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/otp_headers/",

--- a/rustler/src/sys/functions.rs
+++ b/rustler/src/sys/functions.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(dead_code)]
-// `DYN_NIF_CALLBACKS` (defined in the generated `api.*.rs`, only compiled
-// in when not using direct symbols) is a mutable static accessed directly;
+// `DYN_NIF_CALLBACKS` is a mutable static accessed directly;
 // see `internal_set_symbols`/`internal_write_symbols` below.
 #![allow(static_mut_refs)]
 

--- a/rustler/src/sys/functions.rs
+++ b/rustler/src/sys/functions.rs
@@ -5,23 +5,7 @@
 // see `internal_set_symbols`/`internal_write_symbols` below.
 #![allow(static_mut_refs)]
 
-// Statically-linked musl builds link the BEAM directly into the final
-// binary, so the real NIF API symbols are available at link time just like
-// with the `static_nif` feature - no need for a runtime dlsym-based filler
-// there either. This condition (or its negation) is the single place that
-// decides between the two code paths; the generated `api.*.rs`/
-// `api.*.direct.rs` files are self-contained and cfg-free.
-#[cfg(all(
-    not(windows),
-    not(feature = "static_nif"),
-    not(all(target_env = "musl", target_feature = "crt-static"))
-))]
-use super::nif_filler;
-#[cfg(all(
-    not(feature = "static_nif"),
-    not(all(target_env = "musl", target_feature = "crt-static"))
-))]
-use super::nif_filler::DynNifFiller;
+use super::nif_filler::{self, DynNifFiller};
 use super::types::*;
 
 static mut DYN_NIF_CALLBACKS: DynNifCallbacks =

--- a/rustler/src/sys/functions.rs
+++ b/rustler/src/sys/functions.rs
@@ -39,16 +39,10 @@ pub unsafe fn enif_compare_pids(pid1: *const ErlNifPid, pid2: *const ErlNifPid) 
 
 macro_rules! use_snippet {
     ($version:expr) => {
-        #[cfg(all(
-                                            feature = $version,
-                                            any(windows, all(unix, target_pointer_width = "32"))
-                                        ))]
+        #[cfg(all(feature = $version, any(windows, all(unix, target_pointer_width = "32"))))]
         use_snippet! {include, $version, "4"}
 
-        #[cfg(all(
-                                            feature = $version,
-                                            all(unix, target_pointer_width = "64")
-                                        ))]
+        #[cfg(all(feature = $version, all(unix, target_pointer_width = "64")))]
         use_snippet! {include, $version, "8"}
     };
 

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -5,49 +5,56 @@ pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);
 }
 
-#[cfg(not(windows))]
-use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
-#[cfg(not(windows))]
-use libloading::os::unix::Library;
+pub(crate) struct NoopNifFiller;
 
-#[cfg(not(windows))]
-const FLAGS: i32 = RTLD_GLOBAL | RTLD_NOLOAD | RTLD_NOW;
-
-// Path to the shared object that contains the BEAM
-#[cfg(not(windows))]
-const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
-
-#[cfg(not(windows))]
-pub(crate) struct DlsymNifFiller {
-    lib: libloading::Library,
+impl DynNifFiller for NoopNifFiller {
+    fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {}
 }
 
 #[cfg(not(windows))]
-impl DlsymNifFiller {
-    pub(crate) fn new() -> Self {
-        let beam_location = match std::env::var(BEAM_LOC) {
-            Ok(val) if !val.is_empty() => Some(val),
-            _ => None,
-        };
-        let lib = unsafe { Library::open(beam_location, FLAGS) };
-        DlsymNifFiller {
-            lib: lib.unwrap().into(),
+mod dlsym_filler {
+    use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
+    use libloading::os::unix::Library;
+
+    const FLAGS: i32 = RTLD_GLOBAL | RTLD_NOLOAD | RTLD_NOW;
+
+    // Path to the shared object that contains the BEAM
+    const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
+
+    pub(crate) struct DlsymNifFiller {
+        lib: libloading::Library,
+    }
+
+    impl DlsymNifFiller {
+        pub(crate) fn new() -> Self {
+            let beam_location = match std::env::var(BEAM_LOC) {
+                Ok(val) if !val.is_empty() => Some(val),
+                _ => None,
+            };
+            let lib = unsafe { Library::open(beam_location, FLAGS) };
+            DlsymNifFiller {
+                lib: lib.unwrap().into(),
+            }
         }
     }
-}
 
-#[cfg(not(windows))]
-impl DynNifFiller for DlsymNifFiller {
-    fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
-        let symbol = unsafe { self.lib.get::<T>(name.as_bytes()).unwrap() };
-        *field = Some(*symbol);
+    impl super::DynNifFiller for DlsymNifFiller {
+        fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
+            let symbol = unsafe { self.lib.get::<T>(name.as_bytes()).unwrap() };
+            *field = Some(*symbol);
+        }
     }
 }
 
 // On Windows the callback table is always supplied directly by the caller
 // via `internal_set_symbols`, so no dlsym-based (or otherwise) filler is
 // ever actually needed there.
+#[cfg(windows)]
+pub(crate) fn new() -> impl DynNifFiller {
+    NoopNifFiller
+}
+
 #[cfg(not(windows))]
 pub(crate) fn new() -> impl DynNifFiller {
-    DlsymNifFiller::new()
+    dlsym_filler::DlsymNifFiller::new()
 }

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -1,59 +1,51 @@
+#[allow(dead_code)]
 pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);
 }
 
-#[cfg(not(target_os = "windows"))]
-mod internal {
-    use super::DynNifFiller;
-    use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
-    use libloading::os::unix::Library;
+#[cfg(not(windows))]
+use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
+#[cfg(not(windows))]
+use libloading::os::unix::Library;
 
-    const FLAGS: i32 = RTLD_GLOBAL | RTLD_NOLOAD | RTLD_NOW;
+#[cfg(not(windows))]
+const FLAGS: i32 = RTLD_GLOBAL | RTLD_NOLOAD | RTLD_NOW;
 
-    // Path to the shared object that contains the BEAM
-    const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
+// Path to the shared object that contains the BEAM
+#[cfg(not(windows))]
+const BEAM_LOC: &str = "RUSTLER_BEAM_LIBRARY_PATH";
 
-    pub(crate) struct DlsymNifFiller {
-        lib: libloading::Library,
-    }
+#[cfg(not(windows))]
+pub(crate) struct DlsymNifFiller {
+    lib: libloading::Library,
+}
 
-    impl DlsymNifFiller {
-        pub(crate) fn new() -> Self {
-            let beam_location = match std::env::var(BEAM_LOC) {
-                Ok(val) if !val.is_empty() => Some(val),
-                _ => None,
-            };
-            let lib = unsafe { Library::open(beam_location, FLAGS) };
-            DlsymNifFiller {
-                lib: lib.unwrap().into(),
-            }
+#[cfg(not(windows))]
+impl DlsymNifFiller {
+    pub(crate) fn new() -> Self {
+        let beam_location = match std::env::var(BEAM_LOC) {
+            Ok(val) if !val.is_empty() => Some(val),
+            _ => None,
+        };
+        let lib = unsafe { Library::open(beam_location, FLAGS) };
+        DlsymNifFiller {
+            lib: lib.unwrap().into(),
         }
-    }
-
-    impl DynNifFiller for DlsymNifFiller {
-        fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
-            let symbol = unsafe { self.lib.get::<T>(name.as_bytes()).unwrap() };
-            *field = Some(*symbol);
-        }
-    }
-
-    pub(crate) fn new() -> impl DynNifFiller {
-        DlsymNifFiller::new()
     }
 }
 
-#[cfg(target_os = "windows")]
-mod internal {
-    use super::*;
-
-    pub struct NullNifFiller;
-    impl DynNifFiller for NullNifFiller {
-        fn write<T: Copy>(&self, _field: &mut Option<T>, _name: &str) {}
-    }
-
-    pub fn new() -> impl DynNifFiller {
-        NullNifFiller
+#[cfg(not(windows))]
+impl DynNifFiller for DlsymNifFiller {
+    fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {
+        let symbol = unsafe { self.lib.get::<T>(name.as_bytes()).unwrap() };
+        *field = Some(*symbol);
     }
 }
 
-pub(crate) use internal::new;
+// On Windows the callback table is always supplied directly by the caller
+// via `internal_set_symbols`, so no dlsym-based (or otherwise) filler is
+// ever actually needed there.
+#[cfg(not(windows))]
+pub(crate) fn new() -> impl DynNifFiller {
+    DlsymNifFiller::new()
+}

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -11,7 +11,7 @@ impl DynNifFiller for NoopNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {}
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
 mod dlsym_filler {
     use libc::{RTLD_GLOBAL, RTLD_NOLOAD, RTLD_NOW};
     use libloading::os::unix::Library;
@@ -48,13 +48,14 @@ mod dlsym_filler {
 
 // On Windows the callback table is always supplied directly by the caller
 // via `internal_set_symbols`, so no dlsym-based (or otherwise) filler is
-// ever actually needed there.
-#[cfg(windows)]
+// ever actually needed there. For Linux, we use direct symbol lookups again.
+// Thus, the DlSym filler is only used on macos for now
+#[cfg(not(target_os = "macos"))]
 pub(crate) fn new() -> impl DynNifFiller {
     NoopNifFiller
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "macos")]
 pub(crate) fn new() -> impl DynNifFiller {
     dlsym_filler::DlsymNifFiller::new()
 }

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 #[allow(dead_code)]
 pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);
@@ -8,7 +6,7 @@ pub(crate) trait DynNifFiller {
 pub(crate) struct NoopNifFiller;
 
 impl DynNifFiller for NoopNifFiller {
-    fn write<T: Copy>(&self, field: &mut Option<T>, name: &str) {}
+    fn write<T: Copy>(&self, _field: &mut Option<T>, _name: &str) {}
 }
 
 #[cfg(target_os = "macos")]

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -3,6 +3,7 @@ pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);
 }
 
+#[allow(unused)]
 pub(crate) struct NoopNifFiller;
 
 impl DynNifFiller for NoopNifFiller {

--- a/rustler/src/sys/nif_filler.rs
+++ b/rustler/src/sys/nif_filler.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 #[allow(dead_code)]
 pub(crate) trait DynNifFiller {
     fn write<T: Copy>(&self, field: &mut Option<T>, name: &str);

--- a/rustler/src/sys/types.rs
+++ b/rustler/src/sys/types.rs
@@ -347,15 +347,7 @@ pub enum ErlNifOption {
 
 const ERL_NIF_IOVEC_SIZE: usize = 16;
 
-#[cfg(not(windows))]
-pub type SysIOVec = libc::iovec;
-
-#[cfg(windows)]
-#[repr(C)]
-pub struct SysIOVec {
-    pub iov_len: c_ulong,
-    pub iov_base: *mut c_char,
-}
+pub type SysIOVec = std::io::IoSliceMut<'static>;
 
 const ERTS_SMALL_IO_QUEUE: usize = 5;
 

--- a/rustler/src/sys/types.rs
+++ b/rustler/src/sys/types.rs
@@ -351,6 +351,7 @@ const ERL_NIF_IOVEC_SIZE: usize = 16;
 pub type SysIOVec = libc::iovec;
 
 #[cfg(windows)]
+#[repr(C)]
 pub struct SysIOVec {
     pub iov_len: c_ulong,
     pub iov_base: *mut c_char,

--- a/rustler_codegen/src/init.rs
+++ b/rustler_codegen/src/init.rs
@@ -150,7 +150,7 @@ impl From<InitMacroInput> for proc_macro2::TokenStream {
             #[no_mangle]
             extern "C" fn #nif_init_name(callbacks: *mut ::rustler::codegen_runtime::DynNifCallbacks) -> *const ::rustler::codegen_runtime::DEF_NIF_ENTRY {
                 unsafe {
-                    ::rustler::codegen_runtime::internal_set_symbols(*callbacks);
+                    ::rustler::codegen_runtime::internal_set_symbols(callbacks);
                 }
 
                 #inner


### PR DESCRIPTION
This undoes parts of https://github.com/rusterlium/rustler/issues/648. We keep dynamic symbol lookup on Windows (because that is just how it works on this platform) and macOS (because this allows our users to skip messing with linker flags).

The rationale is a forked/vendored copy of rustler that I found, where the dev ran into `dlopen(NULL)` not being implemented at all in Musl static builds. That means we have to have the "static" linking in place if we want to support that platform.

My initial idea of making the `.so` callable didn't quite work out, and with the new symbol generation setup, we have a relatively easy way to make `cargo-rustler` (if we ever implement it fully) expose the necessary symbols to the .so at load time.