### PR TITLE
ERL_NIF_TERM as newtype

### DIFF
--- a/rustler/src/codegen_runtime.rs
+++ b/rustler/src/codegen_runtime.rs
@@ -16,10 +16,12 @@ pub use crate::resource::Registration as ResourceRegistration;
 pub use crate::wrapper::exception::raise_exception;
 pub use crate::wrapper::{
     c_char, c_int, c_uint, c_void, get_nif_resource_type_init_size, DEF_NIF_ENTRY, DEF_NIF_FUNC,
-    NIF_ENV, NIF_MAJOR_VERSION, NIF_MINOR_VERSION, NIF_TERM,
+    NIF_MAJOR_VERSION, NIF_MINOR_VERSION,
 };
 
-pub use crate::sys::{internal_set_symbols, internal_write_symbols, DynNifCallbacks};
+pub use crate::sys::{
+    internal_set_symbols, internal_write_symbols, DynNifCallbacks, ErlNifEnv, ERL_NIF_TERM,
+};
 
 pub unsafe trait NifReturnable {
     unsafe fn into_returned(self, env: Env) -> NifReturned;
@@ -59,19 +61,19 @@ unsafe impl NifReturnable for OwnedBinary {
 }
 
 pub enum NifReturned {
-    Term(NIF_TERM),
-    Raise(NIF_TERM),
+    Term(ERL_NIF_TERM),
+    Raise(ERL_NIF_TERM),
     BadArg,
     Reschedule {
         fun_name: CString,
         flags: crate::schedule::SchedulerFlags,
-        fun: unsafe extern "C" fn(NIF_ENV, i32, *const NIF_TERM) -> NIF_TERM,
-        args: Vec<NIF_TERM>,
+        fun: unsafe extern "C" fn(*mut ErlNifEnv, i32, *const ERL_NIF_TERM) -> ERL_NIF_TERM,
+        args: Vec<ERL_NIF_TERM>,
     },
 }
 
 impl NifReturned {
-    pub unsafe fn apply(self, env: Env) -> NIF_TERM {
+    pub unsafe fn apply(self, env: Env) -> ERL_NIF_TERM {
         match self {
             NifReturned::Term(inner) => inner,
             NifReturned::BadArg => crate::wrapper::exception::raise_badarg(env.as_c_arg()),

--- a/rustler/src/env.rs
+++ b/rustler/src/env.rs
@@ -1,7 +1,9 @@
-use crate::sys::{enif_alloc_env, enif_clear_env, enif_free_env, enif_send, enif_whereis_pid};
+use crate::sys::{
+    enif_alloc_env, enif_clear_env, enif_free_env, enif_send, enif_whereis_pid, ErlNifEnv,
+    ERL_NIF_TERM,
+};
 use crate::thread::is_scheduler_thread;
 use crate::types::LocalPid;
-use crate::wrapper::{NIF_ENV, NIF_TERM};
 use crate::{Encoder, Term};
 use std::marker::PhantomData;
 use std::ptr;
@@ -28,11 +30,11 @@ pub(crate) enum EnvKind {
 #[derive(Clone, Copy)]
 pub struct Env<'a> {
     pub(crate) kind: EnvKind,
-    env: NIF_ENV,
+    env: *mut ErlNifEnv,
     id: EnvId<'a>,
 }
 
-/// Two environments are equal if they're the same `NIF_ENV` value.
+/// Two environments are equal if they're the same `*mut ErlNifEnv` pointer value.
 ///
 /// A `Env<'a>` is equal to a `Env<'b>` if and only if `'a` and `'b` are the same lifetime.
 impl<'b> PartialEq<Env<'b>> for Env<'_> {
@@ -51,7 +53,7 @@ impl<'a> Env<'a> {
     #[inline]
     pub(crate) unsafe fn new_internal<T>(
         _lifetime_marker: &'a T,
-        env: NIF_ENV,
+        env: *mut ErlNifEnv,
         kind: EnvKind,
     ) -> Env<'a> {
         Env {
@@ -71,17 +73,17 @@ impl<'a> Env<'a> {
     /// # Unsafe
     /// Don't create multiple `Env`s with the same lifetime.
     #[inline]
-    pub unsafe fn new<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> Env<'a> {
+    pub unsafe fn new<T>(_lifetime_marker: &'a T, env: *mut ErlNifEnv) -> Env<'a> {
         Self::new_internal(_lifetime_marker, env, EnvKind::ProcessBound)
     }
 
     #[doc(hidden)]
     #[inline]
-    pub unsafe fn new_init_env<T>(_lifetime_marker: &'a T, env: NIF_ENV) -> Env<'a> {
+    pub unsafe fn new_init_env<T>(_lifetime_marker: &'a T, env: *mut ErlNifEnv) -> Env<'a> {
         Self::new_internal(_lifetime_marker, env, EnvKind::Init)
     }
 
-    pub fn as_c_arg(self) -> NIF_ENV {
+    pub fn as_c_arg(self) -> *mut ErlNifEnv {
         self.env
     }
 
@@ -202,7 +204,7 @@ impl<'a> Env<'a> {
 /// There's no way to run Erlang code in an `OwnedEnv`. It's not a process. It's just a workspace
 /// for building terms.
 pub struct OwnedEnv {
-    env: Arc<NIF_ENV>,
+    env: Arc<*mut ErlNifEnv>,
 }
 
 unsafe impl Send for OwnedEnv {}
@@ -331,8 +333,8 @@ impl Drop for OwnedEnv {
 /// example.
 #[derive(Clone)]
 pub struct SavedTerm {
-    env_generation: Weak<NIF_ENV>,
-    term: NIF_TERM,
+    env_generation: Weak<*mut ErlNifEnv>,
+    term: ERL_NIF_TERM,
 }
 
 unsafe impl Send for SavedTerm {}

--- a/rustler/src/nif.rs
+++ b/rustler/src/nif.rs
@@ -1,12 +1,16 @@
-use crate::codegen_runtime::{c_char, c_int, c_uint, DEF_NIF_FUNC, NIF_ENV, NIF_TERM};
+use crate::codegen_runtime::{c_char, c_int, c_uint, DEF_NIF_FUNC};
+use crate::sys::{ErlNifEnv, ERL_NIF_TERM};
 
 pub struct Nif {
     pub name: *const c_char,
     pub arity: c_uint,
     pub flags: c_uint,
     // pub func: DEF_NIF_FUNC,
-    pub raw_func:
-        unsafe extern "C" fn(nif_env: NIF_ENV, argc: c_int, argv: *const NIF_TERM) -> NIF_TERM,
+    pub raw_func: unsafe extern "C" fn(
+        nif_env: *mut ErlNifEnv,
+        argc: c_int,
+        argv: *const ERL_NIF_TERM,
+    ) -> ERL_NIF_TERM,
 }
 
 impl Nif {

--- a/rustler/src/sys/types.rs
+++ b/rustler/src/sys/types.rs
@@ -13,12 +13,28 @@ pub type size_t = usize;
 #[allow(non_camel_case_types)]
 pub type ERL_NIF_UINT = size_t;
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
 #[allow(non_camel_case_types)]
-pub type ERL_NIF_TERM = ERL_NIF_UINT;
+pub struct ERL_NIF_TERM(pub ERL_NIF_UINT);
 
-//#[derive(Debug, Copy, Clone)]
-//#[repr(C)]
-//pub struct ERL_NIF_TERM(ERL_NIF_UINT);  // Don't do this, 32 bit calling convention is different for structs and ints.
+impl std::fmt::Display for ERL_NIF_TERM {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<ERL_NIF_UINT> for ERL_NIF_TERM {
+    fn from(val: ERL_NIF_UINT) -> Self {
+        ERL_NIF_TERM(val)
+    }
+}
+
+impl From<ERL_NIF_TERM> for ERL_NIF_UINT {
+    fn from(val: ERL_NIF_TERM) -> Self {
+        val.0
+    }
+}
 
 /// See [ErlNifEnv](http://www.erlang.org/doc/man/erl_nif.html#ErlNifEnv) in the Erlang docs.
 #[derive(Debug)]

--- a/rustler/src/term.rs
+++ b/rustler/src/term.rs
@@ -1,7 +1,6 @@
 use crate::sys::*;
 use crate::types::binary::OwnedBinary;
 use crate::wrapper::env::term_to_binary;
-use crate::wrapper::NIF_TERM;
 use crate::{Binary, Decoder, Env, NifResult};
 use std::cmp::Ordering;
 use std::fmt::{self, Debug};
@@ -13,7 +12,7 @@ use std::hash::{Hash, Hasher};
 /// that owns it.
 #[derive(Clone, Copy)]
 pub struct Term<'a> {
-    term: NIF_TERM,
+    term: ERL_NIF_TERM,
     env: Env<'a>,
 }
 
@@ -24,19 +23,19 @@ impl Debug for Term<'_> {
 }
 
 impl<'a> Term<'a> {
-    /// Create a `Term` from a raw `NIF_TERM`.
+    /// Create a `Term` from a raw `ERL_NIF_TERM`.
     ///
     /// # Unsafe
     /// The caller must ensure that `env` is the environment that `inner` belongs to,
     /// unless `inner` is an atom term.
     #[inline]
-    pub unsafe fn new(env: Env<'a>, inner: NIF_TERM) -> Self {
+    pub unsafe fn new(env: Env<'a>, inner: ERL_NIF_TERM) -> Self {
         Term { term: inner, env }
     }
     /// This extracts the raw term pointer. It is usually used in order to obtain a type that can
     /// be passed to calls into the erlang vm.
     #[inline]
-    pub fn as_c_arg(&self) -> NIF_TERM {
+    pub fn as_c_arg(&self) -> ERL_NIF_TERM {
         self.term
     }
 

--- a/rustler/src/types/atom.rs
+++ b/rustler/src/types/atom.rs
@@ -1,6 +1,5 @@
-use crate::sys::ErlNifCharEncoding;
+use crate::sys::{ErlNifCharEncoding, ERL_NIF_TERM};
 use crate::wrapper::atom;
-use crate::wrapper::NIF_TERM;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -9,11 +8,11 @@ use std::hash::{Hash, Hasher};
 // it lives and when it is created.
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct Atom {
-    term: NIF_TERM,
+    term: ERL_NIF_TERM,
 }
 
 impl Atom {
-    pub fn as_c_arg(self) -> NIF_TERM {
+    pub fn as_c_arg(self) -> ERL_NIF_TERM {
         self.term
     }
 
@@ -22,7 +21,7 @@ impl Atom {
         unsafe { Term::new(env, self.term) }
     }
 
-    unsafe fn from_nif_term(term: NIF_TERM) -> Self {
+    unsafe fn from_nif_term(term: ERL_NIF_TERM) -> Self {
         Self { term }
     }
 

--- a/rustler/src/types/list.rs
+++ b/rustler/src/types/list.rs
@@ -2,7 +2,8 @@
 //!
 //! Right now the only supported way to read lists are through the ListIterator.
 
-use crate::wrapper::{list, NIF_TERM};
+use crate::sys::ERL_NIF_TERM;
+use crate::wrapper::list;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 
 /// Enables iteration over the items in the list.
@@ -90,7 +91,7 @@ impl<'a> Decoder<'a> for ListIterator<'a> {
 
 //impl<'a, T> Encoder for Iterator<Item = T> where T: Encoder {
 //    fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-//        let term_arr: Vec<NIF_TERM> =
+//        let term_arr: Vec<ERL_NIF_TERM> =
 //            self.map(|x| x.encode(env).as_c_arg()).collect();
 //    }
 //}
@@ -122,7 +123,7 @@ where
 {
     #[inline]
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
+        let term_array: Vec<ERL_NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
         unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
     }
 }
@@ -133,7 +134,7 @@ where
 {
     #[inline]
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        let term_array: Vec<NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
+        let term_array: Vec<ERL_NIF_TERM> = self.iter().map(|x| x.encode(env).as_c_arg()).collect();
         unsafe { Term::new(env, list::make_list(env.as_c_arg(), &term_array)) }
     }
 }

--- a/rustler/src/types/tuple.rs
+++ b/rustler/src/types/tuple.rs
@@ -1,4 +1,5 @@
-use crate::wrapper::{tuple, NIF_TERM};
+use crate::sys::ERL_NIF_TERM;
+use crate::wrapper::tuple;
 use crate::{Decoder, Encoder, Env, Error, NifResult, Term};
 
 /// Convert an Erlang tuple to a Rust vector. (To convert to a Rust tuple, use `term.decode()`
@@ -22,7 +23,7 @@ pub fn get_tuple(term: Term) -> Result<Vec<Term>, Error> {
 /// Convert a vector of terms to an Erlang tuple. (To convert from a Rust tuple to an Erlang tuple,
 /// use `Encoder` instead.)
 pub fn make_tuple<'a>(env: Env<'a>, terms: &[Term]) -> Term<'a> {
-    let c_terms: Vec<NIF_TERM> = terms.iter().map(|term| term.as_c_arg()).collect();
+    let c_terms: Vec<ERL_NIF_TERM> = terms.iter().map(|term| term.as_c_arg()).collect();
     unsafe { Term::new(env, tuple::make_tuple(env.as_c_arg(), &c_terms)) }
 }
 

--- a/rustler/src/wrapper.rs
+++ b/rustler/src/wrapper.rs
@@ -28,8 +28,6 @@ pub use crate::sys::{
 pub use crate::sys::{c_char, c_double, c_int, c_uchar, c_uint, c_void};
 pub type size_t = usize;
 
-pub type NIF_ENV = *mut crate::sys::ErlNifEnv;
-pub type NIF_TERM = size_t;
 pub type NIF_RESOURCE_TYPE = *const crate::sys::ErlNifResourceType;
 
 pub fn get_nif_resource_type_init_size() -> usize {

--- a/rustler/src/wrapper/atom.rs
+++ b/rustler/src/wrapper/atom.rs
@@ -1,20 +1,23 @@
+use std::mem::MaybeUninit;
+
 #[cfg(not(feature = "nif_version_2_17"))]
 use crate::sys::enif_make_atom_len;
 #[cfg(feature = "nif_version_2_17")]
 use crate::sys::enif_make_new_atom_len;
-use crate::sys::ErlNifCharEncoding;
-use crate::sys::{enif_get_atom, enif_get_atom_length, enif_make_existing_atom_len};
-use crate::wrapper::{c_char, c_uint, NIF_ENV, NIF_TERM};
+use crate::sys::{
+    c_char, c_uint, enif_get_atom, enif_get_atom_length, enif_make_existing_atom_len,
+    ErlNifCharEncoding, ErlNifEnv, ERL_NIF_TERM,
+};
 use crate::Error;
 
 #[cfg(not(feature = "nif_version_2_17"))]
 pub unsafe fn make_atom(
-    env: NIF_ENV,
+    env: *mut ErlNifEnv,
     name: &[u8],
     _encoding: ErlNifCharEncoding,
-) -> Result<NIF_TERM, Error> {
+) -> Result<ERL_NIF_TERM, Error> {
     let res = enif_make_atom_len(env, name.as_ptr() as *const c_char, name.len());
-    if res != 0 {
+    if res.0 != 0 {
         Ok(res)
     } else {
         Err(Error::BadArg)
@@ -23,11 +26,11 @@ pub unsafe fn make_atom(
 
 #[cfg(feature = "nif_version_2_17")]
 pub unsafe fn make_atom(
-    env: NIF_ENV,
+    env: *mut ErlNifEnv,
     name: &[u8],
     encoding: ErlNifCharEncoding,
-) -> Result<NIF_TERM, Error> {
-    let mut atom_out: NIF_TERM = 0;
+) -> Result<ERL_NIF_TERM, Error> {
+    let mut atom_out = MaybeUninit::uninit();
 
     // Create a new atom with the requested encoding.
     // Returns 0 if creation fails (e.g. invalid text/encoding).
@@ -35,32 +38,32 @@ pub unsafe fn make_atom(
         env,
         name.as_ptr() as *const c_char,
         name.len(),
-        &mut atom_out as *mut NIF_TERM,
+        atom_out.as_mut_ptr(),
         encoding,
     ) != 0
     {
-        Ok(atom_out)
+        Ok(atom_out.assume_init())
     } else {
         Err(Error::BadArg)
     }
 }
 
 pub unsafe fn make_existing_atom(
-    env: NIF_ENV,
+    env: *mut ErlNifEnv,
     name: &[u8],
     encoding: ErlNifCharEncoding,
-) -> Result<NIF_TERM, Error> {
-    let mut atom_out: NIF_TERM = 0;
+) -> Result<ERL_NIF_TERM, Error> {
+    let mut atom_out = MaybeUninit::uninit();
 
     if enif_make_existing_atom_len(
         env,
         name.as_ptr() as *const c_char,
         name.len(),
-        &mut atom_out as *mut NIF_TERM,
+        atom_out.as_mut_ptr(),
         encoding,
     ) != 0
     {
-        Ok(atom_out)
+        Ok(atom_out.assume_init())
     } else {
         Err(Error::BadArg)
     }
@@ -76,7 +79,7 @@ pub unsafe fn make_existing_atom(
 /// `Error::BadArg` if `term` is not an atom.
 ///
 #[cfg(feature = "nif_version_2_17")]
-pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
+pub unsafe fn get_atom(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> Result<String, Error> {
     // Determine the length of the atom, in bytes.
     let mut len = 0;
     let success = enif_get_atom_length(env, term, &mut len, ErlNifCharEncoding::ERL_NIF_UTF8);
@@ -105,7 +108,7 @@ pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
 }
 
 #[cfg(not(feature = "nif_version_2_17"))]
-pub unsafe fn get_atom(env: NIF_ENV, term: NIF_TERM) -> Result<String, Error> {
+pub unsafe fn get_atom(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> Result<String, Error> {
     // Determine the length of the atom, in bytes.
     let mut len = 0;
     let success = enif_get_atom_length(env, term, &mut len, ErlNifCharEncoding::ERL_NIF_LATIN1);

--- a/rustler/src/wrapper/check.rs
+++ b/rustler/src/wrapper/check.rs
@@ -1,8 +1,8 @@
-use crate::wrapper::{NIF_ENV, NIF_TERM};
+use crate::sys::{ErlNifEnv, ERL_NIF_TERM};
 
 macro_rules! impl_check_fun {
     ($name:ident, $inner:ident) => {
-        pub unsafe fn $name(env: NIF_ENV, term: NIF_TERM) -> bool {
+        pub unsafe fn $name(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> bool {
             crate::sys::$inner(env, term) == 1
         }
     };

--- a/rustler/src/wrapper/env.rs
+++ b/rustler/src/wrapper/env.rs
@@ -1,9 +1,14 @@
-use crate::sys::{enif_binary_to_term, enif_term_to_binary};
-use crate::wrapper::binary::ErlNifBinary;
-use crate::wrapper::{ERL_NIF_BIN2TERM_SAFE, NIF_ENV, NIF_TERM};
+use crate::sys::{
+    enif_binary_to_term, enif_term_to_binary, ErlNifBinary, ErlNifEnv, ERL_NIF_BIN2TERM_SAFE,
+    ERL_NIF_TERM,
+};
 use std::mem::MaybeUninit;
 
-pub unsafe fn binary_to_term(env: NIF_ENV, data: &[u8], safe: bool) -> Option<(NIF_TERM, usize)> {
+pub unsafe fn binary_to_term(
+    env: *mut ErlNifEnv,
+    data: &[u8],
+    safe: bool,
+) -> Option<(ERL_NIF_TERM, usize)> {
     let opts = if safe { ERL_NIF_BIN2TERM_SAFE } else { 0 };
 
     let mut result = MaybeUninit::uninit();
@@ -16,7 +21,7 @@ pub unsafe fn binary_to_term(env: NIF_ENV, data: &[u8], safe: bool) -> Option<(N
     Some((result.assume_init(), read_count))
 }
 
-pub unsafe fn term_to_binary(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifBinary> {
+pub unsafe fn term_to_binary(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> Option<ErlNifBinary> {
     let mut binary = MaybeUninit::uninit();
     let success = enif_term_to_binary(env, term, binary.as_mut_ptr());
 

--- a/rustler/src/wrapper/exception.rs
+++ b/rustler/src/wrapper/exception.rs
@@ -1,7 +1,4 @@
-use crate::{
-    sys::{enif_make_badarg, enif_raise_exception},
-    wrapper::{NIF_ENV, NIF_TERM},
-};
+use crate::sys::{enif_make_badarg, enif_raise_exception, ErlNifEnv, ERL_NIF_TERM};
 
 /// Raise an "error exception".
 ///
@@ -12,7 +9,7 @@ use crate::{
 /// `enif_is_exception`, but not to any other NIF API function."
 ///
 /// And of course the usual rules about `env` and `term` still apply.
-pub unsafe fn raise_exception(env: NIF_ENV, term: NIF_TERM) -> NIF_TERM {
+pub unsafe fn raise_exception(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> ERL_NIF_TERM {
     enif_raise_exception(env, term)
 }
 
@@ -25,6 +22,6 @@ pub unsafe fn raise_exception(env: NIF_ENV, term: NIF_TERM) -> NIF_TERM {
 /// `enif_is_exception`, but not to any other NIF API function."
 ///
 /// And of course `env` must be a valid environment.
-pub unsafe fn raise_badarg(env: NIF_ENV) -> NIF_TERM {
+pub unsafe fn raise_badarg(env: *mut ErlNifEnv) -> ERL_NIF_TERM {
     enif_make_badarg(env)
 }

--- a/rustler/src/wrapper/list.rs
+++ b/rustler/src/wrapper/list.rs
@@ -1,14 +1,14 @@
-use crate::{
-    sys::{
-        enif_get_list_cell, enif_get_list_length, enif_make_list_cell, enif_make_list_from_array,
-        enif_make_reverse_list,
-    },
-    wrapper::{NIF_ENV, NIF_TERM},
+use crate::sys::{
+    enif_get_list_cell, enif_get_list_length, enif_make_list_cell, enif_make_list_from_array,
+    enif_make_reverse_list, ErlNifEnv, ERL_NIF_TERM,
 };
 use std::mem::MaybeUninit;
 
 #[inline]
-pub unsafe fn get_list_cell(env: NIF_ENV, list: NIF_TERM) -> Option<(NIF_TERM, NIF_TERM)> {
+pub unsafe fn get_list_cell(
+    env: *mut ErlNifEnv,
+    list: ERL_NIF_TERM,
+) -> Option<(ERL_NIF_TERM, ERL_NIF_TERM)> {
     let mut head = MaybeUninit::uninit();
     let mut tail = MaybeUninit::uninit();
     let success = enif_get_list_cell(env, list, head.as_mut_ptr(), tail.as_mut_ptr());
@@ -20,7 +20,7 @@ pub unsafe fn get_list_cell(env: NIF_ENV, list: NIF_TERM) -> Option<(NIF_TERM, N
 }
 
 #[inline]
-pub unsafe fn get_list_length(env: NIF_ENV, list: NIF_TERM) -> Option<usize> {
+pub unsafe fn get_list_length(env: *mut ErlNifEnv, list: ERL_NIF_TERM) -> Option<usize> {
     let mut len: u32 = 0;
     let success = enif_get_list_length(env, list, &mut len);
 
@@ -31,17 +31,21 @@ pub unsafe fn get_list_length(env: NIF_ENV, list: NIF_TERM) -> Option<usize> {
 }
 
 #[inline]
-pub unsafe fn make_list(env: NIF_ENV, arr: &[NIF_TERM]) -> NIF_TERM {
+pub unsafe fn make_list(env: *mut ErlNifEnv, arr: &[ERL_NIF_TERM]) -> ERL_NIF_TERM {
     enif_make_list_from_array(env, arr.as_ptr(), arr.len() as u32)
 }
 
 #[inline]
-pub unsafe fn make_list_cell(env: NIF_ENV, head: NIF_TERM, tail: NIF_TERM) -> NIF_TERM {
+pub unsafe fn make_list_cell(
+    env: *mut ErlNifEnv,
+    head: ERL_NIF_TERM,
+    tail: ERL_NIF_TERM,
+) -> ERL_NIF_TERM {
     enif_make_list_cell(env, head, tail)
 }
 
 #[inline]
-pub unsafe fn make_reverse_list(env: NIF_ENV, list: NIF_TERM) -> Option<NIF_TERM> {
+pub unsafe fn make_reverse_list(env: *mut ErlNifEnv, list: ERL_NIF_TERM) -> Option<ERL_NIF_TERM> {
     let mut list_out = MaybeUninit::uninit();
     let success = enif_make_reverse_list(env, list, list_out.as_mut_ptr());
 

--- a/rustler/src/wrapper/map.rs
+++ b/rustler/src/wrapper/map.rs
@@ -1,11 +1,9 @@
-pub use crate::wrapper::ErlNifMapIterator;
-use crate::{
-    sys::{
-        enif_get_map_size, enif_get_map_value, enif_make_map_from_arrays, enif_make_map_put,
-        enif_make_map_remove, enif_make_map_update, enif_make_new_map, enif_map_iterator_prev,
-    },
-    wrapper::{ErlNifMapIteratorEntry, NIF_ENV, NIF_TERM},
+use crate::sys::{
+    enif_get_map_size, enif_get_map_value, enif_make_map_from_arrays, enif_make_map_put,
+    enif_make_map_remove, enif_make_map_update, enif_make_new_map, enif_map_iterator_prev,
+    ErlNifEnv, ErlNifMapIteratorEntry, ERL_NIF_TERM,
 };
+pub use crate::wrapper::ErlNifMapIterator;
 use std::mem::MaybeUninit;
 
 use super::{
@@ -13,7 +11,11 @@ use super::{
     enif_map_iterator_next,
 };
 
-pub unsafe fn get_map_value(env: NIF_ENV, map: NIF_TERM, key: NIF_TERM) -> Option<NIF_TERM> {
+pub unsafe fn get_map_value(
+    env: *mut ErlNifEnv,
+    map: ERL_NIF_TERM,
+    key: ERL_NIF_TERM,
+) -> Option<ERL_NIF_TERM> {
     let mut result = MaybeUninit::uninit();
     let success = enif_get_map_value(env, map, key, result.as_mut_ptr());
 
@@ -23,7 +25,7 @@ pub unsafe fn get_map_value(env: NIF_ENV, map: NIF_TERM, key: NIF_TERM) -> Optio
     Some(result.assume_init())
 }
 
-pub unsafe fn get_map_size(env: NIF_ENV, map: NIF_TERM) -> Option<usize> {
+pub unsafe fn get_map_size(env: *mut ErlNifEnv, map: ERL_NIF_TERM) -> Option<usize> {
     let mut size = MaybeUninit::uninit();
     let success = enif_get_map_size(env, map, size.as_mut_ptr());
 
@@ -33,16 +35,16 @@ pub unsafe fn get_map_size(env: NIF_ENV, map: NIF_TERM) -> Option<usize> {
     Some(size.assume_init())
 }
 
-pub unsafe fn map_new(env: NIF_ENV) -> NIF_TERM {
+pub unsafe fn map_new(env: *mut ErlNifEnv) -> ERL_NIF_TERM {
     enif_make_new_map(env)
 }
 
 pub unsafe fn map_put(
-    env: NIF_ENV,
-    map: NIF_TERM,
-    key: NIF_TERM,
-    value: NIF_TERM,
-) -> Option<NIF_TERM> {
+    env: *mut ErlNifEnv,
+    map: ERL_NIF_TERM,
+    key: ERL_NIF_TERM,
+    value: ERL_NIF_TERM,
+) -> Option<ERL_NIF_TERM> {
     let mut result = MaybeUninit::uninit();
     let success = enif_make_map_put(env, map, key, value, result.as_mut_ptr());
 
@@ -52,7 +54,11 @@ pub unsafe fn map_put(
     Some(result.assume_init())
 }
 
-pub unsafe fn map_remove(env: NIF_ENV, map: NIF_TERM, key: NIF_TERM) -> Option<NIF_TERM> {
+pub unsafe fn map_remove(
+    env: *mut ErlNifEnv,
+    map: ERL_NIF_TERM,
+    key: ERL_NIF_TERM,
+) -> Option<ERL_NIF_TERM> {
     let mut result = MaybeUninit::uninit();
     let success = enif_make_map_remove(env, map, key, result.as_mut_ptr());
 
@@ -63,11 +69,11 @@ pub unsafe fn map_remove(env: NIF_ENV, map: NIF_TERM, key: NIF_TERM) -> Option<N
 }
 
 pub unsafe fn map_update(
-    env: NIF_ENV,
-    map: NIF_TERM,
-    key: NIF_TERM,
-    new_value: NIF_TERM,
-) -> Option<NIF_TERM> {
+    env: *mut ErlNifEnv,
+    map: ERL_NIF_TERM,
+    key: ERL_NIF_TERM,
+    new_value: ERL_NIF_TERM,
+) -> Option<ERL_NIF_TERM> {
     let mut result = MaybeUninit::uninit();
     let success = enif_make_map_update(env, map, key, new_value, result.as_mut_ptr());
 
@@ -84,8 +90,8 @@ pub enum MapIteratorEntry {
 }
 
 pub unsafe fn map_iterator_create(
-    env: NIF_ENV,
-    map: NIF_TERM,
+    env: *mut ErlNifEnv,
+    map: ERL_NIF_TERM,
     entry: MapIteratorEntry,
 ) -> Option<ErlNifMapIterator> {
     let mut iter = MaybeUninit::uninit();
@@ -105,14 +111,14 @@ pub unsafe fn map_iterator_create(
     }
 }
 
-pub unsafe fn map_iterator_destroy(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
+pub unsafe fn map_iterator_destroy(env: *mut ErlNifEnv, iter: &mut ErlNifMapIterator) {
     enif_map_iterator_destroy(env, iter);
 }
 
 pub unsafe fn map_iterator_get_pair(
-    env: NIF_ENV,
+    env: *mut ErlNifEnv,
     iter: &mut ErlNifMapIterator,
-) -> Option<(NIF_TERM, NIF_TERM)> {
+) -> Option<(ERL_NIF_TERM, ERL_NIF_TERM)> {
     let mut key = MaybeUninit::uninit();
     let mut value = MaybeUninit::uninit();
     if enif_map_iterator_get_pair(env, iter, key.as_mut_ptr(), value.as_mut_ptr()) == 0 {
@@ -123,20 +129,20 @@ pub unsafe fn map_iterator_get_pair(
 }
 
 #[inline]
-pub unsafe fn map_iterator_next(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
+pub unsafe fn map_iterator_next(env: *mut ErlNifEnv, iter: &mut ErlNifMapIterator) {
     enif_map_iterator_next(env, iter);
 }
 
-pub unsafe fn map_iterator_prev(env: NIF_ENV, iter: &mut ErlNifMapIterator) {
+pub unsafe fn map_iterator_prev(env: *mut ErlNifEnv, iter: &mut ErlNifMapIterator) {
     enif_map_iterator_prev(env, iter);
 }
 
 #[inline]
 pub unsafe fn make_map_from_arrays(
-    env: NIF_ENV,
-    keys: &[NIF_TERM],
-    values: &[NIF_TERM],
-) -> Option<NIF_TERM> {
+    env: *mut ErlNifEnv,
+    keys: &[ERL_NIF_TERM],
+    values: &[ERL_NIF_TERM],
+) -> Option<ERL_NIF_TERM> {
     let mut map = MaybeUninit::uninit();
     if enif_make_map_from_arrays(
         env,

--- a/rustler/src/wrapper/pid.rs
+++ b/rustler/src/wrapper/pid.rs
@@ -1,9 +1,8 @@
-use crate::wrapper::{ErlNifPid, NIF_ENV, NIF_TERM};
 use std::mem::MaybeUninit;
 
-use crate::sys::{enif_get_local_pid, enif_make_pid};
+use crate::sys::{enif_get_local_pid, enif_make_pid, ErlNifEnv, ErlNifPid, ERL_NIF_TERM};
 
-pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
+pub unsafe fn get_local_pid(env: *mut ErlNifEnv, term: ERL_NIF_TERM) -> Option<ErlNifPid> {
     let mut pid = MaybeUninit::uninit();
     if enif_get_local_pid(env, term, pid.as_mut_ptr()) == 0 {
         return None;
@@ -11,10 +10,10 @@ pub unsafe fn get_local_pid(env: NIF_ENV, term: NIF_TERM) -> Option<ErlNifPid> {
     Some(pid.assume_init())
 }
 
-// pub unsafe fn is_process_alive(env: NIF_ENV, pid: &ErlNifPid) -> bool {
+// pub unsafe fn is_process_alive(env: *mut ErlNifEnv, pid: &ErlNifPid) -> bool {
 //     enif_is_process_alive(env, pid) != 0
 // }
 
-pub unsafe fn make_pid(env: NIF_ENV, pid: ErlNifPid) -> NIF_TERM {
+pub unsafe fn make_pid(env: *mut ErlNifEnv, pid: ErlNifPid) -> ERL_NIF_TERM {
     enif_make_pid(env, pid)
 }

--- a/rustler/src/wrapper/term.rs
+++ b/rustler/src/wrapper/term.rs
@@ -1,8 +1,7 @@
-use crate::sys::{c_char, enif_snprintf};
-use crate::wrapper::NIF_TERM;
+use crate::sys::{c_char, enif_snprintf, ERL_NIF_TERM};
 use std::fmt;
 
-pub fn fmt(term: NIF_TERM, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+pub fn fmt(term: ERL_NIF_TERM, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
     const SIZE: usize = 1024;
     let mut bytes: Vec<u8> = Vec::with_capacity(SIZE);
 

--- a/rustler/src/wrapper/tuple.rs
+++ b/rustler/src/wrapper/tuple.rs
@@ -1,8 +1,11 @@
-use crate::sys::{enif_get_tuple, enif_make_tuple_from_array};
-use crate::wrapper::{c_int, NIF_ENV, NIF_ERROR, NIF_TERM};
+use crate::sys::{c_int, enif_get_tuple, enif_make_tuple_from_array, ErlNifEnv, ERL_NIF_TERM};
+use crate::wrapper::NIF_ERROR;
 use std::mem::MaybeUninit;
 
-pub unsafe fn get_tuple<'a>(env: NIF_ENV, term: NIF_TERM) -> Result<&'a [NIF_TERM], NIF_ERROR> {
+pub unsafe fn get_tuple<'a>(
+    env: *mut ErlNifEnv,
+    term: ERL_NIF_TERM,
+) -> Result<&'a [ERL_NIF_TERM], NIF_ERROR> {
     let mut arity: c_int = 0;
     let mut array_ptr = MaybeUninit::uninit();
     let success = enif_get_tuple(env, term, &mut arity, array_ptr.as_mut_ptr());
@@ -13,6 +16,6 @@ pub unsafe fn get_tuple<'a>(env: NIF_ENV, term: NIF_TERM) -> Result<&'a [NIF_TER
     Ok(term_array)
 }
 
-pub unsafe fn make_tuple(env: NIF_ENV, terms: &[NIF_TERM]) -> NIF_TERM {
+pub unsafe fn make_tuple(env: *mut ErlNifEnv, terms: &[ERL_NIF_TERM]) -> ERL_NIF_TERM {
     enif_make_tuple_from_array(env, terms.as_ptr(), terms.len() as u32)
 }

--- a/rustler_codegen/src/init.rs
+++ b/rustler_codegen/src/init.rs
@@ -68,9 +68,9 @@ impl From<InitMacroInput> for proc_macro2::TokenStream {
                 funcs: nif_funcs.as_ptr(),
                 load: {
                     extern "C" fn nif_load(
-                        env: rustler::codegen_runtime::NIF_ENV,
+                        env: *mut rustler::sys::ErlNifEnv,
                         _priv_data: *mut *mut rustler::codegen_runtime::c_void,
-                        load_info: rustler::codegen_runtime::NIF_TERM
+                        load_info: rustler::sys::ERL_NIF_TERM
                     ) -> rustler::codegen_runtime::c_int {
                         unsafe {
                             let mut env = rustler::Env::new_init_env(&env, env);

--- a/rustler_codegen/src/nif.rs
+++ b/rustler_codegen/src/nif.rs
@@ -62,10 +62,10 @@ pub fn transcoder_decorator(nif_attributes: NifAttributes, fun: syn::ItemFn) -> 
                 flags: #flags as rustler::codegen_runtime::c_uint,
                 raw_func: {
                     unsafe extern "C" fn nif_func(
-                        nif_env: rustler::codegen_runtime::NIF_ENV,
+                        nif_env: *mut rustler::sys::ErlNifEnv,
                         argc: rustler::codegen_runtime::c_int,
-                        argv: *const rustler::codegen_runtime::NIF_TERM
-                    ) -> rustler::codegen_runtime::NIF_TERM {
+                        argv: *const rustler::sys::ERL_NIF_TERM
+                    ) -> rustler::sys::ERL_NIF_TERM {
                         let lifetime = ();
                         let env = rustler::Env::new(&lifetime, nif_env);
 


### PR DESCRIPTION
Due to the different calling conventions for "structs", `ERL_NIF_TERM` was not implemented as a type-safe wrapper. Nowadays, Rust has `#[repr(transparent)]` to deal with these cases, so we can wrap term objects properly. While at it, this drops a bunch of unnecessary type aliasing between `rustler`, `rustler::wrapper`, and `rustler::sys`.